### PR TITLE
Added legacy domain for IT Tallaght

### DIFF
--- a/lib/domains/ie/ittd.txt
+++ b/lib/domains/ie/ittd.txt
@@ -1,0 +1,1 @@
+Institue of Technology, Tallaght (legacy email accounts)


### PR DESCRIPTION
ittd.ie is a domain used for legacy email accounts.
