### PR TITLE
Add domain rz.ba-dresden.de

### DIFF
--- a/lib/domains/de/ba-dresden/rz.txt
+++ b/lib/domains/de/ba-dresden/rz.txt
@@ -1,0 +1,1 @@
+Staatliche Studienakademie Dresden


### PR DESCRIPTION
Add Staatliche Studienakademie Dresden to the list of domains.
Mail addresses take the form of <student>@rz.ba-dresden.de.
