### PR TITLE
fix george brown college

### DIFF
--- a/lib/domains/ca/georgebrown.txt
+++ b/lib/domains/ca/georgebrown.txt
@@ -1,0 +1,1 @@
+George Brown College

--- a/lib/domains/ca/on/gbrownc.txt
+++ b/lib/domains/ca/on/gbrownc.txt
@@ -1,1 +1,0 @@
-George Brown College


### PR DESCRIPTION
move george brown college from /ca/on to /ca. proper domain is
georgebrown.ca
