### PR TITLE
Eastern Macedonia and Thrace Institute of Technology

### DIFF
--- a/lib/domains/gr/teiemt.txt
+++ b/lib/domains/gr/teiemt.txt
@@ -1,0 +1,1 @@
+Eastern Macedonia and Thrace Institute of Technology


### PR DESCRIPTION
The _TEI of kavala_ was recently renamed to _Eastern Macedonia and Thrace Institute of Technology_.
