### PR TITLE
Add KEA

### DIFF
--- a/lib/domains/dk/kea.txt
+++ b/lib/domains/dk/kea.txt
@@ -1,0 +1,1 @@
+Copenhagen School of Design and Technology


### PR DESCRIPTION
This is a PR to include [Københavns Erhvervsakademi](http://kea.dk/en/) in the list of accepted email domains. Earlier today I got an email from Robert Demmer in reply to my comment on the blog post, saying that the domain has been accepted, but it does not appear to be in the repo so I added it. Thanks in advance.
