### PR TITLE
Deleting torun.txt as it refer not only to NCU

### DIFF
--- a/lib/domains/pl/torun.txt
+++ b/lib/domains/pl/torun.txt
@@ -1,2 +1,0 @@
-Nicolaus Copernicus University of Torun
-Nicolaus Copernicus University of Torun


### PR DESCRIPTION
Deleting torun.txt as it refer not only to Nicolaus Copernicus University. The old legacy domain of University was *.uni.torun.pl not *.torun.pl. Now the proper domain is: *.umk.pl
