### PR TITLE
Added eisti.fr domain (École internationale des sciences du traitement de l'information)

### DIFF
--- a/lib/domains/fr/eisti.txt
+++ b/lib/domains/fr/eisti.txt
@@ -1,0 +1,1 @@
+École internationale des sciences du traitement de l'information


### PR DESCRIPTION
École internationale des sciences du traitement de l'information.
http://www.eisti.fr/
