### PR TITLE
oth-aw.de

### DIFF
--- a/lib/domains/de/oth-aw.txt
+++ b/lib/domains/de/oth-aw.txt
@@ -1,0 +1,1 @@
+Ostbayerische Technische Hochschule Amberg-Weiden


### PR DESCRIPTION
Ostbayerische Technische Hochschule Amberg-Weiden

http://www.oth-aw.de
