### PR TITLE
Added "mail.tau.ac.il" email domain

### DIFF
--- a/lib/domains/il/ac/tau/mail.txt
+++ b/lib/domains/il/ac/tau/mail.txt
@@ -1,0 +1,1 @@
+Tel Aviv University


### PR DESCRIPTION
TAU email accounts have "mail.tau.ac.il" domain
