### PR TITLE
adding Hochschule Rhein Waal

### DIFF
--- a/lib/domains/org/hsrw.txt
+++ b/lib/domains/org/hsrw.txt
@@ -1,0 +1,1 @@
+Hochschule Rhein-Waal


### PR DESCRIPTION
Its a german university for applied sciences.
The main url is hochschule-rhein-waal.de
but the mail url is hsrw.org
