### PR TITLE
Added +hf-ict.ch, +hf-ict.info

### DIFF
--- a/lib/domains/ch/hf-ict.txt
+++ b/lib/domains/ch/hf-ict.txt
@@ -1,0 +1,1 @@
+Höhere Fachschule für Informations- und Kommunikationstechnologie

--- a/lib/domains/info/hf-ict.txt
+++ b/lib/domains/info/hf-ict.txt
@@ -1,0 +1,1 @@
+Höhere Fachschule für Informations- und Kommunikationstechnologie


### PR DESCRIPTION
Name: Höhere Fachschule für Informations- und Kommunikationstechnologie
Domains: hf-ict.ch, hf-ict.info
