### PR TITLE
- Added hochschule-regensburg and oth-regensburg.de

### DIFF
--- a/lib/domains/de/hochschule-regensburg.txt
+++ b/lib/domains/de/hochschule-regensburg.txt
@@ -1,0 +1,1 @@
+Hochschule Regensburg

--- a/lib/domains/de/oth-regensburg.txt
+++ b/lib/domains/de/oth-regensburg.txt
@@ -1,0 +1,1 @@
+Ostbayerische Technische Hochschule Regensburg


### PR DESCRIPTION
  in fact these two are the same university as fh-regensburg.de, but have own domain names
  and new students don't get a user@stud.fh-regensburg.de email any
  more)
