### PR TITLE
Adding EPSI

### DIFF
--- a/lib/domains/fr/epsi.txt
+++ b/lib/domains/fr/epsi.txt
@@ -1,0 +1,1 @@
+Ecole Privée des Sciences Informatiques


### PR DESCRIPTION
Hi, EPSI means Ecole Privée des Sciences Informatiques (Private School of Computer Sciences) and is a school based in france : www.epsi.fr/
