### PR TITLE
Adding municipal vocational school for IT munich

### DIFF
--- a/lib/domains/de/musin/muenchen/bs-info.txt
+++ b/lib/domains/de/musin/muenchen/bs-info.txt
@@ -1,0 +1,1 @@
+Städtische Berufsschule für Informationstechnik


### PR DESCRIPTION
Städtische Berufsschule für Informationstechnik, München (german)
Municipal vocational school for IT, munich (kind of translated Name)
