### PR TITLE
Create vuxutb.txt

### DIFF
--- a/lib/domains/se/vuxutb.txt
+++ b/lib/domains/se/vuxutb.txt
@@ -1,0 +1,1 @@
+Plushögskolan


### PR DESCRIPTION
Plushögskolan is a University of Applied Sciences in sweden with several software-development programs including dotNet and java-development, unfortunately the domain vuxutb.se is used for student email and not plushögskolan.se which is the domain for their site. I hope this does not cause any problems because I would like to be able to use IntelliJ during my education.

Marcus Bengtsson - Java-development student at Plushögskolan
