### PR TITLE
Add lib/domains/ch/usi.txt

### DIFF
--- a/lib/domains/ch/usi.txt
+++ b/lib/domains/ch/usi.txt
@@ -1,0 +1,1 @@
+Università della Svizzera italiana


### PR DESCRIPTION
Please add the current domain [usi.ch](http://www.usi.ch/en/index.htm) for the Università della Svizzera italiana (University of Italian Switzerland)

I noticed the old [unisi.ch](https://github.com/JetBrains/swot/blob/master/lib/domains/ch/unisi.txt) domain is already present. However as far as I know (I am just a student),
students only have emails of the form `firstname.lastname@usi.ch` and `username@usi.ch`.
Furthermore, the name indicated: `University of the Italian-speaking Part of Switzerland` is wrong.
The official name of the university is only in Italian and translations are not allowed according to the [naming convention](http://www.press.usi.ch/en/corporate-design/corporate-design-nomi.htm).

Note: I purposely left the old domain as some of the USI staff might still use an email address containing it.
