### PR TITLE
Update and rename ohm-hochschule.txt to th-nuernberg.txt

### DIFF
--- a/lib/domains/de/ohm-hochschule.txt
+++ b/lib/domains/de/ohm-hochschule.txt
@@ -1,1 +1,0 @@
-Georg Simon Ohm University of Applied Sciences

--- a/lib/domains/de/th-nuernberg.txt
+++ b/lib/domains/de/th-nuernberg.txt
@@ -1,0 +1,1 @@
+Technische Hochschule Nürnberg Georg Simon Ohm


### PR DESCRIPTION
University received a new title last year. They also changed the domain and emails.
New domain: th-nuernberg.de
