### PR TITLE
Added Hochschule Niederrhein 

### DIFF
--- a/lib/domains/de/hn.txt
+++ b/lib/domains/de/hn.txt
@@ -1,0 +1,1 @@
+Hochschule Niederrhein


### PR DESCRIPTION
Added Hochschule Niederrhein (University of Applied Sciences) as used in student E-Mails in the pattern {firstname}.{lastname}@stud.hn.de.

http://www.hs-niederrhein.de
http://whois.domaintools.com/hn.de
