### PR TITLE
Update and rename fh-nuernberg.txt to th-nuernberg.txt

### DIFF
--- a/lib/domains/de/fh-nuernberg.txt
+++ b/lib/domains/de/fh-nuernberg.txt
@@ -1,1 +1,0 @@
-Georg-Simon-Ohm-Fachhochschule Nürnberg

--- a/lib/domains/de/th-nuernberg.txt
+++ b/lib/domains/de/th-nuernberg.txt
@@ -1,0 +1,1 @@
+Technische Hochschule Nürnberg Georg Simon


### PR DESCRIPTION
the "fachhochschule nürnberg" recently became a "technische hochschule" and changed their domain.
see http://www.th-nuernberg.de/
