### PR TITLE
University of Economics in Katowice

### DIFF
--- a/lib/domains/pl/katowice/ue
+++ b/lib/domains/pl/katowice/ue
@@ -1,0 +1,1 @@
+University of Economics in Katowice


### PR DESCRIPTION
This university Was here, but earlier was signed as Academy of Economics in Katowice. Few years ago it has changed it's name to University of Economics in Katowice, so domain has changed also to ue.katowice.pl and e-mail accounts are like account@ekonom.ue.katowice.pl or account@student.ue.katowice.pl.
