### PR TITLE
Add Ahuntsic College in Quebec, Canada

### DIFF
--- a/lib/domains/ca/qc/collegeahuntsic.txt
+++ b/lib/domains/ca/qc/collegeahuntsic.txt
@@ -1,0 +1,1 @@
+Collège Ahuntsic


### PR DESCRIPTION
Students as well as teachers have the "account@collegeahuntsic.qc.ca" email
address.
