### PR TITLE
Added Mikkeli University of Applied Sciences

### DIFF
--- a/lib/domains/fi/mamk.txt
+++ b/lib/domains/fi/mamk.txt
@@ -1,0 +1,1 @@
+Mikkeli University of Applied Sciences


### PR DESCRIPTION
Students use edu.mamk.fi addresses, staff uses mamk.fi.
