### PR TITLE
Add Cegep Limoilou

### DIFF
--- a/lib/domains/ca/cegeplimoilou.txt
+++ b/lib/domains/ca/cegeplimoilou.txt
@@ -1,0 +1,1 @@
+Cégep Limoilou


### PR DESCRIPTION
Cegep Limoilou is a french College in Quebec, Canada. 

http://www.cegeplimoilou.ca/

Students email are @etudiant.cegeplimoilou.ca and staff are @cegeplimoilou.ca
