### PR TITLE
New domain for HSZG

### DIFF
--- a/lib/domains/de/hszg.txt
+++ b/lib/domains/de/hszg.txt
@@ -1,0 +1,1 @@
+Hochschule Zittau/Görlitz (FH)


### PR DESCRIPTION
Added new domain for Hochschule Zittau/Görlitz (FH) (HSZG)
