### PR TITLE
Southern Federal University

### DIFF
--- a/lib/domains/ru/sfedu.txt
+++ b/lib/domains/ru/sfedu.txt
@@ -1,0 +1,1 @@
+Southern Federal University


### PR DESCRIPTION
Added Southern Federal University. Primary domain – sfedu.ru
Russia, Rostov-on-Don.

http://sfedu.ru/international/
http://en.wikipedia.org/wiki/Southern_Federal_University
