### PR TITLE
Fix Technical University Munich domains

### DIFF
--- a/lib/domains/de/mytum.txt
+++ b/lib/domains/de/mytum.txt
@@ -1,0 +1,1 @@
+Technical University of Munich

--- a/lib/domains/de/tu-muenchen.txt
+++ b/lib/domains/de/tu-muenchen.txt
@@ -1,1 +1,0 @@
-Technische Universität München


### PR DESCRIPTION
While tu-muenchen.de is indeed the homepage of that university, the
email addresses of staff are @tum.de, while the email adresses of
students are @mytum.de.
