### PR TITLE
Create davenportschools.org

### DIFF
--- a/lib/domains/org/davenportschools.txt
+++ b/lib/domains/org/davenportschools.txt
@@ -1,0 +1,1 @@
+West High School


### PR DESCRIPTION
Davenport Schools (Iowa) uses both davenportschools.org and mail.davenport.k12.ia.us
