### PR TITLE
Alumni is not Alumno (current student in Spanish)

### DIFF
--- a/src/swot/Swot.kt
+++ b/src/swot/Swot.kt
@@ -1,7 +1,7 @@
 package swot
 
 fun isAcademic(emailOrDomain: String): Boolean {
-    if (emailOrDomain.contains("@alum")) return false
+    if (emailOrDomain.contains("@alumni")) return false
 
     val parts = domainParts(emailOrDomain)
     return !isBlacklisted(parts) && (isUnderTLD(parts) || findSchoolNames(parts).isNotEmpty())


### PR DESCRIPTION
Change validation just for 'alumni' subdomains because 'alumno' means
(current) student in Spanish. (e.g. studentname@alumno.uned.es)