### PR TITLE
Added CRLJ

### DIFF
--- a/lib/domains/ca/qc/edu-collanaud.txt
+++ b/lib/domains/ca/qc/edu-collanaud.txt
@@ -1,0 +1,1 @@
+S’applique pour les trois Cégeps constituants de Lanaudière


### PR DESCRIPTION
http://www.cegep-lanaudiere.qc.ca

Valide pour toutes les adresses des cégeps constituants de Lanaudière : 
- Cégep régional de Lanaudière à Joliette
- Cégep régional de Lanaudière à L'assomption
- Cégep régional de Lanaudière à Terrebonne

Syntaxe des adresses : NumeroEtudiant@edu-collanaud.qc.ca
