### PR TITLE
Added Raabeschule

### DIFF
--- a/lib/domains/net/raabeschule.txt
+++ b/lib/domains/net/raabeschule.txt
@@ -1,0 +1,1 @@
+Gymnasium Raabeschule Braunschweig


### PR DESCRIPTION
This is only for the mailserver, the webpage domain is: raabeschule.de
