### PR TITLE
santotomas.cl domain added

### DIFF
--- a/lib/domains/cl/santotomas.txt
+++ b/lib/domains/cl/santotomas.txt
@@ -1,0 +1,1 @@
+Universidad Santo Tomás


### PR DESCRIPTION
this is the domain for the Saint Tomas Unversity in Chile (http://www.santotomas.cl/)
