### PR TITLE
Added University of the Arts Bremen

### DIFF
--- a/lib/domains/de/hfk-bremen.txt
+++ b/lib/domains/de/hfk-bremen.txt
@@ -1,0 +1,1 @@
+Hochschule für Künste Bremen


### PR DESCRIPTION
The University of the Arts Bremen runs a Digital Media program in partnership with the University of Bremen. Art and informatics students study together with differing foci depending on their field. Therefor it would be great if students from the University of the Arts Bremen would have access to JetBrain's IDEs too.
