### PR TITLE
Create lacitec

### DIFF
--- a/lib/domains/ca/on/lacitec
+++ b/lib/domains/ca/on/lacitec
@@ -1,0 +1,1 @@
+La Cite Collegial


### PR DESCRIPTION
https://www.collegelacite.ca
La Cité collégiale is the largest French-language college in Ontario. Created in 1989, in Ottawa it offers more than 90 programs to some 5000 full-time students from Ontario, other parts of Canada and foreign countries.
