### PR TITLE
Adding Geneva Department of Instruction

### DIFF
--- a/lib/domains/ch/eduge.txt
+++ b/lib/domains/ch/eduge.txt
@@ -1,0 +1,1 @@
+Département de l'instruction publique de Genève


### PR DESCRIPTION
Hello,

I'd like to include eduge.ch. 
This domain is owned by the Republic of Geneva to provide emails and doc sharing to students.
More info at http://www.ge.ch/dip or http://www.eduge.ch (french only sites)

Thanks and Best Regards
Stephane
