### PR TITLE
Added epfedu.fr domain for EPF French Engineering school.

### DIFF
--- a/lib/domains/fr/epfedu.txt
+++ b/lib/domains/fr/epfedu.txt
@@ -1,0 +1,1 @@
+EPF Ecole d'Ingénieurs


### PR DESCRIPTION
The EPF school is already in the repository for its "epf.fr" domain, but this domain is only used by staff members of this school.

Students are assigned email addresses on the "epfedu.fr" domain, hence my pull request.
