### PR TITLE
Added both Cegep of Victoriaville's domain

### DIFF
--- a/lib/domains/info/cegepvicto.txt
+++ b/lib/domains/info/cegepvicto.txt
@@ -1,0 +1,1 @@
+Cégep de Victoriaville

--- a/lib/domains/info/cgpvicto.txt
+++ b/lib/domains/info/cgpvicto.txt
@@ -1,0 +1,1 @@
+Cégep de Victoriaville


### PR DESCRIPTION
Added both Cegep of Victoriaville's domain
cgpvicto.info is the old domain, still being used by students who aren't on their first year
cegepvicto.info is the new domain, being used by new students and futur students
