### PR TITLE
Create 2isa.txt

### DIFF
--- a/lib/domains/org/2isa.txt
+++ b/lib/domains/org/2isa.txt
@@ -1,0 +1,3 @@
+Institut Informatique Sud Aveyron
+Website: http://www.2isa.com/
+student emails at @2isa.org for example sergey.epifanov@2isa.org


### PR DESCRIPTION
2isa.org is the domain for student email of www.2isa.com
