### PR TITLE
Create nortonhillschool.txt

### DIFF
--- a/lib/domains/com/nortonhillschool.txt
+++ b/lib/domains/com/nortonhillschool.txt
@@ -1,0 +1,1 @@
+Norton Hill School


### PR DESCRIPTION
Add Norton Hill School.
Only students and staff have email addresses at this domain.
The main school website is also hosted at this domain.
