### PR TITLE
Videndjurs.dk

### DIFF
--- a/lib/domains/dk/videndjurs.txt
+++ b/lib/domains/dk/videndjurs.txt
@@ -1,0 +1,1 @@
+Videndjus Gymnasier, Videndjurs Erhvervsuddannelser (English website "http://www.videndjurs.dk/Default.aspx?ID=3992")


### PR DESCRIPTION
Adds Videndjurs.dk, an umbrella organisation of several danish high schools and Vocational education schools

Videndjus Gymnasier, Videndjurs Erhvervsuddannelser
English site: "http://www.videndjurs.dk/Default.aspx?ID=3992"
