### PR TITLE
adding King George V School, HK

### DIFF
--- a/lib/domains/hk/kgv.txt
+++ b/lib/domains/hk/kgv.txt
@@ -1,0 +1,1 @@
+King George V School


### PR DESCRIPTION
Added King George V School, HK.  To allow all the students in the Computer Programming club and Computer Science GCSE & IB lessons to use the wonderful tools from JetBrains.

eddie
