### PR TITLE
Add NTI-Gymnasiet alternative domain (nti.se)

### DIFF
--- a/lib/domains/se/nti.txt
+++ b/lib/domains/se/nti.txt
@@ -1,0 +1,1 @@
+NTI College Sweden


### PR DESCRIPTION
There exists an alternative domain which some students are using and it would be great if it could be added.