### PR TITLE
Update uaic.txt

### DIFF
--- a/lib/domains/ro/uaic.txt
+++ b/lib/domains/ro/uaic.txt
@@ -1,1 +1,1 @@
-University of Iasi
+University Alexandru Ioan Cuza of Iasi


### PR DESCRIPTION
The name of the university was not correct as there are multiple universities in Iasi. (UAIC stands for Alexandru Ioan Cuza's University in romanian)
