### PR TITLE
Added Saint Mary's University

### DIFF
--- a/lib/domains/ca/smu/ap.txt
+++ b/lib/domains/ca/smu/ap.txt
@@ -1,0 +1,1 @@
+Saint Mary's University (Department of Astronomy & Physics)


### PR DESCRIPTION
Graduate student email accounts are tagged with their department's subdomain.  In this case, ap.smu.ca is the Department of Astronomy and Physics.
