### PR TITLE
Added Singidunum University

### DIFF
--- a/lib/domains/rs/singimail.txt
+++ b/lib/domains/rs/singimail.txt
@@ -1,0 +1,1 @@
+Singidunum University


### PR DESCRIPTION
Even though there is @singidunum.ac.rs as and email option for Singidunum University mails, it is used only by professors. Students use @singimail.rs only