### PR TITLE
Adding elevcampus.dk

### DIFF
--- a/lib/domains/dk/elevcampus.txt
+++ b/lib/domains/dk/elevcampus.txt
@@ -1,0 +1,1 @@
+EUC Syd - Teknisk Gymnasium Sønderjylland


### PR DESCRIPTION
Adding EUC Syd - Teknisk Gymnasium Sønderjylland (Higher Technical Examination Programme) with the website http://eucsyd.dk