### PR TITLE
University of Enna "KORE" adedd

### DIFF
--- a/lib/domains/it/unikore.txt
+++ b/lib/domains/it/unikore.txt
@@ -1,0 +1,1 @@
+Università degli Studi di Enna "Kore"

--- a/lib/domains/it/unikorestudent.txt
+++ b/lib/domains/it/unikorestudent.txt
@@ -1,0 +1,1 @@
+Università degli Studi di Enna "Kore"


### PR DESCRIPTION
Added main domain (unikore.it) and students domain (unikorestudent.it) for Università degli Studi di Enna "Kore" (Enna - Italy)