### PR TITLE
Add Madeira City Schools

### DIFF
--- a/lib/domains/org/madeiracityschools.txt
+++ b/lib/domains/org/madeiracityschools.txt
@@ -1,0 +1,1 @@
+Madeira City Schools


### PR DESCRIPTION
Added Madeira City Schools (http://www.madeiracityschools.org). A school district in Madeira, OH.