### PR TITLE
Create usmp

### DIFF
--- a/lib/domains/pe/usmp.txt
+++ b/lib/domains/pe/usmp.txt
@@ -1,0 +1,1 @@
+Universidad San Martin de Porres


### PR DESCRIPTION
 Though, the mail domain is 'usmp.pe'. Main web site of the university is 'usmp.edu.pe'.