### PR TITLE
Delete hibu.txt

### DIFF
--- a/lib/domains/no/hibu.txt
+++ b/lib/domains/no/hibu.txt
@@ -1,1 +1,0 @@
-Buskerud University College


### PR DESCRIPTION
No longer a valid name after the merger to "HBV" in 2014.