### PR TITLE
RPN added

### DIFF
--- a/lib/domains/ch/rpn.txt
+++ b/lib/domains/ch/rpn.txt
@@ -1,0 +1,1 @@
+Réseau pédagogique neuchâtelois


### PR DESCRIPTION
RPN is the network of all Neuchâtel schools : CPLN and CIFOM technical schools included.