### PR TITLE
Added maxplanck.txt

### DIFF
--- a/lib/domains/lt/maxplanck.txt
+++ b/lib/domains/lt/maxplanck.txt
@@ -1,0 +1,1 @@
+I.T.I.S. Max Planck


### PR DESCRIPTION
Students at I.T.I.S. Max Planck have domain maxplanck.it, the main website for the school is: http://www.itisplanck.it/