### PR TITLE
Add Universita telematica internazionale UniNettuno

### DIFF
--- a/lib/domains/net/uninettunouniversity.txt
+++ b/lib/domains/net/uninettunouniversity.txt
@@ -1,0 +1,1 @@
+Università Telematica Internazionale UNINETTUNO

--- a/lib/domains/net/uninettunouniversity.txt
+++ b/lib/domains/net/uninettunouniversity.txt
@@ -1,1 +1,1 @@
-Università Telematica Internazionale UNINETTUNO
+Universita Telematica Internazionale UniNettuno


### PR DESCRIPTION
The UniNettuno University (Italian: Università telematica internazionale UniNettuno), often simply abbreviated as "UniNettuno" is a private university founded in 2005 in Rome, Italy.

Website: www.uninettunouniversity.net