### PR TITLE
Add www.gimakad.torun.pl

### DIFF
--- a/lib/domains/pl/torun/gimakad.txt
+++ b/lib/domains/pl/torun/gimakad.txt
@@ -1,0 +1,1 @@
+Gimnazjum i Liceum Akademickie w Toruniu


### PR DESCRIPTION
Part of Nicolaus Copernicus University in Toruń. To check site, use
adress with 'www' (www.gimakad.torun.pl - website have a problem with adress without 'www'). 