### PR TITLE
swissinternationalschool

### DIFF
--- a/lib/domains/ch/swissinternationalschool
+++ b/lib/domains/ch/swissinternationalschool
@@ -1,0 +1,3 @@
+SIS Swiss International Schools Schweiz AG
+Seestrasse 269
+8038 Zürich


### PR DESCRIPTION
SIS Swiss International Schools Schweiz
Bilingual International School in Switzerland, located in Zürich, Basel, Wallisellen, Winterthur, Männedorf, Rotkreuz-Zug, Tamis-Chur, Pfäffikon SZ, Schönenwerd, Suhr AG