### PR TITLE
Entries for "Hochschule Rhein-Waal" domains added

### DIFF
--- a/lib/domains/de/hochschule-rhein-waal.txt
+++ b/lib/domains/de/hochschule-rhein-waal.txt
@@ -1,0 +1,1 @@
+Hochschule Rhein-Waal

--- a/lib/domains/eu/hsrw.txt
+++ b/lib/domains/eu/hsrw.txt
@@ -1,0 +1,1 @@
+Hochschule Rhein-Waal


### PR DESCRIPTION
_hochschule-rhein-waal.de_ => `lib/domains/de/hochschule-rhein-waal.txt`
_hsrw.eu_ => `lib/domains/eu/hsrw.txt`