### PR TITLE
Adding Jesuit High School

### DIFF
--- a/lib/domains/net/jhs.txt
+++ b/lib/domains/net/jhs.txt
@@ -1,0 +1,1 @@
+Jesuit High School


### PR DESCRIPTION
Jesuit High School from Sacramento California. 
Primary School Website: Jesuithighschool.org
Email Domain: jhs.net

JHS.net is what we use for our email accounts. 
Proof from are primary website: http://www.jesuithighschool.org/assignment/english-department-2014-summer-reading-assignments

Are student email accounts are formatted as lastnamefirstinitialGraduationYear@Student.jhs.net

Please Comment for additional support.

@ zweizwei