### PR TITLE
Adding East Providence Public Schools 

### DIFF
--- a/lib/domains/com/epschoolsri.txt
+++ b/lib/domains/com/epschoolsri.txt
@@ -1,0 +1,1 @@
+East Providence Public Schools


### PR DESCRIPTION
This is a pull request to add East Providence Public Schools to swot. epschoolsri.com is the primary domain used for email by all students and faculty in the district, including East Providence High School. The district is k-12.

Primary school website: eastprovidencehighschool.com
District website: epschoolsri.com

Student emails are in the format of: [last two digits of graduation year][first initial][last name][first two digits of student id]@epschoolsri.com

Thank you! :)
