### PR TITLE
Added openuniversiteit.be

### DIFF
--- a/lib/domains/be/openuniversiteit.txt
+++ b/lib/domains/be/openuniversiteit.txt
@@ -1,0 +1,1 @@
+Open University Belgium


### PR DESCRIPTION
After ou.nl (Its Dutch counterpart) has already been added openuniversiteit.be should be added too. 