### PR TITLE
Create hanovernorwichschools.txt

### DIFF
--- a/lib/domains/org/hanovernorwichschools.txt
+++ b/lib/domains/org/hanovernorwichschools.txt
@@ -1,0 +1,1 @@
+Hanover High School

--- a/lib/domains/org/hanovernorwichschools.txt
+++ b/lib/domains/org/hanovernorwichschools.txt
@@ -1,1 +1,1 @@
-Hanover High School
+Dresden School District


### PR DESCRIPTION
Hanover High School in the Dresden School District. School website is http://hhs.hanovernorwichschools.org, District website is http://hanovernorwichschools.org or http://sau70.hanovernorwichschools.org