### PR TITLE
Added NSW DEC

### DIFF
--- a/lib/domains/au/gov/nsw/education.txt
+++ b/lib/domains/au/gov/nsw/education.txt
@@ -1,0 +1,1 @@
+NSW Department of Education and Communities


### PR DESCRIPTION
The NSW Department of Education and Communities education should cover every government secondary school in NSW.