### PR TITLE
Add wg6.co.uk to education domains

### DIFF
--- a/lib/domains/uk/co/wg6.txt
+++ b/lib/domains/uk/co/wg6.txt
@@ -1,0 +1,1 @@
+Wilmington Grammar Schools Sixth Form


### PR DESCRIPTION
Adds the wg6.co.uk School's domain.