### PR TITLE
Add CSG Reggesteyn

### DIFF
--- a/lib/domains/nu/reggesteyn.txt
+++ b/lib/domains/nu/reggesteyn.txt
@@ -1,0 +1,1 @@
+CSG Reggesteyn


### PR DESCRIPTION
http://reggesteyn.nl is school domain (emails at .nl are for staff, .nu is for students.)
Location: 2 schools in Nijverdal, 1 in Rijssen