### PR TITLE
Add Eigsi

### DIFF
--- a/lib/domains/fr/eigsi.txt
+++ b/lib/domains/fr/eigsi.txt
@@ -1,0 +1,1 @@
+Ecole d'ingénieurs


### PR DESCRIPTION
Ecole d’ingénieurs, la rochelle.
www.eigsi.fr