### PR TITLE
Add Park6.org (K-12 public school)

### DIFF
--- a/lib/domains/org/park6.txt
+++ b/lib/domains/org/park6.txt
@@ -1,0 +1,1 @@
+Park County School District #6 (K-12)


### PR DESCRIPTION
Park6.org is the official domain of Park County School District #6 in Cody, WY.  All associated email accounts are faculty and students. [Link](http://www.park6.org)