### PR TITLE
Added Cybernetics Faculty, Taras Shevchenko National University of Kyiv

### DIFF
--- a/lib/domains/ua/kiev/unicyb.txt
+++ b/lib/domains/ua/kiev/unicyb.txt
@@ -1,0 +1,1 @@
+Cybernetics Faculty, National Taras Shevchenko University of Kiev


### PR DESCRIPTION
Added Cybernetics Faculty, National Taras Shevchenko University of Kiev, we have separate mail server as you can see on our website main page: http://www.cyb.univ.kiev.ua/en.html
Oleksandr Maksymets, Professor Assistant