### PR TITLE
Add MSTU CA

### DIFF
--- a/lib/domains/aero/mstuca.txt
+++ b/lib/domains/aero/mstuca.txt
@@ -1,0 +1,1 @@
+Moscow State Technical University of Civil Aviation


### PR DESCRIPTION
Added Moscow State Technical University of Civil Aviation (mstuca.aero)
https://en.wikipedia.org/wiki/Moscow_State_Technical_University_of_Civil_Aviation