### PR TITLE
Add fon.mk domain

### DIFF
--- a/lib/domains/mk/fon.txt
+++ b/lib/domains/mk/fon.txt
@@ -1,0 +1,1 @@
+FON University


### PR DESCRIPTION
FON University is currently providing student emails at the fon.mk domain, and only uses the fon.edu.mk domain for staff emails.