### PR TITLE
Add Khon Kaen University's Domain for student email.

### DIFF
--- a/lib/domains/com/kkumail.txt
+++ b/lib/domains/com/kkumail.txt
@@ -1,0 +1,1 @@
+Khon Kaen University


### PR DESCRIPTION
Khon Kaen University has two domain for... 
teacher & staff : kku.ac.th
student : kkumail.com (please add this).

Thank you in advance.