### PR TITLE
Adding mumail (Maynooth University)

### DIFF
--- a/lib/domains/ie/mumail.txt
+++ b/lib/domains/ie/mumail.txt
@@ -1,0 +1,1 @@
+Maynooth University


### PR DESCRIPTION
NUI Maynooth recently changed its name, see here
https://www.maynoothuniversity.ie/communications-marketing/university-identity-guidelines

@mumail.ie is our mail server
@nuim.ie is still used by some staff