### PR TITLE
Added erpsk12 to the list

### DIFF
--- a/lib/domains/org/erpsk12.txt
+++ b/lib/domains/org/erpsk12.txt
@@ -1,0 +1,1 @@
+Eaton Rapids Public Schools


### PR DESCRIPTION
This domain is used by the Eaton Rapids Public Schools district.

One question, will this cover a subdomain for students (eg, `students.erpsk12.org`)? If not, should I create another text file to cover that?