### PR TITLE
Create oatforge.txt

### DIFF
--- a/lib/domains/uk/co/oatforge.txt
+++ b/lib/domains/uk/co/oatforge.txt
@@ -1,0 +1,1 @@
+Ormiston Forge Academy


### PR DESCRIPTION
Ormiston Forge Academy is a secondary school and sixth form with academy status located in the Old Hill area of Cradley Heath, West Midlands, England. The academy serves pupils living in the Cradley Heath, Old Hill and Rowley Regis areas of Sandwell. The academy has a large learning infrastructure, which enables young people and the community access to technology and facilities.
The academy has around 1400 students aged between 11 and 19, this includes a Sixth Form which provides a continuity of education and a strong sense of family. www.oatforge.com