### PR TITLE
Added myokanagan domain for Okanagan College

### DIFF
--- a/lib/domains/ca/bc/myokanagan.txt
+++ b/lib/domains/ca/bc/myokanagan.txt
@@ -1,0 +1,1 @@
+Okanagan College


### PR DESCRIPTION
Okanagan College uses the 'myokanagan' domain name for it's students and staff.
https://my.okanagan.bc.ca/cp/home/displaylogin