### PR TITLE
Add wctech.org

### DIFF
--- a/lib/domains/org/wctech.txt
+++ b/lib/domains/org/wctech.txt
@@ -1,0 +1,1 @@
+Warren County Technical School


### PR DESCRIPTION
[Warren County Technical School](http://www.wctech.org) is a technical high school in New Jersey.  While it isn't a university, the age-range is comparable to colleges in other countries.