### PR TITLE
Add Department of Education Tasmania, Australia

### DIFF
--- a/lib/domains/au/edu/tas/education.txt
+++ b/lib/domains/au/edu/tas/education.txt
@@ -1,0 +1,1 @@
+Department of Education Tasmania

--- a/lib/domains/au/edu/tased.txt
+++ b/lib/domains/au/edu/tased.txt
@@ -1,0 +1,1 @@
+Department of Education Tasmania

--- a/lib/domains/au/gov/tas/education.txt
+++ b/lib/domains/au/gov/tas/education.txt
@@ -1,0 +1,1 @@
+Department of Education Tasmania


### PR DESCRIPTION
Adds the three email domains belonging to Department of Education schools in Tasmania, Australia.

These domains are:

- `education.tas.gov.au`
- `education.tas.edu.au`
- `tased.edu.au`