### PR TITLE
Add Laboratório Nacional de Computação Científica

### DIFF
--- a/lib/domains/br/lncc.txt
+++ b/lib/domains/br/lncc.txt
@@ -1,0 +1,1 @@
+Laboratório Nacional de Computação Científica


### PR DESCRIPTION
Adding LNCC - Laboratório Nacional de Computação Científica as an academic institution.

link: http://www.lncc.br/