### PR TITLE
Add Central Queensland University

### DIFF
--- a/lib/domains/com/cqumail.txt
+++ b/lib/domains/com/cqumail.txt
@@ -1,0 +1,1 @@
+Central Queensland University (CQU) 


### PR DESCRIPTION
CQU (www.cqu.edu.au) put their student email on cqumail.com. Detailed
here : http://policy.cqu.edu.au/Policy/policy_file.do?policyid=642