### PR TITLE
Added domain for OCAD(Ontario College of Art and Design) University

### DIFF
--- a/lib/domains/ca/ocadu.txt
+++ b/lib/domains/ca/ocadu.txt
@@ -1,0 +1,1 @@
+OCAD(Ontario College of Art and Design) University


### PR DESCRIPTION
ocadu.ca is the primary domain for OCAD University, formerly known as the Ontario College of Art & Design.