### PR TITLE
Add Turku schools with edu mail addresses

### DIFF
--- a/lib/domains/fi/turku/edu.txt
+++ b/lib/domains/fi/turku/edu.txt
@@ -1,0 +1,1 @@
+Turku Schools


### PR DESCRIPTION
Most higher education schools in Turku have a domain of edu.turku.fi