### PR TITLE
Create iserv-trg-oha.txt

### DIFF
--- a/lib/domains/de/iserv-trg-oha.txt
+++ b/lib/domains/de/iserv-trg-oha.txt
@@ -1,0 +1,1 @@
+Tilman-Riemenschneider-Gymnasium Osterode am Harz


### PR DESCRIPTION
Our school name is "Tilman-Riemenschneider-Gymnasium Osterode am Harz", it's a German grammar school. Our website is located at http://trg-oha.de but all of the email addresses end with @iserv-trg.oha.de because that's the domain of our portal server called "IServ" (http://iserv.eu). Feel free to ask questions if something is vague...