### PR TITLE
Added edu-kw1c.nl

### DIFF
--- a/lib/domains/nl/edu-kw1c.txt
+++ b/lib/domains/nl/edu-kw1c.txt
@@ -1,0 +1,1 @@
+Koning Willem 1 College


### PR DESCRIPTION
The students of koning willem 1 college are using a @edu-kw1c.nl domain for there mail.