### PR TITLE
Add Weihenstephan-Triesdorf University of Applied Sciences

### DIFF
--- a/lib/domains/de/hswt.txt
+++ b/lib/domains/de/hswt.txt
@@ -1,0 +1,1 @@
+Weihenstephan-Triesdorf University of Applied Sciences


### PR DESCRIPTION
Add a file for Weihenstephan-Triesdorf University of Applied Sciences,
(HSWT), formerly known as fh-weihenstephan.de