### PR TITLE
Create pks.mpg.de

### DIFF
--- a/lib/domains/de/mpg/pks.txt
+++ b/lib/domains/de/mpg/pks.txt
@@ -1,0 +1,1 @@
+Max Planck Institute for the Physics of Complex Systems


### PR DESCRIPTION
Max Planck Institute for the Physics of Complex Systems hosts several PhD students. Institutional webpage: www.pks.mpg.de