### PR TITLE
Create demokritos.gr

### DIFF
--- a/lib/domains/gr/demokritos.gr
+++ b/lib/domains/gr/demokritos.gr
@@ -1,0 +1,1 @@
+NCSR Demokritos


### PR DESCRIPTION
Please add NCSR Demokritos in Greece. Demokritos is a public research organization of the Greek Ministry of Education.