### PR TITLE
Added Universidad Ricardo Palma

### DIFF
--- a/lib/domains/pe/urp.txt
+++ b/lib/domains/pe/urp.txt
@@ -1,0 +1,1 @@
+Universidad Ricardo Palma


### PR DESCRIPTION
Universidad Ricardo Palma changed its domain from @urp.edu.pe to @urp.pe