### PR TITLE
Added Hanken School of Economics

### DIFF
--- a/lib/domains/fi/hanken.txt
+++ b/lib/domains/fi/hanken.txt
@@ -1,0 +1,1 @@
+Hanken School of Economics


### PR DESCRIPTION
Staff accounts at the base domains, students from student.hanken.fi.