### PR TITLE
Add Centennial High School

### DIFF
--- a/lib/domains/org/friscoisd.txt
+++ b/lib/domains/org/friscoisd.txt
@@ -1,0 +1,1 @@
+Frisco Centennial High School

--- a/lib/domains/org/friscoisd.txt
+++ b/lib/domains/org/friscoisd.txt
@@ -1,1 +1,1 @@
-Frisco Centennial High School
+Centennial High School


### PR DESCRIPTION
Added Centennial High School as part of the Frisco Independent School District.

Student Emails: first.last.XXX@k12.friscoisd.org
Staff Emails: last(FirstLetterOfFirstName)@friscoisd.org

Only School Administration can create emails.