### PR TITLE
Create bfmiit.txt

### DIFF
--- a/lib/domains/ru/bfmiit.txt
+++ b/lib/domains/ru/bfmiit.txt
@@ -1,0 +1,2 @@
+Bryansk branch Moscow State University of Railway Engineering (BfMIIT)
+Брянский филиал Московского государственного университета путей сообщения (БфМИИТ)


### PR DESCRIPTION
Bryansk branch Moscow State University of Railway Engineering (BfMIIT)
Open sources quoting the domain college:
1. http://miit.ru/portal/page/portal/miit/divs/hist?id_page=1206&id_pi_hist=1212&id_pi_divs=1215&id_pi_top=1265&id_pi_cpm=3&id_pi_mm=48&id_pi_mmc=64&id_pi_m2l=67&letter_divs=0&search_divs=0&curr_page_divs=1&curr_page_hist=1&curr_page_mmc=1&view_mode_top=1&idk_info_hist=1137&ct_mmc=2&view_mode_divs=2.0&id_division_divs=22593&ct_hist=3&id_division_hist=22593 (Source website University)

2. http://2gis.ru/bryansk/geo/8726359933211340/firm/8726252559011487/center/34.411905%2C53.203983/zoom/16 (authoritative book of reference)

3. http://www.edu.ru/abitur/act.19/ds.1/isn.4297/index.php (free source)

4. https://maps.yandex.ru/12/smolensk/?source=wizbiz-new&ll=34.415334%2C53.203934&z=18&whatshere%5Bpoint%5D=34.416783%2C53.204197&whatshere%5Bzoom%5D=18 (Yandex catalog)