### PR TITLE
Adding UCLL (University College Leuven-Limburg)

### DIFF
--- a/lib/domains/be/ucll.txt
+++ b/lib/domains/be/ucll.txt
@@ -1,0 +1,1 @@
+University College Leuven-Limburg


### PR DESCRIPTION
Hello,

A part of GroepT has been split of and merged into a new college collaboration; UCLL
I have added the domain here so our students can continue to benefit having access to the JetBrains software which we use for our ICT education programs.

Thank you.

Koen.