### PR TITLE
Created Friesland College staff domain

### DIFF
--- a/lib/domains/nl/fcroc.txt
+++ b/lib/domains/nl/fcroc.txt
@@ -1,0 +1,1 @@
+Friesland College Regionaal Opleidingencentrum


### PR DESCRIPTION
fclive.txt is the domain for Friesland College students. This one is for the teachers.