### PR TITLE
Create lyon-epsi.txt

### DIFF
--- a/lib/domains/fr/lyon-epsi.txt
+++ b/lib/domains/fr/lyon-epsi.txt
@@ -1,0 +1,1 @@
+EPSI Lyon


### PR DESCRIPTION
Add EPSI Lyon, french computer science school (www.epsi.fr, 9 schools in France)
Special webpage on the Lyon campus : http://www.epsi.fr/Campus/Campus-de-Lyon
Old domain @epsi.fr was split (one by campus)