### PR TITLE
Added cat/uib.txt

### DIFF
--- a/lib/domains/cat/uib.txt
+++ b/lib/domains/cat/uib.txt
@@ -1,0 +1,1 @@
+Universitat de les Illes Balears


### PR DESCRIPTION
Alias for the University of the Balearic Islands (the other one is es/uib.txt).