### PR TITLE
add ecnu email domain for students

### DIFF
--- a/lib/domains/cn/ecnu.txt
+++ b/lib/domains/cn/ecnu.txt
@@ -1,1 +1,0 @@
-East China Normal University

--- a/lib/domains/cn/edu/ecnu/student.txt
+++ b/lib/domains/cn/edu/ecnu/student.txt
@@ -1,0 +1,1 @@
+East China Normal University


### PR DESCRIPTION
there is a ecnu.edu.cn in lib, but now the email domain for students has changed to ecnu.cn