### PR TITLE
Add @student.alfa-college.nl domain for Alfa College

### DIFF
--- a/lib/domains/nl/alfa-college/student.txt
+++ b/lib/domains/nl/alfa-college/student.txt
@@ -1,0 +1,1 @@
+Student subdomain for Alfa College in Hoogeveen and Groningen


### PR DESCRIPTION
Alfa College is situated in both Groningen and Hoogeveen in the Netherlands

The school has been taking benefit of using Jetbrain products for a while now, but only just recently got their own domain and email addresses for students.

Website: http://alfa-college.nl
