### PR TITLE
added avh.txt

### DIFF
--- a/lib/domains/hamburg/avh.txt
+++ b/lib/domains/hamburg/avh.txt
@@ -1,0 +1,1 @@
+Alexander von Humboldt Gymnasium


### PR DESCRIPTION
domain is only in use for the school server and emails
webpage is at http://avh.schulhomepages.hamburg.de/
proof of use: http://avh.schulhomepages.hamburg.de/?page_id=36 email of
the "Betreuer der Homepage"