### PR TITLE
Added lehre.mosbach.dhbw.de

### DIFF
--- a/lib/domains/de/dhbw/mosbach/lehre.txt
+++ b/lib/domains/de/dhbw/mosbach/lehre.txt
@@ -1,0 +1,1 @@
+﻿Duale Hochschule Baden-Württemberg, Mosbach


### PR DESCRIPTION
New domain for http://dhbw-mosbach.de/ (old one is still in use).