### PR TITLE
Lobachevsky State University of Nizhni Novgorod

### DIFF
--- a/lib/domains/ru/nnov/uic.txt
+++ b/lib/domains/ru/nnov/uic.txt
@@ -1,0 +1,1 @@
+Lobachevsky State University of Nizhni Novgorod


### PR DESCRIPTION
Added uic.nnov.ru that hosts mail server of Lobachevsky State University of Nizhni Novgorod