### PR TITLE
Add Korea Aerospace University

### DIFF
--- a/lib/domains/kr/kau.txt
+++ b/lib/domains/kr/kau.txt
@@ -1,0 +1,1 @@
+Korea Aerospace University


### PR DESCRIPTION
Korea Aerospace University has been added since its previous name
(Hankuk Aviation University) is no longer used recently and we replaced
it to Korea Aerospace University.

PLEASE NOTE IT :D

And I located this file beneath the direct location of ‘kr’ rather than
file replacement. Because our web-mail system has been ended and they
encourages to use Office 365 account associated with Academic domain.

Our previous domain was account@kau.ac.kr but now we can use web mail
with account@kau.kr.