### PR TITLE
Add the faculty domain for the College of Western Idaho

### DIFF
--- a/lib/domains/cc/cwidaho.txt
+++ b/lib/domains/cc/cwidaho.txt
@@ -1,0 +1,1 @@
+College of Western Idaho


### PR DESCRIPTION
The College of Western Idaho has two email domains: "@mycwi.cc" for student emails, and "@cwidaho.cc" for faculty members.  This commit adds the faculty domain.