### PR TITLE
Create Valid University of Zambia Domain Name

### DIFF
--- a/lib/domains/zm/unza.txt
+++ b/lib/domains/zm/unza.txt
@@ -1,0 +1,1 @@
+University of Zambia


### PR DESCRIPTION
The current text file describing the University of Zambia -> /lib/domains/zm/unza/www.txt is invalid as it assumes the domain name for the University is www.unza.zm when www is simply a subdomain. This raises an issue as subdomains like cs.unza.zm cannot be identified as valid sub domains.
This submission corrects the entry to /lib/domains/zm/unza.txt which is the correct representation of the *.unza.zm domain names