### PR TITLE
Added edu.ge.ch

### DIFF
--- a/lib/domains/ch/ge/edu.txt
+++ b/lib/domains/ch/ge/edu.txt
@@ -1,0 +1,1 @@
+Département de l'Instruction Publique du Canton de Genève


### PR DESCRIPTION
Added edu.ge.ch, aka the Département de l'Instruction Publique du Canton de Genève, aka the public schools of Geneva.