### PR TITLE
Added afpa.fr

### DIFF
--- a/lib/domains/fr/afpa.txt
+++ b/lib/domains/fr/afpa.txt
@@ -1,0 +1,1 @@
+AFPA Association nationale pour la Formation Professionnelle des Adultes


### PR DESCRIPTION
Added "AFPA, Association Nationale pour la Formation Professionnelle des Adultes" : Public, first training organization in France.