### PR TITLE
Add WRDSB (Canada) email domains

### DIFF
--- a/lib/domains/ca/on/wrdsb.txt
+++ b/lib/domains/ca/on/wrdsb.txt
@@ -1,0 +1,1 @@
+Waterloo Region District School Board

--- a/lib/domains/ca/wrdsb/googleapps.txt
+++ b/lib/domains/ca/wrdsb/googleapps.txt
@@ -1,0 +1,1 @@
+Waterloo Region District School Board

--- a/lib/domains/ca/wrdsb/ins.txt
+++ b/lib/domains/ca/wrdsb/ins.txt
@@ -1,0 +1,1 @@
+Waterloo Region District School Board


### PR DESCRIPTION
[Waterloo Region District School Board](http://www.wrdsb.ca/) has three email paths for students and staff: @ins.wrdsb.ca, @googleapps.wrdsb.ca, and @wrdsb.on.ca.