### PR TITLE
Create ocsbstudent.ca

### DIFF
--- a/lib/domains/ca/ocsbstudent.ca
+++ b/lib/domains/ca/ocsbstudent.ca
@@ -1,0 +1,1 @@
+Ottawa Catholic School Board


### PR DESCRIPTION
GAfE Domain for Ottawa Catholic School Board for students managed by [ocsb.ca](http://ocsb.ca). 

Covers 65 elementary, 2 senior elementary, and 15 secondary schools in Ottawa, Canada.

see #1695 for teachers.

Example e-mail: john.doe@ocsbstudent.ca