### PR TITLE
Create ocsb

### DIFF
--- a/lib/domains/ca/ocsb
+++ b/lib/domains/ca/ocsb
@@ -1,0 +1,1 @@
+Ottawa Catholic School Board


### PR DESCRIPTION
Domain for Ottawa Catholic School Board educators, staff, and teachers. see #1694 for students

Example e-mail: john.doe@ocsb.ca