### PR TITLE
Create gcsnc.txt

### DIFF
--- a/lib/domains/com/gcsnc.txt
+++ b/lib/domains/com/gcsnc.txt
@@ -1,1 +1,1 @@
-Guilford County Schools teacher/staff emails (@gcsnc.com) and student emails (@gaggle.gcsnc.com). Issued only to current GCSNC staff/students.
+Guilford County Public Schools

--- a/lib/domains/com/gcsnc.txt
+++ b/lib/domains/com/gcsnc.txt
@@ -1,0 +1,1 @@
+Guilford County Schools teacher/staff emails (@gcsnc.com) and student emails (@gaggle.gcsnc.com). Issued only to current GCSNC staff/students.


### PR DESCRIPTION
**Guilford County Schools NC Staff/Student emails**. Was trying to download CLion for free as a Brown Summit Middle School student today but the email did not work. Students have studentid@gaggle.gcsnc.com emails, teachers have these (but rarely use them) and teachers and all staff use staffname@gcsnc.com emails. This domain is accepted by MS DreamSpark and Github education. 

MW I have submitted manual request with student ID scan.

P.S. Will this include the subdomain gaggle.gcsnc.com or do I need to add a folder for that?