### PR TITLE
Update Tec.dk

### DIFF
--- a/lib/domains/dk/tec.txt
+++ b/lib/domains/dk/tec.txt
@@ -1,1 +1,1 @@
-TEC - Teknisk Erhvervsskole Center
+TEC - Technical Education Copenhagen


### PR DESCRIPTION
Tec har officially been renamed Technical Education Copenhagen as of July 2015