### PR TITLE
Add missing IITs

### DIFF
--- a/lib/domains/in/ac/iitbbs.txt
+++ b/lib/domains/in/ac/iitbbs.txt
@@ -1,0 +1,1 @@
+Indian Institute of Technology Bhubaneswar

--- a/lib/domains/in/ac/iitgn.txt
+++ b/lib/domains/in/ac/iitgn.txt
@@ -1,0 +1,1 @@
+Indian Institute of Technology Gandhinagar

--- a/lib/domains/in/ac/iitj.txt
+++ b/lib/domains/in/ac/iitj.txt
@@ -1,0 +1,1 @@
+Indian Institute of Technology Jodhpur

--- a/lib/domains/in/ac/iitp.txt
+++ b/lib/domains/in/ac/iitp.txt
@@ -1,0 +1,1 @@
+Indian Institute of Technology Patna

--- a/lib/domains/in/ac/iitrpr.txt
+++ b/lib/domains/in/ac/iitrpr.txt
@@ -1,0 +1,1 @@
+Indian Institute of Technology Ropar


### PR DESCRIPTION
These colleges offer 4 years B.Tech program in Computer Science and Engineering. These are new IITs ([info](https://en.wikipedia.org/wiki/Indian_Institutes_of_Technology)) missing from the list

- iitbbs.ac.in ([curriculum](http://www.iitbbs.ac.in/btech-curriculum.php))  
- iitgn.ac.in ([info](http://cs.iitgn.ac.in/?page_id=44))
- iitj.ac.in ([PDF](http://iitj.ac.in/uploaded_docs/Curricula/Curricula%20CSE.pdf))
- iitp.ac.in ([curriculum](http://www.iitp.ac.in/index.php/academics/programmes/undergraduate/course-curriculum.html))
- iitrpr.ac.in ([info](http://www.iitrpr.ac.in/cse))