### PR TITLE
Add NIT, Fukushima College

### DIFF
--- a/lib/domains/jp/kosen-ac/fukushima.txt
+++ b/lib/domains/jp/kosen-ac/fukushima.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Fukushima College


### PR DESCRIPTION
Please add the domain of National Institute of Technology, Fukushima College.
This collage is affiliated with the National Institude of Technology.
So, Whois Infomation is the same of Hachinohe Collage. 