### PR TITLE
Add Smolny College of Saint Petersburg State University

### DIFF
--- a/lib/domains/org/smolny.txt
+++ b/lib/domains/org/smolny.txt
@@ -1,0 +1,1 @@
+Saint Petersburg State University


### PR DESCRIPTION
Please add the Faculty of Liberal Arts and Sciences (_Smolny College_) of Saint Petersburg State University. 
The official website is http://artesliberales.spbu.ru, however, email is hosted at http://mail.smolny.org (http://smolny.org also redirects to the official website). 
To verify this, you may look for contacts in the footer of the website.

The faculty has a fully-fledged computer science major track. Most of the courses from the curriculum are listed here: http://artesliberales.spbu.ru/academics/katalog-kursov?bm=bakalavr&ct=&programm=cmsc&lang=  This page is in Russian language only, though.

Besides, WHOIS info (https://who.is/whois/smolny.org) points at Bard College in NY, since the faculty actually provides a joint degree program between Bard College and Saint Petersburg State University. 
I hope I made it clear!