### PR TITLE
Add rhsfultonschools to the list of .org academic domains.

### DIFF
--- a/lib/domains/org/rhsfultonschools.txt
+++ b/lib/domains/org/rhsfultonschools.txt
@@ -1,0 +1,1 @@
+Roswell High School


### PR DESCRIPTION
rhsfultonschool.org is the email domain for Roswell High School
in Roswell, Georgia, USA, part of Fulton County Schools.

Note: fultonschools.org is already in the list of accepted
domains, but covers the entire county K-12. rhsfultonschools.org
is only for Roswell High School.