### PR TITLE
Add synonym for Kherson State University

### DIFF
--- a/lib/domains/ua/ks/university.txt
+++ b/lib/domains/ua/ks/university.txt
@@ -1,0 +1,1 @@
+Kherson State University


### PR DESCRIPTION
Add synonym for Kherson State University.
This university already in the list with domain university.kherson.ua, but university.ks.ua is synonym for it and the most of students use the short version 