### PR TITLE
Added edu.guu.ru subdomain

### DIFF
--- a/lib/domains/ru/guu/edu.txt
+++ b/lib/domains/ru/guu/edu.txt
@@ -1,0 +1,2 @@
+State University of Management
+State University of Management


### PR DESCRIPTION
There are two domains used for students and professors in State University of Management.
Domain guu.ru already exists, this file created to add subdomain edu.guu.ru which used for students in SUM.