### PR TITLE
Added domain edu.ti.ch

### DIFF
--- a/lib/domains/ch/ti/edu.txt
+++ b/lib/domains/ch/ti/edu.txt
@@ -1,0 +1,1 @@
+TI-EDU è il nome della rete d'attività di insegnamento superiore e di ricerca scientifica nella Svizzera italiana (Cantone Ticino)


### PR DESCRIPTION
Added the domain edu.ti.ch, this domain is used by a lot of school in south of Switzerland (swiss italian). It's used by almost all professional school (http://www4.ti.ch/decs/) like this one http://www4.ti.ch/decs/ds/portale-scuole/scuole-professionali/dettaglio/?user_decsscuole_pi1%5Bscu_id%5D=69 where I work and I teach Software Developing in Java, Swing and PHP (http://www.spailocarno.ch/spai/download.php?id=233).