### PR TITLE
Added Croatian Academic and Research Network - CARNet

### DIFF
--- a/lib/domains/hr/carnet.txt
+++ b/lib/domains/hr/carnet.txt
@@ -1,0 +1,1 @@
+Croatian Academic and Research Network - CARNet

--- a/lib/domains/hr/skole.txt
+++ b/lib/domains/hr/skole.txt
@@ -1,1 +1,1 @@
-Croatian Academic and Research network
+Croatian Academic and Research Network - CARNet - primary and secondary educational system


### PR DESCRIPTION
Added Croatian Academic and Research Network - CARNet, corrected typo and added indication that `skole.hr` domain is for primary and secondary educational system