### PR TITLE
Create ibb-dresden.txt

### DIFF
--- a/lib/domains/de/ibb-dresden.txt
+++ b/lib/domains/de/ibb-dresden.txt
@@ -1,0 +1,1 @@
+Private Schule IBB gGmbH Dresden

--- a/lib/domains/de/mittelschule-ibb.txt
+++ b/lib/domains/de/mittelschule-ibb.txt
@@ -1,0 +1,1 @@
+Private Ganztagsoberschule und Privates Ganztagsgymnasium der Privaten Schule IBB gGmbH


### PR DESCRIPTION
www.ibb-dresden.de
- Vocational Education & Training(at least 1 up to 3 years)
- Primary / secondary school (see ibb-schulbildung.de)

The Domain ibb-dresden.de ist used by all educational staff.