### PR TITLE
add Hoschule Weserbergland as de/hsw-hameln

### DIFF
--- a/lib/domains/de/hsw-hameln.txt
+++ b/lib/domains/de/hsw-hameln.txt
@@ -1,0 +1,1 @@
+Hochschule Weserbergland


### PR DESCRIPTION
http://www.hsw-hameln.de/

http://www.hsw-hameln.de/bildungs-studienangebote/duales-studium/programm/wirtschaftsinformatik-bsc/

