### PR TITLE
Added Vestfold Fylkeskommune (vfk.no)

### DIFF
--- a/lib/domains/no/vfk.txt
+++ b/lib/domains/no/vfk.txt
@@ -1,0 +1,1 @@
+Vestfold Fylkeskommune


### PR DESCRIPTION
Domain used by multiple schools that specialize in different things.

**Subdomains:**
skole.vfk.no - used by students