### PR TITLE
Add NIT, Tokuyama College

### DIFF
--- a/lib/domains/jp/ac/tokuyama.txt
+++ b/lib/domains/jp/ac/tokuyama.txt
@@ -1,1 +1,0 @@
-National Institute of Technology, Tokuyama College

--- a/lib/domains/jp/ac/tokuyama.txt
+++ b/lib/domains/jp/ac/tokuyama.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Tokuyama College


### PR DESCRIPTION
Please add the domain of National Institute of Technology, Tokuyama College.
This college is affiliated with the National Institute of Technology.
