### PR TITLE
Add Lucerne University of Teacher Education (Switzerland)

### DIFF
--- a/lib/domains/ch/phlu.txt
+++ b/lib/domains/ch/phlu.txt
@@ -1,0 +1,1 @@
+PH Luzern - University of Teacher Education Lucerne


### PR DESCRIPTION
Lucerne University of Teacher Education (PHLU Luzern)