### PR TITLE
Create facnet.txt

### DIFF
--- a/lib/domains/br/facnet.txt
+++ b/lib/domains/br/facnet.txt
@@ -1,0 +1,1 @@
+Faculdade de Negócios e Tecnologias da Informação


### PR DESCRIPTION
"Inaugurada em 2002, a Faculdade de Negócios e Tecnologias da Informação (FACNET) é mantida pela Anhanguera Educacional Ltda. e oferece cursos de graduação na modalidade presencial, autorizados e/ou reconhecidos pelo MEC, bem como cursos de pós-graduação lato sensu (especialização) e de extensão." - Foursquare