### PR TITLE
rggu added to domain list

### DIFF
--- a/lib/domains/ru/rggu.txt
+++ b/lib/domains/ru/rggu.txt
@@ -1,0 +1,1 @@
+Russian State University for the Humanities


### PR DESCRIPTION
rggu.ru is the new domain for the Russian State University for the Humanities