### PR TITLE
Add Friends Academy (fa.org)

### DIFF
--- a/lib/domains/org/fa.txt
+++ b/lib/domains/org/fa.txt
@@ -1,0 +1,1 @@
+Friends Academy


### PR DESCRIPTION
This pull request adds an entry for [Friends Academy](www.fa.org), an independent Quaker college-preparatory private school located in Long Island, serving Early Childhood through 12th grade.

Please see page 13 of the [Academic Pathways document](https://www.fa.org/uploaded/US_Attachments/2016-17_Pathways.pdf) for proof of a long-term IT-related course offering.

Please see [this partial screenshot](http://ww2.fa.org/static/swot-pull-request-screenshot.png) of the faculty-accessible student directory, showing that student email addresses use the domain @fa.org.