### PR TITLE
added UCDB to domains

### DIFF
--- a/lib/domains/br/ucdb.txt
+++ b/lib/domains/br/ucdb.txt
@@ -1,0 +1,1 @@
+Universidade Catolica Dom Bosco


### PR DESCRIPTION
UCDB - Universidade Católica Dom Bosco
(or Dom Bosco Catholic University)
[http://site.ucdb.br/](http://site.ucdb.br/)

One of their IT courses:
[http://site.ucdb.br/cursos/4/graduacao/26/engenharia-de-computacao/193/](http://site.ucdb.br/cursos/4/graduacao/26/engenharia-de-computacao/193/)