### PR TITLE
Add Eton College

### DIFF
--- a/lib/domains/uk/org/etoncollege.txt
+++ b/lib/domains/uk/org/etoncollege.txt
@@ -1,0 +1,2 @@
+Eton College
+


### PR DESCRIPTION
The main url is http://www.etoncollege.com/

They offer a 2 year GCSE course (equivalent of first two years of high school) in Computer Science [here](http://www.etoncollege.com/e_d_block.aspx)

All emails on the site (for example the web clerk webclerk@etoncollege.org.uk at the bottom of every page) use the .org.uk domain. They don't have many emails publicly but every one there uses the etoncollege.org.uk domain.

See also http://www.etoncollege.com/EtonEmail.aspx which links to a page where the domain is verified. 