### PR TITLE
Create fing.txt

### DIFF
--- a/lib/domains/uy/edu/fing.txt
+++ b/lib/domains/uy/edu/fing.txt
@@ -1,0 +1,2 @@
+Facultad de Ingeniería, Universidad de la República
+https://www.fing.edu.uy/


### PR DESCRIPTION
Adding support for Engineering Department of the Universidad de la República
https://www.fing.edu.uy/ (belongs to http://www.udelar.edu.uy/)