### PR TITLE
Oswaldo Cruz Foundation (Fundação Oswaldo Cruz, Fiocruz), Brazil

### DIFF
--- a/lib/domains/br/fiocruz.txt
+++ b/lib/domains/br/fiocruz.txt
@@ -1,0 +1,1 @@
+Fundação Oswaldo Cruz


### PR DESCRIPTION
Oswaldo Cruz Foundation (Fundação Oswaldo Cruz, Fiocruz) is a leading Public Health Research Institute in Latin America, under the Brazilian Ministry of Health, with several graduate programs.
More details regarding research and teaching can be found at http://portal.fiocruz.br/en/content/research-and-teaching