### PR TITLE
New address for ECE

### DIFF
--- a/lib/domains/fr/ecetech/edu.txt
+++ b/lib/domains/fr/ecetech/edu.txt
@@ -1,0 +1,1 @@
+Ecole Centrale d'Electronique - ECE

--- a/lib/domains/fr/edu/ecetech.txt
+++ b/lib/domains/fr/edu/ecetech.txt
@@ -1,0 +1,1 @@
+Ecole Centrale d'Electronique - ECE

--- a/lib/domains/fr/edu/ecetech.txt
+++ b/lib/domains/fr/edu/ecetech.txt
@@ -1,1 +1,0 @@
-Ecole Centrale d'Electronique - ECE


### PR DESCRIPTION
New email address for ece.fr to edu.ecetech.fr

(http://www.ecetech.fr/) is a French IT university.

The edu extension is only for email addresses.

(Maybe my path is wrong ? I want @edu.ecetech.fr)