### PR TITLE
Distinguish Olivet University and Olivet Nazarene University

### DIFF
--- a/lib/domains/edu/Olivet.txt
+++ b/lib/domains/edu/Olivet.txt
@@ -1,1 +1,0 @@
-Olivet University

--- a/lib/domains/edu/olivet.txt
+++ b/lib/domains/edu/olivet.txt
@@ -1,0 +1,1 @@
+Olivet Nazarene University

--- a/lib/domains/edu/olivet.txt
+++ b/lib/domains/edu/olivet.txt
@@ -1,1 +1,0 @@
-Olivet University

--- a/lib/domains/edu/olivetuniversity.txt
+++ b/lib/domains/edu/olivetuniversity.txt
@@ -1,0 +1,1 @@
+Olivet University


### PR DESCRIPTION
Before this PR, there was lib/domains/edu/Olivet.txt file with content Olivet University. However, domain of Olivet University is olivetuniversity.edu while olivet.edu is domain for Olivet Nazarene University. This PR distinguish those 2 different institution with correct name and domain.