### PR TITLE
Name Change of Fachhochschule Brandenburg to Technische Hochschule Brandenburg

### DIFF
--- a/lib/domains/de/fh-brandenburg.txt
+++ b/lib/domains/de/fh-brandenburg.txt
@@ -1,1 +1,1 @@
-Fachhochschule Brandenburg
+Technische Hochschule Brandenburg

--- a/lib/domains/de/th-brandenburg.txt
+++ b/lib/domains/de/th-brandenburg.txt
@@ -1,0 +1,1 @@
+Technische Hochschule Brandenburg


### PR DESCRIPTION
See commit comments.

you can see that the name changed in multiple official news and the uni's website. Here's one such link from the news:
http://www.skb-tv.de/news/fh-brandenburg-bekommt-neuen-namen/