### PR TITLE
Add Buskerud fylkeskommune

### DIFF
--- a/lib/domains/no/bfk/vgs.txt
+++ b/lib/domains/no/bfk/vgs.txt
@@ -1,0 +1,1 @@
+Buskerud Fylkeskommune


### PR DESCRIPTION
Domain used by multiple schools in Buskerud, Norway.
Majority of the schools has technology oriented studies.

**Mail domain:**
vgs.bfk.no

**Buskerud county website:**
[bfk.no](http://bfk.no)


**List of schools:**
[http://www.bfk.no/Tjenesteomrade/Utdanning/videregaende-skole/Skoler-og-Arbeidsinstitutt/](http://www.bfk.no/Tjenesteomrade/Utdanning/videregaende-skole/Skoler-og-Arbeidsinstitutt/) (In Norwegian)
