### PR TITLE
Added domain file for Queen Mary, University of London

### DIFF
--- a/lib/domains/uk/ac/qmul.txt
+++ b/lib/domains/uk/ac/qmul.txt
@@ -1,0 +1,1 @@
+Queen Mary, University of London


### PR DESCRIPTION
Information for adding the domain quicker:

- [University official website URL](http://www.qmul.ac.uk)
- [BSc (Hons) Computer Science](http://www.qmul.ac.uk/undergraduate/coursefinder/courses/80043.html#second), 3 year course
- On the [email section](http://www.its.qmul.ac.uk/services/students/email/) of Services for students is a link to information for [setting up email in an IMAP client](http://www.its.qmul.ac.uk/support/self-help/email_setup/settingupemail/143256.html), which indicates the students email address is their  Username followed by @qmul.ac.uk.