### PR TITLE
Add NIT, Kagawa College

### DIFF
--- a/lib/domains/jp/kosen-ac/kagawa.txt
+++ b/lib/domains/jp/kosen-ac/kagawa.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Kagawa College


### PR DESCRIPTION
Please add the domain of National Institute of Technology, Kagawa College.
This collage is affiliated with the National Institude of Technology.
So, Whois Infomation is the same of Kagawa Collage.