### PR TITLE
Added CHS

### DIFF
--- a/lib/domains/us/fl/k12/stjohns.txt
+++ b/lib/domains/us/fl/k12/stjohns.txt
@@ -1,0 +1,1 @@
+Creekside High School


### PR DESCRIPTION
Creekside High School is a public school that offers a 4 year Cybersecurity academy.

http://www-chs.stjohns.k12.fl.us/