### PR TITLE
Added Yrgo university

### DIFF
--- a/lib/domains/se/goteborg/educ.txt
+++ b/lib/domains/se/goteborg/educ.txt
@@ -1,0 +1,2 @@
+Yrgo
+.groups


### PR DESCRIPTION
Added university Yrgo, one of many under the educ.goteborg.se domain. Emails for those universities under the domain is formatted _firstname.lastname@educ.goteborg.se_.

The main site for Yrgo is [http://yrgo.se](http://yrgo.se)

The web development program that I am a teacher at has an information page located at [http://yrgo.se/utbildningar/media-och-kommunikation/webbutvecklare/](http://yrgo.se/utbildningar/media-och-kommunikation/webbutvecklare/)

You can see that all contact information is using email addresses containing educ.goteborg.se  - including this pdf [http://yrgo.se/wp-content/uploads/auto-pdf-generation/webbutvecklare/webbutvecklare-20160422.pdf](http://yrgo.se/wp-content/uploads/auto-pdf-generation/webbutvecklare/webbutvecklare-20160422.pdf)


The content is in Swedish, I hope this is not a problem. 