### PR TITLE
Added Yrgo, gothenburg education student mail domain

### DIFF
--- a/lib/domains/se/goteborg/skola.txt
+++ b/lib/domains/se/goteborg/skola.txt
@@ -1,0 +1,2 @@
+Göteborgs stad Utbildning, Yrgo
+.group


### PR DESCRIPTION
Added student mail domain for Yrgo University & Gothenburg education. Emails for the students are formatted as: _firstname.lastname@skola.goteborg.se_.

This pullrequest is a follow up to: https://github.com/JetBrains/swot/pull/2212

The students are using Google Apps For Education to sign in to their emails, so I do not have a portal available with more information. The information they get say that they will sign in at http://epost.skola.goteborg.se. 

Pleas let me know if you will need something more. Regards.