### PR TITLE
Modify the domain name for the University of Medicine Bucharest

### DIFF
--- a/lib/domains/ro/umf.txt
+++ b/lib/domains/ro/umf.txt
@@ -1,0 +1,2 @@
+"Carol Davila" University of Medicine and Pharmacy Bucharest
+Universitatea de Medicină și Farmacie „Carol Davila” București

--- a/lib/domains/ro/univermed-cdgm.txt
+++ b/lib/domains/ro/univermed-cdgm.txt
@@ -1,1 +1,0 @@
-University of Medicine and Pharmacy of Bucharest


### PR DESCRIPTION
Hello,

This is a PR to modify the older, unused domain name 'univermed-cdgm.ro' of the 'Carol Davila University of Medicine Bucharest'. The domain in use is 'umf.ro' for web and email. See http://www.univermed-cdgm.ro vs. http://www.umf.ro.
Our university offers 1-year pre-graduate courses in IT (including biostatistics and medical informatics) and also a master in Medical Biophysics and Cell Biotechnology. Unfortunately, there is no description on the University web site of the former, but details are available (in Romanian) regarding the latter [here](http://umf.ro/index.php/facultati/medicina-generala/89-facultati/medgen/departamente-discipline/477-masterat-biofizica-si-biotehnologie-celulara). There is also a [brochure](http://umf.ro/images/PDF/Departamente_Discipline/brosuramartie_2013.pdf) in English available, listing some of the relevant study topics: Genomics and proteomics, Basics of statistics and advanced processing of experimental data, etc.
E-mails within the 'umf.ro' domain ([login](http://mail.umf.ro/src/login.php)) are used mainly for faculty staff and master / PhD students. This is noticeable on the general '[Contact](http://umf.ro/index.php/organizare/conducere/contact-general-rectorat)' page and also in department contact lists. There is also a copyright notice on the main page (see attached image) with fiscal details of the University. 
<img width="966" alt="umf_ro" src="https://cloud.githubusercontent.com/assets/13225298/18082636/76c2eba4-6ea8-11e6-9dac-2f4519370252.png">
You could also check the [Romanian TLD](https://www-apps.rotld.ro/whois/cgi-bin/index?lang=en) and see that both domains (old and new) have the same owner.
As I am concerned, my position is lecturer within the Cell Biology Department and have a strong interest in lsequencing data analysis.

Regards,
Eugen Radu
eugen.radu@umf.ro
