### PR TITLE
Create karmoyskolen.txt

### DIFF
--- a/lib/domains/no/karmoyskolen.txt
+++ b/lib/domains/no/karmoyskolen.txt
@@ -1,0 +1,1 @@
+Karmøy Kommune Skoledomene


### PR DESCRIPTION
karmoyskolen.no is a shared domain for all schools in the Karmøy council of Rogaland, Norway.
All schools under it include Vormedal ungdomsskole, Åkra ungdomsskule, Ådland barnaskule, Mykje barneskole, Stangeland ungdomsskole, and more.