### PR TITLE
Add Central Magnet School

### DIFF
--- a/lib/domains/us/tn/k12/rcs/central.txt
+++ b/lib/domains/us/tn/k12/rcs/central.txt
@@ -1,0 +1,1 @@
+Central Magnet School


### PR DESCRIPTION
I'm interested in having my school added to this list.
# Domain
The domain of my school is [central.rcs.k12.tn.us](http://central.rcs.k12.tn.us). However, the domain for the district is simply [rcschools.net](http://rcschools.net).
# Long-term IT-related courses
This school has an AP Computer Science class and two other programming courses, all of which last one year. Proof for all of these classes' existence can be found [here](http://central.rcs.k12.tn.us/courses.html) on page 8.
# Email
My school issues email addresses. This can be proved by going to [email.rcschools.net](http://email.rcschools.net), which brings up a login field, showing there is an email server there.
I understand that the school emails are issued at a different domain than that of the school website. If this means that I need to change the pull request in some way, please tell me. I'm not quite sure how application for the education discount works, so I don't know if it's a problem that the email domain isn't a `k12.tn.us` domain. It should be enough for proof that on the [central.rcs.k12.tn.us](http://central.rcs.k12.tn.us) homepage, there is a link to [email.rcschools.net](http://email.rcschools.net) under Resources > Student Links > Office 365 Email.  
Thanks!