### PR TITLE
Add Konrad Lorenz Gymnasium (klg.or.at)

### DIFF
--- a/lib/domains/at/or/klg.txt
+++ b/lib/domains/at/or/klg.txt
@@ -1,0 +1,1 @@
+Konrad Lorenz Gymnasium


### PR DESCRIPTION
Website: http://www.klg.or.at/

Post-secondary 3-year specialization in informatics see http://www.klg.or.at/faecher/wahlpflichtfaecher?s=INF_plus

Staff and students use this mail domain, see e.g. http://www.klg.or.at/lehrer