### PR TITLE
HTL Krems changed its domain

### DIFF
--- a/lib/domains/at/htlkrems.txt
+++ b/lib/domains/at/htlkrems.txt
@@ -1,0 +1,1 @@
+HTL Krems

--- a/lib/domains/com/onmicrosoft/htlkrems3500.txt
+++ b/lib/domains/com/onmicrosoft/htlkrems3500.txt
@@ -1,1 +1,0 @@
-HTL Krems


### PR DESCRIPTION
HTL Krems changed its network and domain. Actually, the webpage is only accessible via the old URL: http://www.htlkrems.ac.at; In future, all services should be migrated to htlkrems.at

Changes: htlkrems3500.onmicrosoft.com -> htlkrems.at

[photo_2016-09-15_18-06-49](https://cloud.githubusercontent.com/assets/21141148/18557486/7528b9e4-7b6f-11e6-9243-d9e4bad6b71d.jpg)