### PR TITLE
Added Web school factory

### DIFF
--- a/lib/domains/fr/etu-webschoolfactory.txt
+++ b/lib/domains/fr/etu-webschoolfactory.txt
@@ -1,0 +1,1 @@
+La Web School Factory

--- a/lib/domains/fr/prof-webschoolfactory.fr
+++ b/lib/domains/fr/prof-webschoolfactory.fr
@@ -1,0 +1,1 @@
+La Web School Factory

--- a/lib/domains/fr/webschoolfactory.txt
+++ b/lib/domains/fr/webschoolfactory.txt
@@ -1,0 +1,1 @@
+La Web School Factory


### PR DESCRIPTION
Added the 3 domains of the Web school factory.

This is a 5 year web school, in Paris, France.

The domains are : 
`webschoolfactory.fr` : main domain
`etu-webschoolfactory.fr` : Domain used for students e-mail addresses
`prof-webschoolfactory.fr` : Domain used for teachers e-mail addresses