### PR TITLE
Create apschools.txt

### DIFF
--- a/lib/domains/org/apschools.txt
+++ b/lib/domains/org/apschools.txt
@@ -1,0 +1,1 @@
+Alliance Public Schools


### PR DESCRIPTION
Actual website is apschools.schoolfusion.us, however email addresses are under apschools.org, which also redirects to website.