### PR TITLE
Updated Gymnasium Rhauderfehn

### DIFF
--- a/lib/domains/de/gymnasium-rhauderfehn.txt
+++ b/lib/domains/de/gymnasium-rhauderfehn.txt
@@ -1,1 +1,0 @@
-Gymnasium Rhauderfehn

--- a/lib/domains/eu/gymnasium-rhauderfehn.txt
+++ b/lib/domains/eu/gymnasium-rhauderfehn.txt
@@ -1,0 +1,1 @@
+Gymnasium Rhauderfehn


### PR DESCRIPTION
Moved gymnasium-rhauderfehn.de to gymnasium-rhauderfehn.eu