### PR TITLE
Create umons.txt

### DIFF
--- a/lib/domains/be/ac/umons.txt
+++ b/lib/domains/be/ac/umons.txt
@@ -1,0 +1,1 @@
+University of Mons (merging of UMH and FPMS).


### PR DESCRIPTION
.umons.ac.be replaces both .umh.ac.be and .fpms.ac.be, since those universities merged in 2009.