### PR TITLE
Added Lublin University of Technology (pollub.pl)

### DIFF
--- a/lib/domains/pl/pollub.txt
+++ b/lib/domains/pl/pollub.txt
@@ -1,0 +1,1 @@
+Lublin University of Technology


### PR DESCRIPTION
This domain is available only for teachers.