### PR TITLE
Add teiwest.gr to the school domains data

### DIFF
--- a/lib/domains/gr/teiwest.txt
+++ b/lib/domains/gr/teiwest.txt
@@ -1,0 +1,1 @@
+Technological Educational Institute of Western Greece


### PR DESCRIPTION
Technological Educational Institute of Messolonghi (TEIMES) and Technological Educational Institute of Patras (TEIPAT) were merged in 2013 to Technological Educational Institute of Western Greece (TEIWEST).
This change reflects this merge.

Student email addresses are now in the process of migrating to the new teiwest.gr domain.

Not removing the old teipat.gr and teimes.gr as I expect most of the emails there are still being used.