### PR TITLE
New domain for Jönköping University.

### DIFF
--- a/lib/domains/se/ju.txt
+++ b/lib/domains/se/ju.txt
@@ -1,0 +1,1 @@
+Jönköping University


### PR DESCRIPTION
Old domain is hj.se, new one is ju.se  (This changed took place earlier and no longer are mails forwarded)