### PR TITLE
Add NIT, Toyota College

### DIFF
--- a/lib/domains/jp/kosen-ac/toyota.txt
+++ b/lib/domains/jp/kosen-ac/toyota.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Toyota College


### PR DESCRIPTION
Please add the domain of National Institute of Technology, Toyota College.
Our college is also called Toyota Kosen.This collage is affiliated with the National Institude of Technology.
So, Whois Infomation is the same of Toyota Collage.