### PR TITLE
Add Driestar College

### DIFF
--- a/lib/domains/nl/driestarleerling.txt
+++ b/lib/domains/nl/driestarleerling.txt
@@ -1,0 +1,1 @@
+Driestar College


### PR DESCRIPTION
"driestarleerling.nl" is the e-mail domain for students from all three locations of the Driestar College ([driestarcollege.nl](http://driestarcollege.nl/)) in The Netherlands.