### PR TITLE
Create msnsixth.txt

### DIFF
--- a/lib/domains/com/msnsixth.txt
+++ b/lib/domains/com/msnsixth.txt
@@ -1,0 +1,1 @@
+Midsomer Norton Sixth Form


### PR DESCRIPTION
Add Midsomer Norton Sixth Form.
Only students have email addresses at this domain.
Sixth Form website is also hosted at this domain (msnsixth.com).