### PR TITLE
Added more domains for Incheon National University

### DIFF
--- a/lib/domains/kr/ac/incheon.txt
+++ b/lib/domains/kr/ac/incheon.txt
@@ -1,0 +1,1 @@
+Incheon National University

--- a/lib/domains/kr/ac/inu.txt
+++ b/lib/domains/kr/ac/inu.txt
@@ -1,0 +1,1 @@
+Incheon National University


### PR DESCRIPTION
They have 3 domains; incheon.ac.kr, inu.ac.kr, and inchon.ac.kr(deprecated).
