### PR TITLE
Create ibrict.txt

### DIFF
--- a/lib/domains/om/edu/ibrict.txt
+++ b/lib/domains/om/edu/ibrict.txt
@@ -1,0 +1,1 @@
+Ibri College of Technology


### PR DESCRIPTION
This is the file for the domain name of Ibri College of Technology. The College's website is at http://www.ibrict.edu.om.

The IT Department page is found at http://www.ibrict.edu.om/view.aspx?site=academics/information-tech. Under this page there is a list of specializations which are offered by the college.  The following PDF shows the list of courses offered by the college for the Diploma level of the Software Engineering Specialization:

http://www.ibrict.edu.om/site/academics/information-tech/it/softwareEngineering_diploma.pdf