### PR TITLE
Create auis

### DIFF
--- a/lib/domains/krd/auis
+++ b/lib/domains/krd/auis
@@ -1,0 +1,1 @@
+American University of Iraq, Sulaimani


### PR DESCRIPTION
The American University of Iraq, Sulaimani (AUIS) is one of the prominent universities in Iraq. It used to be on "iq" (Iraq) TLD. Now it uses "krd" TLD. 

It is located in the city of Sulaimani, Kurdistan Region, Iraq.