### PR TITLE
Delete auis.txt

### DIFF
--- a/lib/domains/iq/edu/auis.txt
+++ b/lib/domains/iq/edu/auis.txt
@@ -1,1 +1,0 @@
-American University of Iraq, Sulaimani (Kurdistan Region)


### PR DESCRIPTION
This is no longer functional, at least for email addresses. Any emails address formatted as name@auis.edu.iq will not receive emails. Instead the domain name has been moved to .edu.krd. So now, it is formally auis.edu.krd (http://www.auis.edu.krd). Students also use name@auis.edu.krd (I'm myself a student there).