### PR TITLE
Add Driestar College

### DIFF
--- a/lib/domains/nl/driestarleerling.txt
+++ b/lib/domains/nl/driestarleerling.txt
@@ -1,0 +1,1 @@
+Driestar College


### PR DESCRIPTION
> "driestarleerling.nl" is the domain for school-related Microsoft-accounts (+ e-mail) assigned to pupils of the Driestar College.

Pull request #2507 closed, cannot reopen it as I'm not an owner or editor.
my [last comment](https://github.com/JetBrains/swot/pull/2507#issuecomment-269216445) there should resolve the issue of verifying if the domain actually belongs to the school.