### PR TITLE
VUB - Vrije Universiteit Brussel

### DIFF
--- a/lib/domains/be/vub
+++ b/lib/domains/be/vub
@@ -1,0 +1,1 @@
+Vrije Universiteit Brussel


### PR DESCRIPTION
VUB is migrating new accounts FROM vub.ac.be TO vub.be
Both are being used