### PR TITLE
Added CSG Augustinus (Groningen)

### DIFF
--- a/lib/domains/nl/csgaugustinus.txt
+++ b/lib/domains/nl/csgaugustinus.txt
@@ -1,0 +1,1 @@
+CSG Augustinus


### PR DESCRIPTION
"csgaugustinus.nl" is the domain for school-related Microsoft-accounts (e-mail included) assigned to pupils of CSG Augustinus.