### PR TITLE
Add domain for INSA Lyon

### DIFF
--- a/lib/domains/fr/bde-insa-lyon.txt
+++ b/lib/domains/fr/bde-insa-lyon.txt
@@ -1,0 +1,1 @@
+Institut National des Sciences Appliquées de Lyon

--- a/lib/domains/org/insa-lyon.txt
+++ b/lib/domains/org/insa-lyon.txt
@@ -1,0 +1,1 @@
+Institut National des Sciences Appliquées de Lyon


### PR DESCRIPTION
Register alternate domain for INSA Lyon.
This domain is an alias of bde.insa-lyon.org and is used by the student organization of the school.