### PR TITLE
Added Douglas County School District

### DIFF
--- a/lib/domains/org/dcsdk12.txt
+++ b/lib/domains/org/dcsdk12.txt
@@ -1,0 +1,2 @@
+Douglas County School District
+.group

--- a/lib/domains/org/dcsdk12/s.txt
+++ b/lib/domains/org/dcsdk12/s.txt
@@ -1,0 +1,2 @@
+Douglas County School District
+.group


### PR DESCRIPTION
The normal dcsdk12.org domain is for the teachers, and s.dcsdk12.org is
for the students

Website: [https://www.dcsdk12.org/high-school-education](https://www.dcsdk12.org/high-school-education)
Year-long Course (Page 34, AP Computer Science A): [http://www.legendtitans.org/assets/courseguide.pdf](http://www.legendtitans.org/assets/courseguide.pdf)

Proof of student email:

![school-email-proof-2](https://cloud.githubusercontent.com/assets/6487079/21790135/56c25aea-d697-11e6-80cc-aa70f088710d.PNG)

NOTE: I'm not quite sure whether I needed to create a file for the s.dcsdk12.org domain if the dcsdk12.org file is already in there.