### PR TITLE
Added Het Baarnsch Lyceum

### DIFF
--- a/lib/domains/nl/hetbaarnschlyceum.txt
+++ b/lib/domains/nl/hetbaarnschlyceum.txt
@@ -1,0 +1,1 @@
+Het Baarnsch Lyceum


### PR DESCRIPTION
hetbaarnschlyceum.nl is the e-mail domain used by teachers/students at Het Baarnsch Lyceum