### PR TITLE
Add Clear Creek Amana High School

### DIFF
--- a/lib/domains/org/ccaschools.txt
+++ b/lib/domains/org/ccaschools.txt
@@ -1,0 +1,1 @@
+Clear Creek Amana High School


### PR DESCRIPTION
Adds Clear Creek Amana High.
http://www.ccaschools.org/index.php/high-school