### PR TITLE
Added clg.qc.ca domain

### DIFF
--- a/lib/domains/ca/qc/clg.txt
+++ b/lib/domains/ca/qc/clg.txt
@@ -1,0 +1,1 @@
+Collège Lionel-Groulx


### PR DESCRIPTION
Quebec CEGEP / College.
Here is its website: http://www.clg.qc.ca/