### PR TITLE
Domain name is different for student email-id than that of professors.

### DIFF
--- a/lib/domains/etu/univ-st-etienne.txt
+++ b/lib/domains/etu/univ-st-etienne.txt
@@ -1,0 +1,1 @@
+Université Jean Monnet Student


### PR DESCRIPTION
Student:    name@etu.univ-st-etienne   # etu ->  étudiant(Student)
Professors: http://mldm.univ-st-etienne.fr/catalogue/Master_MLDM_Intro-to-ML.pdf
            Ex: name@univ-st-etienne.fr

Note: It seems that student email-id domain was never added, and since it not under same sub-domain so it does not work. It already works for professors because https://github.com/JetBrains/swot/blob/master/lib/domains/fr/univ-st-etienne.txt.
email-id: prem.prakash@etu.univ-st-etienne