### PR TITLE
Adding tue.txt

### DIFF
--- a/lib/domains/de/mpg/tue.txt
+++ b/lib/domains/de/mpg/tue.txt
@@ -1,0 +1,1 @@
+Max Planck Institute for Intelligent Systems, Tuebingen, Germany


### PR DESCRIPTION
Max Planck Institute for Intelligent Systems, Tuebingen, Germany with domain names *.tue.mpg.de