### PR TITLE
Add Cowbridge Comprehensive School Sixth Form

### DIFF
--- a/lib/domains/uk/co/cowbridgecomprehensiveschool.txt
+++ b/lib/domains/uk/co/cowbridgecomprehensiveschool.txt
@@ -1,0 +1,1 @@
+Cowbridge Comprehensive School Sixth Form

--- a/lib/domains/uk/co/cowbridgecs.txt
+++ b/lib/domains/uk/co/cowbridgecs.txt
@@ -1,0 +1,1 @@
+Cowbridge Comprehensive School Sixth Form


### PR DESCRIPTION
Add Cowbridge Comprehensive School Sixth Form

http://www.cowbridgecomprehensiveschool.co.uk/cms/_files/AS%20Options%20Booklet%20September%202017.pdf

Computer Science Page 19

Information and Communication
Technology (ICT) Page 43

Both of which are 2 Year A Level Courses