### PR TITLE
Added matc.txt for matc.edu

### DIFF
--- a/lib/domains/edu/matc.txt
+++ b/lib/domains/edu/matc.txt
@@ -1,0 +1,1 @@
+Milwaukee Area Technical College


### PR DESCRIPTION
"**matc.edu**" is the domain for faculty at _Milwaukee Area Technical College_.

Official website URL:
[http://www.matc.edu](http://www.matc.edu)

Specific course pages can't be linked to directly, but these pages list 1-year IT courses (e.g., Web Programming):
[IT Web & Software Developer](http://www.matc.edu/student/offerings/2015-2016/degrees/it-web-and-software-developer.cfm)
[IT Programmer Analyst](http://www.matc.edu/student/offerings/2012-2013/degrees/it_programmer_analyst.cfm)

This page lists subjects, from which you can access specific course pages:
[http://infonline.matc.edu/live-infonline/html/subject.html](http://infonline.matc.edu/live-infonline/html/subject.html)

Email address examples for faculty "@matc.edu":
[http://www.matc.edu/matc_news/ExpertList.cfm](http://www.matc.edu/matc_news/ExpertList.cfm)