### PR TITLE
epita.net & ens2m.org 

### DIFF
--- a/lib/domains/net/epita.txt
+++ b/lib/domains/net/epita.txt
@@ -1,1 +1,1 @@
-École pour l’informatique et les techniques avancées
+École Pour l'Informatique et les Techniques Avancées

--- a/lib/domains/net/epita.txt
+++ b/lib/domains/net/epita.txt
@@ -1,0 +1,1 @@
+École pour l’informatique et les techniques avancées

--- a/lib/domains/org/ens2m.txt
+++ b/lib/domains/org/ens2m.txt
@@ -1,0 +1,1 @@
+École nationale supérieure de mécanique et des microtechniques

--- a/lib/domains/org/ens2m.txt
+++ b/lib/domains/org/ens2m.txt
@@ -1,1 +1,1 @@
-École nationale supérieure de mécanique et des microtechniques
+École Nationale Supérieure de Mécanique et des Microtechniques


### PR DESCRIPTION
- Add epita.net domain for "École pour l’informatique et les techniques avancées"
- Add ens2m.org domain for "École nationale supérieure de mécanique et des microtechniques"
