### PR TITLE
Add the Copenhagen Institute of Interaction Design (CIID)

### DIFF
--- a/lib/domains/dk/ciid.txt
+++ b/lib/domains/dk/ciid.txt
@@ -1,0 +1,1 @@
+Copenhagen Institute of Interaction Design (CIID)


### PR DESCRIPTION
Please add the Copenhagen Institute of Interaction Design (CIID) to your list of education institutes http://ciid.dk/