### PR TITLE
Add top-level domain kabk.nl back in

### DIFF
--- a/lib/domains/nl/kabk.txt
+++ b/lib/domains/nl/kabk.txt
@@ -1,0 +1,1 @@
+Koninklijke Academie van Beeldende Kunsten, Den Haag


### PR DESCRIPTION
@GaborK moved this to kabk/student.txt in c4e724517932b7b1ee63fa865ab26800e14a6693

But teachers use the top-level `kabk.nl` domain.

Merci!