### PR TITLE
Add Edge Hill University

### DIFF
--- a/lib/domains/uk/ac/edgehill.txt
+++ b/lib/domains/uk/ac/edgehill.txt
@@ -1,0 +1,1 @@
+Edge Hill University

--- a/lib/domains/uk/ac/edgehill/go.txt
+++ b/lib/domains/uk/ac/edgehill/go.txt
@@ -1,0 +1,1 @@
+Edge Hill University


### PR DESCRIPTION
edgehill.ac.uk and go.edgehill.ac.uk each host student email addresses of varying ages.
https://www.edgehill.ac.uk/courses/computer-science-bsc/
https://www.edgehill.ac.uk/itservices/microsoft-office/ references both domains as being email domains for our students.