### PR TITLE
Add Eden Prairie High School

### DIFF
--- a/lib/domains/org/ep-student.txt
+++ b/lib/domains/org/ep-student.txt
@@ -1,0 +1,1 @@
+Eden Prairie School District - Student Emails

--- a/lib/domains/us/mn/k12/edenpr.txt
+++ b/lib/domains/us/mn/k12/edenpr.txt
@@ -1,0 +1,1 @@
+Eden Prairie School District - Teacher Email


### PR DESCRIPTION
Added emails for student's and staff of Eden Prairie School District.
Student emails use the convention of __`studentID`__`@ep-student.org` and teacher emails use the convention of __`firstName`__`_`__`lastName`__`@edenpr.k12.mn.us` (spaces are caused accidentally by Markdown). Emails can only be created by District Administration.
Eden Prairie High School offers multiple AP Computer Science classes each taking up ~2 terms (1/2 of the year).
Website of the school district is `edenpr.org`, [here](https://www.edenpr.org/cms/lib/MN01909581/Centricity/Domain/269/2017-18%20Course%20Guide%20.pdf#7) is a link to the course offerings of next year (already at the section for Computer Science, if not it is at the top of page 7).