### PR TITLE
Add Woodrush High School

### DIFF
--- a/lib/domains/email/woodrushhigh.txt
+++ b/lib/domains/email/woodrushhigh.txt
@@ -1,0 +1,1 @@
+Woodrush High School


### PR DESCRIPTION
Added Woodrush High School to the repository.
School website: woodrushhigh.worcs.sch.uk (however the student email pattern follows studentname@woodrushhigh.email)

Course list: http://woodrushhigh.worcs.sch.uk/index.phtml?d=554632 (here you can see the BTECT ICT course listed.

Thanks!