### PR TITLE
Create ghsem.txt

### DIFF
--- a/lib/domains/de/schule-bw/em/ghsem.txt
+++ b/lib/domains/de/schule-bw/em/ghsem.txt
@@ -1,0 +1,1 @@
+Gewerbliche und Hauswirtschaftlich-Sozialpflegerische Schulen Emmendingen


### PR DESCRIPTION
URL: www.ghse.de

IT-related: www.ghse.de/ghse/index.php/schularten/vollzeitschularten/technisches-gymnasium/profil-informationstechnik and www.ghse.de/ghse/index.php/schularten/vollzeitschularten/berufskollegs/2-jaehriges-berufskolleg-informations-und-kommunikationstechnik

Proof: www.ghsem.em.schule-bw.de refers to www.ghse.de