### PR TITLE
added kannur engg collage,kerala

### DIFF
--- a/lib/domains/in/ac/gcek.txt
+++ b/lib/domains/in/ac/gcek.txt
@@ -1,0 +1,1 @@
+Government College of Engineering Kannur


### PR DESCRIPTION
 Government College of Engineering, Kannur is one of the premier institutes among the 9 Government Engineering Colleges in Kerala and was established in 1986. The college is functioning in a sprawling 68-acre scenic campus, having sound and self-sufficient infrastructure, at Mangattuparamba, near the National Highway, 15 k.m from the headquarters of Kannur district.

The college is affiliated to Kerala Technological University. It offers 5 B.Tech Degree programs in Civil, Mechanical, Electrical and Electronics, Electronics and Communication and Computer Science and Engineering branches. The College also offers 4 M.Tech programs in Civil Engineering (Computer Aided Structural Engineering), Mechanical Engineering(Advanced Manufacturing and Mechanical Systems Design), Electrical and Electronics Engineering(Power Electronics and Drives),and Electronics and Communication Engineering (Signal Processing and Embedded Systems).