### PR TITLE
Add ig2i.centralelille.fr

### DIFF
--- a/lib/domains/fr/centralelille/ig2i.txt
+++ b/lib/domains/fr/centralelille/ig2i.txt
@@ -1,0 +1,1 @@
+Institut de génie informatique et industriel (Département de Centrale Lille)


### PR DESCRIPTION
The IG2I is now officially part of Centrale Lille. The students are encouraged to use the new address @ig2i.centralelille.fr, even if the old @ig2i.fr address is still working for now.

fr/ig2i.txt is already registered, same for fr/ec-lille.txt (which is the main engineer school from Centrale Lille).