### PR TITLE
Added Orel State Technical University domain

### DIFF
--- a/lib/domains/ru/ostu.txt
+++ b/lib/domains/ru/ostu.txt
@@ -1,0 +1,1 @@
+Orel State Technical University


### PR DESCRIPTION
Former name of current Orel State University.

Main site now -- [oreluniver.ru](http://oreluniver.ru)