### PR TITLE
Email domains for Scheppersinstituut Deurne & Antwerpen

### DIFF
--- a/lib/domains/be/scheppers.txt
+++ b/lib/domains/be/scheppers.txt
@@ -1,0 +1,3 @@
+Scheppersinstituut Deurne & Antwerpen
+Scheppersinstituut Antwerpen
+Scheppersinstituut Deurne

--- a/lib/domains/be/scheppersinstituut.txt
+++ b/lib/domains/be/scheppersinstituut.txt
@@ -1,0 +1,3 @@
+Scheppersinstituut Deurne & Antwerpen
+Scheppersinstituut Antwerpen
+Scheppersinstituut Deurne


### PR DESCRIPTION
Our school‘s website is found at http://www.scheppers.be/. Both scheppers.be and scheppersinstituut.be are used as email domains by the institution for students as well as teachers.

On the page: http://www.scheppers.be/studierichtingen.html#id-se-n-se you can find information about our post-secondary degree in Web development and Network Administration (Webontwikkeling en Netwerkbeheer). From next school year onwards I would like to use the Webstorm IDE with my students in our Web Development classes.

![image](https://cloud.githubusercontent.com/assets/220438/26284765/f29ddc60-3e42-11e7-930a-8becd8452d02.png)
