### PR TITLE
Add icmm.txt for the ICMM UB RAS

### DIFF
--- a/lib/domains/ru/icmm.txt
+++ b/lib/domains/ru/icmm.txt
@@ -1,0 +1,4 @@
+Institute of Continuous Media Mechanics of the Ural Branch of Russian Academy of Science
+ICMM UB RAS
+Федеральное государственное бюджетное учреждение науки Институт механики сплошных сред Уральского отделения Российской академии наук
+ИМСС УрО РАН


### PR DESCRIPTION
[Here](https://www.icmm.ru/images/files/education/postgraduate/pg_student/edu_process/01_02_05_class_schedule_2016-2017.pdf) is our schedule with courses, but it is only in .pdf file and in Russian.  The name of the IT course is "Параллельные вычислeния в механике сплошных сред" (Parallel computing in continuous media mechanics)

In fact, it is the only e-mail domain for all the Institute employees and PhD students. Anyway, I have attached an official document regarding e-mail accounts provisioning (but it is in Russian again).
[resource_access_provision.pdf](https://github.com/JetBrains/swot/files/1019154/resource_access_provision.pdf)
