### PR TITLE
Create Universidad Catolica de Oriente file

### DIFF
--- a/lib/domains/co/net/uco.txt
+++ b/lib/domains/co/net/uco.txt
@@ -1,0 +1,1 @@
+Universidad Católica de Oriente


### PR DESCRIPTION
This file is the domain to university email (..@uco.net.co), and university domain (web page) is uco.edu.co that is already created in folder lib/domains/co/edu/uco.txt. The university has that 2 domains.