### PR TITLE
Add North Broward Prepatory School

### DIFF
--- a/lib/domains/org/mynbps.txt
+++ b/lib/domains/org/mynbps.txt
@@ -1,0 +1,1 @@
+North Broward Prepatory School

--- a/lib/domains/org/nbps.txt
+++ b/lib/domains/org/nbps.txt
@@ -1,0 +1,1 @@
+North Broward Prepatory School


### PR DESCRIPTION
Adds [nbps](https://nbps.org) to the list.

[Course Catalog](http://www.nordangliaeducation.com/our-schools/florida/north-broward-preparatory-school/academics/our-curriculum/high-school/course-descriptions) -> [Academic Technology Courses](https://www.thinglink.com/scene/902996363493507073)

[WHOIS showing domain ownership](https://whois.icann.org/en/lookup?name=mynbps.org)
