### PR TITLE
Add Nova School of Business and Economics.

### DIFF
--- a/lib/domains/pt/novasbe.txt
+++ b/lib/domains/pt/novasbe.txt
@@ -1,0 +1,1 @@
+Nova School of Business and Economics


### PR DESCRIPTION
NovaSBE is part of Universidade Nova de Lisboa
www.novasbe.unl.pt/