### PR TITLE
Submit school domain for Nanyang Polytechnic

### DIFF
--- a/lib/domains/sg/edu/nyp.txt
+++ b/lib/domains/sg/edu/nyp.txt
@@ -1,0 +1,1 @@
+Nanyang Polytechnic


### PR DESCRIPTION
Official university website
- [Nanyang Polytechnic official website](http://www.nyp.edu.sg)

3-year IT related program
- [Diploma in Information Technology](http://www.nyp.edu.sg/schools/sit/full-time-courses/information-technology.html)

Proof of use of domain name (@nyp.edu.sg)
- [Official email address listed on their contact page](http://www.nyp.edu.sg/be-part-of-nyp/contact-us.html)
- Official email address for general enquiries - askNYP@nyp.edu.sg
- [Student handbook (PDF)](http://www.nyp.edu.sg/content/dam/nyp/current-students/academic-matters/student-handbook/student-handbook.pdf)