### PR TITLE
Added Poole High School's email Domains.

### DIFF
--- a/lib/domains/uk/co/poolehigh.txt
+++ b/lib/domains/uk/co/poolehigh.txt
@@ -1,0 +1,1 @@
+Poole High School

--- a/lib/domains/uk/sch/poole/poolehigh.txt
+++ b/lib/domains/uk/sch/poole/poolehigh.txt
@@ -1,0 +1,1 @@
+Poole High School


### PR DESCRIPTION
The current official website is: [https://poolehigh.co.uk](https://poolehigh.co.uk) ([poolehigh.poole.sch.uk](http://poolehigh.poole.sch.uk) redirects there)

The proof that IT related courses are offered:
[https://poolehigh.co.uk/sixth-form/courses/computer-science/](https://poolehigh.co.uk/sixth-form/courses/computer-science/) (A level Computer Science Course)
[http://poolehigh.co.uk/wp-content/uploads/2016/10/Sixth-Form-Prospectus.pdf](http://poolehigh.co.uk/wp-content/uploads/2016/10/Sixth-Form-Prospectus.pdf) Page 6 (Shows that this is a 2 Year Course)

The proof that students are given and use poolehigh.co.uk domain emails:
[https://poolehigh.co.uk/wp-content/uploads/2016/11/E-Learning-Summary-for-Year-11.pdf](https://poolehigh.co.uk/wp-content/uploads/2016/11/E-Learning-Summary-for-Year-11.pdf) Page 3

Staff are given both poolehigh.co.uk emails (through gmail), and poolehigh.poole.sch.uk emails (through an exchange server), though I cannot prove this as it is not public that staff use poolehigh.co.uk emails, and only some staff poolehigh.poole.sch.uk emails are public as well (as seen on [https://poolehigh.co.uk/get-in-touch/](https://poolehigh.co.uk/get-in-touch/) under Departments)

PS: Their website is a bit slow on some devices, and can be awful to navigate.