### PR TITLE
Create edubs.ch

### DIFF
--- a/lib/domains/ch/edubs.txt
+++ b/lib/domains/ch/edubs.txt
@@ -1,0 +1,1 @@
+Basler Bildungsserver


### PR DESCRIPTION
This domain is used by all schools in basel.
Per example my school: [https://www.gbbasel.ch/](https://www.gbbasel.ch/)
On [this](https://www.edubs.ch/schullaufbahn/gymnasium) site there is a link to [all academic high schools](http://www.mb.bs.ch/schulen/gymnasien/fuenf-gymnasien.html) in basel which use edubs.ch for there main email domain