### PR TITLE
Please add University Hospital Basel

### DIFF
--- a/lib/domains/ch/usb.txt
+++ b/lib/domains/ch/usb.txt
@@ -1,0 +1,1 @@
+Universitätsspital Basel


### PR DESCRIPTION
The University Hospital Basel works in association with the University of Basel (unibas.txt). The medical teaching and research is done at the University Hospital Basel. 

Main Website 
http://www.usb.ch (will be forwarded to http://www.unispital-basel.ch)

Teaching and Research
https://www.unispital-basel.ch/en/lehre-forschung/

Whois entry
https://www.nic.ch/whois/?domain=usb.ch&language=en&tld=ch

E-Mail Domain is: usb.ch

Thanks,
Joshy