### PR TITLE
Education Lucerne

### DIFF
--- a/lib/domains/ch/edulu.txt
+++ b/lib/domains/ch/edulu.txt
@@ -1,0 +1,1 @@
+Berufsbildungszentrum Wirtschaft, Informatik und Technik (Kanton Luzern)


### PR DESCRIPTION
Edulu stands for Education Lucerne and includes the "Berufsbildungszentrum Wirtschaft, Informatik und Technik" *.
All the "Berufsbildungszentrum" of the canton of Lucerne share the same domain (edulu.ch / beruf.lu.ch).

There are only @edulu.ch email addresses, there is no real website for that domain. The Website itself is:
https://beruf.lu.ch/berufsbildungszentren/bbzw

As you can see on the teachers contact page
https://beruf.lu.ch/berufsbildungszentren/bbzw/Kontakt/Kontakt_Sursee/Lehrpersonen_Sursee
All the teachers have an @edulu.ch email address.

\* In Switzerland we have the dual education system on which students attend lessons at "Berufsschulen"/"Berufsbildungszentren" such as the "Berufsbildungszentrum Wirtschaft, Informatik und Technik" (https://en.wikipedia.org/wiki/Dual_education_system#School_section)