### PR TITLE
Ubbo Emmius Scholengemeenschap Addition

### DIFF
--- a/lib/domains/net/ubboemmius.txt
+++ b/lib/domains/net/ubboemmius.txt
@@ -1,0 +1,1 @@
+Ubbo Emmius Scholengemeenschap, The Netherlands, Students Email Domain

--- a/lib/domains/nl/ubboemmius
+++ b/lib/domains/nl/ubboemmius
@@ -1,0 +1,1 @@
+Ubbo Emmius Scholengemeenschap, The Netherlands


### PR DESCRIPTION
ubboemmius.nl = The domain mainly used for the school's website and teachers.
ubboemmius.net = The domain used by the school's students

I would like this school to be added.

