### PR TITLE
Added Domain for Berufsförderungswerk Oberhausen

### DIFF
--- a/lib/domains/de/bfw-oberhausen.txt
+++ b/lib/domains/de/bfw-oberhausen.txt
@@ -1,0 +1,1 @@
+Berufsförderungswerk Oberhausen, Primary Domain

--- a/lib/domains/de/bfwob.txt
+++ b/lib/domains/de/bfwob.txt
@@ -1,0 +1,1 @@
+Berufsförderungswerk Oberhausen


### PR DESCRIPTION
Berufsförderungswerk Oberhausen. 
Apprenticeship for Software Developers, Sysadmins and Telecommunications-Electricians.
Primary domain for information and verification is http://www.bfw-oberhausen.de/
Provided Domain file is primarily used for student email addresses.