### PR TITLE
add csiriicb.txt

### DIFF
--- a/lib/domains/in/csiriicb.txt
+++ b/lib/domains/in/csiriicb.txt
@@ -1,0 +1,1 @@
+CSIR-Indian Institute of chemical Biology


### PR DESCRIPTION
Institute Name: CSIR-Indian Institute of Chemical Biology
Institute Website: http://www.iicb.res.in/
Domain: csiriicb.in 

