### PR TITLE
Add new school "Gymnasium Nepomucenum Rietberg"

### DIFF
--- a/lib/domains/de/wwschool/gnr.txt
+++ b/lib/domains/de/wwschool/gnr.txt
@@ -1,0 +1,1 @@
+Gymnasium Nepomucenum Rietberg


### PR DESCRIPTION
The domain does not match the home page of the school as we are using a different system/domain for student email addresses. Please contact the administration "Frau Milsch" or "Frau Oesterschling" (see http://www.nepomucenum-rietberg.de/kontakt/) to verify the domain gnr.wwschool.de as student email domain. Thanks in advance.