### PR TITLE
Create bubblers.txt

### DIFF
--- a/lib/domains/us/pa/k12/bubblers.txt
+++ b/lib/domains/us/pa/k12/bubblers.txt
@@ -1,0 +1,1 @@
+South Middleton School District


### PR DESCRIPTION
School URL: http://smsd.us/

IT course: http://www.smsd.us/webpages/dmancuso/

Student emails use the bubblers.us domain, not the smsd.us domain. Proof of this is in the whois lookup for bubblers.us:
https://www.whois.com/whois/bubblers.us