### PR TITLE
Added Université des Antilles

### DIFF
--- a/lib/domains/fr/univ-antilles/etu.txt
+++ b/lib/domains/fr/univ-antilles/etu.txt
@@ -1,0 +1,1 @@
+Université des Antilles


### PR DESCRIPTION
Homepage : http://univ-antilles.fr/
(http://univ-ag.fr/ will should be soon obsolete)