### PR TITLE
🐻 Add UCSF Global Programs domain.

### DIFF
--- a/lib/domains/org/ucglobalprograms.txt
+++ b/lib/domains/org/ucglobalprograms.txt
@@ -1,0 +1,1 @@
+University of California, San Francisco


### PR DESCRIPTION
This is the domain used by UCSF for their Global Health programs. See the [WHOIS](https://whois.icann.org/en/lookup?name=ucglobalprograms.org):

![screen shot 2017-07-18 at 4 34 42 pm](https://user-images.githubusercontent.com/668093/28346721-ae086192-6be7-11e7-99cc-1b5d4b836f3b.png)
