### PR TITLE
Update and rename qafqaz.txt to qu.txt

### DIFF
--- a/lib/domains/az/edu/qafqaz.txt
+++ b/lib/domains/az/edu/qafqaz.txt
@@ -1,1 +1,0 @@
-Qafqaz University

--- a/lib/domains/az/edu/qu.txt
+++ b/lib/domains/az/edu/qu.txt
@@ -1,0 +1,1 @@
+Baku Engineering University


### PR DESCRIPTION
Qafqaz University has been closed in 2016. All the staff and students have been moved to newly established "Baku Engineering University". But "qu.edu.az" domain is still in use by BEU.