### PR TITLE
Adding @mu.ie for Maynooth University.

### DIFF
--- a/lib/domains/ie/mu.txt
+++ b/lib/domains/ie/mu.txt
@@ -1,0 +1,1 @@
+Maynooth University


### PR DESCRIPTION
Adding @mu.ie for [Maynooth University](http://maynoothuniversity.ie).


See [here for details](https://www.maynoothuniversity.ie/it-services/muie-email-change).