### PR TITLE
Add IMT LILLE DOUAI to FR domains

### DIFF
--- a/lib/domains/fr/imt-lille-douai.txt
+++ b/lib/domains/fr/imt-lille-douai.txt
@@ -1,0 +1,1 @@
+Ecole nationale superieure Mines-Telecom Lille-Douai


### PR DESCRIPTION
Add École nationale supérieure Mines-Télécom Lille-Douai (imt-lille-douai.txt)

Website : http://imt-lille-douai.fr/
Informations about courses : http://en.calameo.com/read/005222720e147288eaa83