### PR TITLE
City College Email Change

### DIFF
--- a/lib/domains/eu/sheffield/citycollege.txt
+++ b/lib/domains/eu/sheffield/citycollege.txt
@@ -1,0 +1,1 @@
+The University of Sheffield International Faculty, CITY College

--- a/lib/domains/gr/academic/city.txt
+++ b/lib/domains/gr/academic/city.txt
@@ -1,1 +1,0 @@
-The University of Sheffield International Faculty, CITY College


### PR DESCRIPTION
The University of Sheffield International Faculty, CITY College changed their Email.

Old Email: @city.academic.gr
New Email: @citycollege.sheffield.eu

Proof: [PDF](https://www.dropbox.com/s/6aaxbvbrfyrhlry/The%20University%20of%20Sheffield%2C%20International%20Faculty%20Mail%20-%20%5BComputer%20Support%5D_%20New%20CITY%20Email%20Addresses.pdf?dl=0)