### PR TITLE
Added Manjara Charitable Trust's RGIT and VJTI

### DIFF
--- a/lib/domains/in/ac/mctrgit.txt
+++ b/lib/domains/in/ac/mctrgit.txt
@@ -1,0 +1,3 @@
+Manjara Charitable Trust's Rajiv Gandhi Institute of Technology, Mumbai
+aka Rajiv Gandhi Institute of Technology, Mumbai
+aka RGIT

--- a/lib/domains/in/ac/vjti.txt
+++ b/lib/domains/in/ac/vjti.txt
@@ -1,0 +1,2 @@
+Veermata Jijabai Technological Institute, Mumbai
+aka VJTI


### PR DESCRIPTION
Added Manjara Charitable Trust's Rajiv Gandhi Institute of Technology aka Rajiv Gandhi Institute of Technology aka RGIT and Veermata Jijabai Technological Institute which is a college in city of Mumbai in India.