### PR TITLE
Added grb-online.net

### DIFF
--- a/lib/domains/net/grb-online.txt
+++ b/lib/domains/net/grb-online.txt
@@ -1,0 +1,1 @@
+Gymnasium Riedberg


### PR DESCRIPTION
The official homepage of the Gymnasium Riedberg is gymnasium-riedberg.com. The mailing domain used is `grb-online.net`. http://gymnasium-riedberg.de/de/service/downloads/send/3-/2-riedbergonline shows the relation between the two domains. This school also offers informatics as an advanced or basic lesson after the 10th Grade.