### PR TITLE
Rename Amikom

### DIFF
--- a/lib/domains/id/ac/amikom.txt
+++ b/lib/domains/id/ac/amikom.txt
@@ -1,1 +1,1 @@
-STMIK AMIKOM Yogyakarta
+Universitas AMIKOM Yogyakarta


### PR DESCRIPTION
STMIK Amikom Yogyakarta has been renamed to Univesitas Amikom Yogyakarta, see the official website at amikom.ac.id