### PR TITLE
UNISA: Add "student_num@mylife.unisa.ac.za" mail

### DIFF
--- a/lib/domains/za/ac/unisa/mylife.txt
+++ b/lib/domains/za/ac/unisa/mylife.txt
@@ -1,0 +1,1 @@
+University of South Africa


### PR DESCRIPTION
University of South Africa: Added student_num@mylife.unisa.ac.za

I noted the comment: **We intentionally exclude alumni domains (like john.smith@alumni.stanford.edu) as well.**

For UNISA, the **mylife** subdomain is important as we use a hosted Microsoft Office email plan. 
