### PR TITLE
Added a domain for "Berufsbildungszentrum Wirtschaft, Informatik und Technik"

### DIFF
--- a/lib/domains/ch/sluz.txt
+++ b/lib/domains/ch/sluz.txt
@@ -1,0 +1,1 @@
+Berufsbildungszentrum Wirtschaft, Informatik und Technik (Kanton Luzern)


### PR DESCRIPTION
The offical website is "https://beruf.lu.ch/berufsbildungszentren/bbzw" (it's in german).