### PR TITLE
Added Tradium

### DIFF
--- a/lib/domains/dk/tradium/elev.txt
+++ b/lib/domains/dk/tradium/elev.txt
@@ -1,0 +1,1 @@
+Tradium (Students)


### PR DESCRIPTION
Added Tradium, a large school in Randers, Denmark