### PR TITLE
Added Germantown Muncipal School District

### DIFF
--- a/lib/domains/org/gmsdk12.txt
+++ b/lib/domains/org/gmsdk12.txt
@@ -1,0 +1,1 @@
+Germantown Municipal School District

--- a/lib/domains/org/gmsdk12/students.txt
+++ b/lib/domains/org/gmsdk12/students.txt
@@ -1,1 +1,2 @@
 Germantown Municipal School District
+.group


### PR DESCRIPTION
District Website: [gmsdk12.org](http://gmsdk12.org)
2017 - 2018 Houston High School Course Catalog: [HHS Course Catalog 2017-18.pdf](http://filecabinet5.eschoolview.com/F2ED651E-240C-4D18-AFC6-5F29034FE4C8/HHS%20Course%20Catalog%202017-18.pdf)
"AP Computer Science Principals", "AP Computer Science A", "Coding I", "Coding II Honors", "Programming & Software Development Dual Enrollment", and "Mobile App Development" are all on pages 11 and 12
I hope that this counts as official proof that students.gmsdk12.org is the students' email domain for GMSD: [Logging into Office365.pdf](http://www.gmsdk12.org/Downloads/Logging%20into%20Office365.pdf)