### PR TITLE
Add FernFH

### DIFF
--- a/lib/domains/at/ac/fernfh.txt
+++ b/lib/domains/at/ac/fernfh.txt
@@ -1,0 +1,1 @@
+Ferdinand Porsche FernFH


### PR DESCRIPTION
URL for IT-related long-term courses (3 Years: Bachelor/2 Years: Master): http://fernfh.ac.at/studienrichtungen/wirtschaftsinformatik/