### PR TITLE
Add promsocatc.net - Collège Technique "Aumôniers du Travail"

### DIFF
--- a/lib/domains/net/promsocatc.txt
+++ b/lib/domains/net/promsocatc.txt
@@ -1,0 +1,1 @@
+Collège Technique "Aumôniers du Travail"


### PR DESCRIPTION
Official website:
http://www.promsocatc.com

Bachelor in IT program:
http://www.promsocatc.com/formation/bachelier-en-informatique-de-gestion/

The public website is in .com, but students/teachers mails are in .net
See http://www.promsocatc.com/plateforme/Plateforme_promsocatc.pdf p. 2
(point 1.3)