### PR TITLE
Add S6F teacher and student domains

### DIFF
--- a/lib/domains/uk/org/s6f.txt
+++ b/lib/domains/uk/org/s6f.txt
@@ -1,0 +1,1 @@
+Scarborough Sixth Form College

--- a/lib/domains/uk/org/s6f/student.txt
+++ b/lib/domains/uk/org/s6f/student.txt
@@ -1,0 +1,1 @@
+Scarborough Sixth Form College


### PR DESCRIPTION
Add Scarborough Sixth Form College domain and student subdomain.

Official Domain : s6f.org.uk
Relevant Courses : Computer Science (https://s6f.org.uk/course/computing/) , Information Technology (https://s6f.org.uk/course/information-technology/)
NUS Page : https://www.nus.org.uk/en/students-unions/scarborough-vi-form-college-students-council/