### PR TITLE
Add Moscow College of Architecture and Urban Planning

### DIFF
--- a/lib/domains/ru/mcag.txt
+++ b/lib/domains/ru/mcag.txt
@@ -1,0 +1,1 @@
+Moscow College of Architecture and Urban Planning


### PR DESCRIPTION
Please add Moscow College of Architecture and Urban Planning
Official Website: http://mcag.mskobr.ru/
Mail Domain (mcag.ru) is provided via 3rd-party server.

State standard for specialty: Applied Informatics (qualification technician-programmer, duration of training 3 years 10 months)
http://mcag.mskobr.ru/files/230701_prikladnaya_informatika.pdf
![mail_off2](https://user-images.githubusercontent.com/32012192/30511527-8a66c604-9ae3-11e7-89a1-25aec85c025e.PNG)

