### PR TITLE
Adding Philipp-Matthäus-Hahn-Schule

### DIFF
--- a/lib/domains/de/gsz-bl.txt
+++ b/lib/domains/de/gsz-bl.txt
@@ -1,0 +1,1 @@
+Philipp-Matthäus-Hahn-Schule – Gewerbliches Schulzentrum Balingen

--- a/lib/domains/de/gsz-zak.txt
+++ b/lib/domains/de/gsz-zak.txt
@@ -1,0 +1,1 @@
+Philipp-Matthäus-Hahn-Schule – Gewerbliches Schulzentrum Balingen


### PR DESCRIPTION
This PR adds the Philipp-Matthäus-Hahn-Schule – Gewerbliches Schulzentrum Balingen. It's a secondary school ("Gymnasium" in German) and a professional school ("Berufsschule" in German). Several subjects having something todo with information technology, electronics, crafting and personal hygiene are taught there.

There are two domains used for e-mailing: *@gsz-zak.de for students and *@gsz-bl.de for teachers. They're both redirecting to the homepage of the school, [gsz-zak.de](http://gsz-zak.de).