### PR TITLE
Add cegepst.qc.ca domain

### DIFF
--- a/lib/domains/ca/qc/cegepst.txt
+++ b/lib/domains/ca/qc/cegepst.txt
@@ -1,0 +1,1 @@
+Cégep de Sorel-Tracy


### PR DESCRIPTION
Cégep de Sorel-Tracy
http://www.cegepst.qc.ca/