### PR TITLE
Add Qingyuan Polytechnic

### DIFF
--- a/lib/domains/cn/com/qypt.txt
+++ b/lib/domains/cn/com/qypt.txt
@@ -1,0 +1,1 @@
+Qingyuan Polytechnic


### PR DESCRIPTION
add domain for Qingyuan Polytechnic in Guangdong Province, China.