### PR TITLE
Add rcs-k12.us, rochester.k12.mi.us

### DIFF
--- a/lib/domains/us/mi/k12/rochester.txt
+++ b/lib/domains/us/mi/k12/rochester.txt
@@ -1,0 +1,2 @@
+Rochester Community School District
+Rochester Community Schools

--- a/lib/domains/us/rcs-k12.txt
+++ b/lib/domains/us/rcs-k12.txt
@@ -1,0 +1,2 @@
+Rochester Community School District
+Rochester Community Schools


### PR DESCRIPTION
URL: http://www.rochester.k12.mi.us
`@rochester.k12.mi.us` is for teachers
`@rcs-k12.us` is for students and teachers (all teachers have a `@rochester.k12.mi.us` and `@rcs-k12.us` email)
Course descriptions for computer science class: http://www.rochester.k12.mi.us/pages/129583/computer-science
Proof that `@rcs-k12.us` is a valid email address for the district: http://www.rochester.k12.mi.us/rochester-high-school/announcements/45705/rcs-student-google-account
http://www.rochester.k12.mi.us/stoney-creek-high-school/pages/9786/mr-bliss
http://www.rochester.k12.mi.us/rochester-high-school/pages/133778/ms-smith