### PR TITLE
Adding ensta-paristech

### DIFF
--- a/lib/domains/fr/ensta-paristech.txt
+++ b/lib/domains/fr/ensta-paristech.txt
@@ -1,0 +1,1 @@
+ENSTA ParisTech


### PR DESCRIPTION
```
host ensta-paristech.fr
ensta-paristech.fr has address 147.250.10.70
ensta-paristech.fr mail is handled by 20 ns4.ensta.fr.
ensta-paristech.fr mail is handled by 20 ns3.ensta.fr.
```