### PR TITLE
Add Domain of Humboldt-Gymnasium Gifhorn

### DIFF
--- a/lib/domains/de/hg-gf.txt
+++ b/lib/domains/de/hg-gf.txt
@@ -1,0 +1,1 @@
+Humboldt-Gymnasium Gifhorn


### PR DESCRIPTION
Gymnasium(Highschool) in Germany

Public domain: [Website](http://humboldtgymnasium.de) 


Information regarding CS courses: [link](http://www.humboldtgymnasium.de/CM/index.php?option=com_content&view=category&layout=blog&id=52&Itemid=77)
Its outdated for whatever reason but they still offer the courses.

Proof that the domain belongs to the school and offers student email: [link](http://www.humboldtgymnasium.de/CM/index.php?option=com_content&view=article&id=1459:anmeldung-an-der-weboberflaeche-iserv-der-schule&catid=140:elterninfo&Itemid=96)