### PR TITLE
Njala University Sierra Leone

### DIFF
--- a/lib/domains/edu/njala
+++ b/lib/domains/edu/njala
@@ -1,0 +1,1 @@
+Njala Universitty Sierra Leone


### PR DESCRIPTION
Njala University is a public university located in Bo and in Njala, Moyamba District, Sierra Leone. It is the second largest university in Sierra Leone and is also part of the University of Sierra Leone.