### PR TITLE
Coleg Cambria

### DIFF
--- a/lib/domains/uk/ac/cambria.txt
+++ b/lib/domains/uk/ac/cambria.txt
@@ -1,0 +1,1 @@
++ Coleg Cambria


### PR DESCRIPTION
https://www.cambria.ac.uk/

Email Addresses of Students are in form of [ID Number]@cambria.ac.uk

This college offers Computing Science at BTEC, A-Level, and GCSE with School Links (School Links students are given a Cambria email address).

https://www.cambria.ac.uk/courses/course-detail/?subject=1&course_id=258