### PR TITLE
Added VOvA student domain

### DIFF
--- a/lib/domains/nl/vova/leerling.txt
+++ b/lib/domains/nl/vova/leerling.txt
@@ -1,0 +1,1 @@
+Voortgezet Onderwijs van Amsterdam


### PR DESCRIPTION
Added leerling.vova.nl the email domain for the students of VOvA. Voortgezet Onderwijs van Amsterdam http://vova.nl/ and http://hyperionlyceum.nl