### PR TITLE
Added Scholengroep Carmel Hengelo

### DIFF
--- a/lib/domains/nl/mijncarmelhengelo.txt
+++ b/lib/domains/nl/mijncarmelhengelo.txt
@@ -1,0 +1,1 @@
+Scholengroep Carmel Hengelo


### PR DESCRIPTION
"mijncarmelhengelo.nl" is the domain for school-related Microsoft-accounts (e-mail included) assigned to pupils of Scholengroep Carmel Hengelo