### PR TITLE
add toba-kosen

### DIFF
--- a/lib/domains/jp/kosen-ac/toba.txt
+++ b/lib/domains/jp/kosen-ac/toba.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Toba College


### PR DESCRIPTION
I can prove my domain.
Our college is also called Toba Kosen.This collage is affiliated with the National Institude of Technology.
So, Whois Infomation is the same of Toba Collage.

Here is our collage's official web site.
http://www.toba-cmt.ac.jp/

And I’m sorry, I can’t show you any reference page saying we use the domain. There’s no page about that anywhere.

In addition, I show you WHOIS information about toba.kosen-ac.jp.(from http://whois.jp/) 

-------------------------------------------
Domain Information: [ドメイン情報]
[Domain Name]                   KOSEN-AC.JP

[登録者名]                      独立行政法人　国立高等専門学校機構
[Registrant]                    National Institute of Technology, Japan

[Name Server]                   ns1.dns.ne.jp
[Name Server]                   ns2.dns.ne.jp
[Signing Key]                   

[登録年月日]                    2015/02/23
[有効期限]                      2018/02/28
[状態]                          Active
[最終更新]                      2017/06/02 15:19:54 (JST)

Contact Information: [公開連絡窓口]
[名前]                          独立行政法人　国立高等専門学校機構
[Name]                          National Institute of Technology, Japan
[Email]                         joho@kosen-k.go.jp
[Web Page]                       
[郵便番号]                      193-0834
[住所]                          東京都八王子市
                                東浅川町701-2
[Postal Address]                Tokyo
                                Hachioji-shi
                                701-2 Higashiasakawa-machi
[電話番号]                      042-662-3164
[FAX番号]                       
_______

The attached picture was distributed to students.This is explaining how to use mail address of toba.kosen-ac.jp in office365.
![kosen](https://user-images.githubusercontent.com/26608037/32878956-75e642c6-caeb-11e7-88d8-78a63deceac6.jpg)
