### PR TITLE
Added IV Liceum Ogólnokształcące im. Tadeusza Kościuszki w Toruniu

### DIFF
--- a/lib/domains/pl/torun/loiv.txt
+++ b/lib/domains/pl/torun/loiv.txt
@@ -1,0 +1,2 @@
+IV Liceum Ogólnokształcące im. Tadeusza Kościuszki w Toruniu
+General Tadeusz Kosciuszko High School #4 in Torun


### PR DESCRIPTION
a.k.a. General Tadeusz Kosciuszko High School #4 in Torun

https://pl.wikipedia.org/wiki/IV_Liceum_Og%C3%B3lnokszta%C5%82c%C4%85ce_im._Tadeusza_Ko%C5%9Bciuszki_w_Toruniu

A well recognized Polish high school with strong ties to the Nicolaus Copernicus University in Torun.