### PR TITLE
Add XIV LO in Warsaw

### DIFF
--- a/lib/domains/pl/waw/staszic.txt
+++ b/lib/domains/pl/waw/staszic.txt
@@ -1,0 +1,2 @@
+XIV Liceum Ogólnokształcące im. Stanisława Staszica w Warszawie
+Stanisław Staszic 14th High School in Warsaw


### PR DESCRIPTION
Official school homepage: https://staszic.waw.pl/
Wikipedia page: https://pl.wikipedia.org/wiki/XIV_Liceum_Og%C3%B3lnokszta%C5%82c%C4%85ce_im._Stanis%C5%82awa_Staszica_w_Warszawie

Some pupils acquired student license by submitting their ID, but I think it would be easier for them, simply by providing official school email.