### PR TITLE
Fachhochschule -> Hochschule Neubrandenburg

### DIFF
--- a/lib/domains/de/fh-nb.txt
+++ b/lib/domains/de/fh-nb.txt
@@ -1,1 +1,0 @@
-Fachhochschule Neubrandenburg

--- a/lib/domains/de/hs-nb.txt
+++ b/lib/domains/de/hs-nb.txt
@@ -1,0 +1,1 @@
+Hochschule Neubrandenburg


### PR DESCRIPTION
The Fachhochschule Neubrandenburg renamed itself to Hochschule Neubrandenburg.
The domain also changed from fh-nb.de to hs-nb.de accordingly.

[Base URL](https://www.hs-nb.de/en/)
[Course Information Geoinformatics](https://www.hs-nb.de/en/courses-of-study/undergraduate-courses/geoinformatics-beng/) Bachelor of Engineering, seven semesters.