### PR TITLE
Added SERŠ Maribor

### DIFF
--- a/lib/domains/si/sers.txt
+++ b/lib/domains/si/sers.txt
@@ -1,0 +1,1 @@
+Srednja elektro-računalniška šola Maribor


### PR DESCRIPTION
Roughly translates to "High school for electrical engineering and computer science" (Maribor, Slovenia).

Website: http://www.sers.si

Only students and faculty have emails `@sers.si`.