### PR TITLE
Add os3 as education

### DIFF
--- a/lib/domains/nl/os3.txt
+++ b/lib/domains/nl/os3.txt
@@ -1,0 +1,2 @@
+University of Amsterdam 
+- Security and Network engineering


### PR DESCRIPTION
Official URL: https://www.uva.nl/
Official URL about the course: http://gss.uva.nl/content/masters/security-and-network-engineering/security-and-network-engineering.html
On that page it also shows that os3 is its branding name. You can find more information on the https://www.os3.nl/ website.
