### PR TITLE
Update Bangor to modern name

### DIFF
--- a/lib/domains/uk/ac/bangor.txt
+++ b/lib/domains/uk/ac/bangor.txt
@@ -1,1 +1,1 @@
-University of Wales, Bangor
+Prifysgol Bangor University


### PR DESCRIPTION
Bangor University left the University of Wales 10 years ago