### PR TITLE
Add Grŵp Llandrillo Menai

### DIFF
--- a/lib/domains/uk/ac/gllm.txt
+++ b/lib/domains/uk/ac/gllm.txt
@@ -1,0 +1,1 @@
+﻿Grŵp Llandrillo Menai


### PR DESCRIPTION
The college has quite a few physical locations across North Wales

Link to a page on their website showing one of the degrees in computing that they offer - https://www.gllm.ac.uk/courses/bsc-(hons)-computing-(software-development)/

Link to a policy which states that all students are given an email address in the form of studentnumber@gllm.ac.uk. All staff are also given email addresses directly under this domain - https://www.gllm.ac.uk/policies/learner/4294967426.pdf

Hopefully that should be enough to get it included, but if it isn't let me know and I'll do what I can to help
