### PR TITLE
Added ITIS PININFARINA

### DIFF
--- a/lib/domains/it/itispininfarina.txt
+++ b/lib/domains/it/itispininfarina.txt
@@ -1,0 +1,1 @@
+ITIS Pininfarina, Moncalieri (TO)


### PR DESCRIPTION
Added itispininfarina.it to domains
Official GOV Domain: itispininfarina.gov.it
Official IT Domain: www.itispininfarina.it
(www.itispininfarina.it redirects to www.itispininfarina.gov.it)