### PR TITLE
Add schools in Gävle

### DIFF
--- a/lib/domains/se/gavle/edu.txt
+++ b/lib/domains/se/gavle/edu.txt
@@ -1,0 +1,3 @@
+Borgarskolan
+Polhemsskolan
+Vasaskolan


### PR DESCRIPTION
This adds the three main "Gymnasium" (high school/secondary school) in Gävle.'

[This page has links to all three](http://www.gavle.se/Utbildning--barnomsorg/Gymnasieskola/Lista-over-gymnasieskolor-i-Gavle/)

Links directly to the schools:
[Borgarskolan](http://borgarskolan.gavle.se/)
[Polhemsskolan](http://polhem.gavle.se/)
[Vasaskolan](http://vasa.gavle.se/)