### PR TITLE
Adding North London Collegiate School

### DIFF
--- a/lib/domains/uk/org/nlcs.txt
+++ b/lib/domains/uk/org/nlcs.txt
@@ -1,0 +1,1 @@
+North London Collegiate School


### PR DESCRIPTION
North London Collegiate School is a prestigious girls' day school covering school and further education curriculum in London, UK. The website for the school is http://www.nlcs.org.uk . The email domain is the same.