### PR TITLE
Add Changchun University

### DIFF
--- a/lib/domains/cn/edu/ccu.txt
+++ b/lib/domains/cn/edu/ccu.txt
@@ -1,0 +1,1 @@
+Changchun University

--- a/lib/domains/cn/edu/ccu/mails.txt
+++ b/lib/domains/cn/edu/ccu/mails.txt
@@ -1,0 +1,1 @@
+Changchun University


### PR DESCRIPTION
Institution: Changchun University
Location: Changchun, Jilin, China
Official website: http://www.ccu.edu.cn/
Staff Mail Domain: ccu.edu.cn
Student Mail Domain: mails.ccu.edu.cn

Changchun University (Chinese: 长春大学) is a multi-disciplinary university in Changchun, Jilin. It includes three campuses all together covering 1,129,000 squaremeters. Established in 1946, Changchun University has trained more than 40,000 undergraduate students.