### PR TITLE
Create bc-enschede.nl

### DIFF
--- a/lib/domains/nl/bc-enschede.nl
+++ b/lib/domains/nl/bc-enschede.nl
@@ -1,0 +1,1 @@
+Bonhoeffer College Enschede


### PR DESCRIPTION
bc-enschede.nl is the domain of Bonhoeffer College Enschede, email addresses are at live.bc-enschede.nl, but I thought that the engine is okay with subdomains.