### PR TITLE
Westport, CT public schools domain change

### DIFF
--- a/lib/domains/org/westportps.txt
+++ b/lib/domains/org/westportps.txt
@@ -1,0 +1,1 @@
+Westport, CT Public Schools

--- a/lib/domains/us/ct/k12/westport.txt
+++ b/lib/domains/us/ct/k12/westport.txt
@@ -1,1 +1,0 @@
-Westport Public Schools


### PR DESCRIPTION
Westport, CT public schools - including Staples High School, has changed domains. Previously student emails were address to <student>@students.westport.k12.ct.us. This has been changed to <student>@students.westportps.org.  Staff will now use the @westportps.org domain as well.

Notice of this change can be found here: 
[Notice](http://support.westport.k12.ct.us/announcements/publicdomainnamechangefaq)

The Westport Public Schools website (with new domain) can be viewed [here](https://www.westportps.org/)

I am submitting this request as I have a child who attends Staples High School and he is a user of JetBrains student products.

Thank you!
