### PR TITLE
Added Vega School

### DIFF
--- a/lib/domains/za/co/vegaconnect.txt
+++ b/lib/domains/za/co/vegaconnect.txt
@@ -1,0 +1,1 @@
+Vega School


### PR DESCRIPTION
Adding in of Vega school, and it's domain name, vegaconnect under co.za from South Africa.