### PR TITLE
Kyrgyz National University named after Jusup Balasagyn

### DIFF
--- a/lib/domains/kg/knu.txt
+++ b/lib/domains/kg/knu.txt
@@ -1,0 +1,1 @@
+Jusup Balasagyn Kyrgyz National University

--- a/lib/domains/kg/university.txt
+++ b/lib/domains/kg/university.txt
@@ -1,0 +1,1 @@
+Jusup Balasagyn Kyrgyz National University


### PR DESCRIPTION
1. Official university website: https://www.knu.kg/ru/
2. Bachelor and Master's programmes in IT:
https://www.fiit.knu.kg/index.php?option=com_content&view=category&id=46&Itemid=512&lang=ru
3. Proof that university.kg domain belongs to knu.kg:
https://www.knu.kg/ru/index.php?option=com_content&view=article&id=935&Itemid=577