### PR TITLE
Create ssnd.txt

### DIFF
--- a/lib/domains/sk/ssnd.txt
+++ b/lib/domains/sk/ssnd.txt
@@ -1,0 +1,1 @@
+Spojená škola sv. Jána Bosca v Novej Dubnici


### PR DESCRIPTION
Spojená škola sv. Jána Bosca v Novej Dubnici
- main web: www.ssnd.sk - redirected to common https://ssnd.edupage.sk
- edupage.sk is common information system used by most schools in Slovakia
- there is also old web before edupage.sk: http://old.ssnd.sk
- it has 4 departments: msnd, zsnd, gymnd and sosnd
- the last one is new IT related Technical Lyceum: https://sosnd.edupage.sk (will use tl.ssnd.sk soon)
- edupage.sk is common for all schools, but it is NOT used by e-mails
- students are using @student.ssnd.sk, teachers @ssnd.sk
- MX are on G Suite for Education
- I hope this is good proof: https://whois.sk-nic.sk/?query=ssnd.sk
- you may contact me on admin at ssnd.sk