### PR TITLE
Add The British School in The Netherlands

### DIFF
--- a/lib/domains/nl/bsnstudent.txt
+++ b/lib/domains/nl/bsnstudent.txt
@@ -1,0 +1,1 @@
+The British School in The Netherlands


### PR DESCRIPTION
Add The British School in The Netherlands as a valid educational
institute since they have a computer science course.

Their website can be seen [here](https://britishschool.nl).

Their curriculum can be seen [here](https://issuu.com/bsnetherlands/docs/bsn_20sixth_20form_20curriculum_20s?e=26621386/55452267). (Note Computer Science)

To prove this is their email provider you can see it is used to connect with their AppleID [here](https://www.bsngateway.nl/sites/ext/Pages/HowdoIfindmyAppleID.aspx) (This is on their internal site). The page can be seen properly by removing a "margin-left", then you'll see [this](https://share.vedsted.me/chrome_2018-02-10_19-02-30.png). The important sentence is *"Usually students will (and should)​ have an Apple ID e-mail address ending in @bsnstudent.nl."*.

Further proof: the contact person on [this post](https://www.facebook.com/694828983981711/posts/836819459816156#) is a student too.