### PR TITLE
created mtl.txt

### DIFF
--- a/lib/domains/ca/herzing/mtl.txt
+++ b/lib/domains/ca/herzing/mtl.txt
@@ -1,0 +1,1 @@
+Herzing College Montreal


### PR DESCRIPTION
Herzing College Montreal
created mtl.txt to add mtl.herzing.ca college domain

Institution/School Name:
Herzing College Montreal

Instiution/School Website:
https://www.herzing.ca/montreal/

Programming courses:
- Computing support (14 months)
https://www.herzing.ca/montreal/training/computing-support/
- Programmer Analyst (15 months)
https://www.herzing.ca/montreal/training/programmer-analyst/
- Graphic Design for the Web (12 months)
https://www.herzing.ca/montreal/training/graphic-design-web/

Domain proof:
this is found under https://www.herzing.ca/montreal/
but i cant find one with mtl.herzing.ca we only use it internally
![image](https://user-images.githubusercontent.com/36282106/36117435-a3600500-1007-11e8-827e-2fe8105b5a90.png)


Email Users:
- Academic/Teaching Staff
- Other/Support Staff

Education Levels:
- College (University) or Undergraduate School or equivalent