### PR TITLE
extension for University of Mannheim

### DIFF
--- a/lib/domains/education/mbs.txt
+++ b/lib/domains/education/mbs.txt
@@ -1,0 +1,1 @@
+University of Mannheim, Mannheim Business School


### PR DESCRIPTION
mbs.education Extension for the University of Mannheim, Deutschland.