### PR TITLE
Update and rename dhxd.txt to nuce.txt

### DIFF
--- a/lib/domains/vn/edu/dhxd.txt
+++ b/lib/domains/vn/edu/dhxd.txt
@@ -1,1 +1,0 @@
-Hanoi University of Civil Engineering

--- a/lib/domains/vn/edu/nuce.txt
+++ b/lib/domains/vn/edu/nuce.txt
@@ -1,0 +1,1 @@
+National University of Civil Engineering


### PR DESCRIPTION
"dhxd" is the abbreviation of National University of Civil Engineering (NUCE) in Vietnamese. In fact, our university's domain name is nuce.edu.vn, not dhxd.edu.vn. The email domain of the student is also @nuce.edu.vn. And the official website where the IT-related long-term course provided by this university is http://fit.nuce.edu.vn/.