### PR TITLE
New domain for Université de Corse Pascal Paoli

### DIFF
--- a/lib/domains/corsica/universita.txt
+++ b/lib/domains/corsica/universita.txt
@@ -1,0 +1,1 @@
+Université de Corse Pascal Paoli

--- a/lib/domains/corsica/universita.txt
+++ b/lib/domains/corsica/universita.txt
@@ -1,1 +1,1 @@
-Université de Corse Pascal Paoli
+Università di Corsica Pasquale Paoli

--- a/lib/domains/fr/univ-corse.txt
+++ b/lib/domains/fr/univ-corse.txt
@@ -1,1 +1,1 @@
-Université de Corse Pascal Paoli
+Università di Corsica Pasquale Paoli


### PR DESCRIPTION
This is currently used along with univ-corse.fr.