### PR TITLE
Create amesstudent.ac.nz

### DIFF
--- a/lib/domains/nz/ac/amesstudent.txt
+++ b/lib/domains/nz/ac/amesstudent.txt
@@ -1,0 +1,1 @@
+AMES  - The Institute of IT


### PR DESCRIPTION
University official website: https://www.ames.ac.nz/
URL Page for #year Bachelor's Program: https://www.ames.ac.nz/degree/bachelor-of-creative-software/
Proof College uses this domain: Domain name for students is "amesstudent.ac.nz", it has AMES (institute name) in it.