### PR TITLE
Create esoft.txt

### DIFF
--- a/lib/domains/lk/esoft.txt
+++ b/lib/domains/lk/esoft.txt
@@ -1,0 +1,1 @@
+ESOFT Metro Campus


### PR DESCRIPTION
Adding ESOFT Metro Campus, Sri Lanka

IT related course which is more >1 Year: http://esoft.lk/computer-studies/school-of-computing/bit-university-of-colombo/bit-plus/

@esoft.lk is the only domain used for any email created at the campus. 