### PR TITLE
Gymnasium Bayreuther Straße

### DIFF
--- a/lib/domains/net/gymbay.txt
+++ b/lib/domains/net/gymbay.txt
@@ -1,0 +1,1 @@
+Staedtisches Gymnasium Bayreuther Strasse - Wuppertal


### PR DESCRIPTION
Homepage: gymbay.de
Adress: Bayreuther Str. 35, 42115 Wuppertal Germany
E-Mail domain: gymbay.net
Reason for the difference: Our school uses the iserv.eu system on a different domain https://gymbay.net/iserv/ for the web-interface of iserv