### PR TITLE
add brazilian university of UniNassau

### DIFF
--- a/lib/domains/br/com/sempreuninassau.txt
+++ b/lib/domains/br/com/sempreuninassau.txt
@@ -1,0 +1,1 @@
+UniNassau University


### PR DESCRIPTION
This is about [UniNassau](https://www.uninassau.edu.br/) university.

The mail domains is `.com.br` but web page is `.edu.br`, why ? i don't know.

The university is well-known on brazil, and recently (this year) launched email service.