### PR TITLE
Added University of internet-professions «Netology»

### DIFF
--- a/lib/domains/ru/netology-group.txt
+++ b/lib/domains/ru/netology-group.txt
@@ -1,0 +1,1 @@
+University of internet-professions «Netology»


### PR DESCRIPTION
Hello!

The domain netology-group.ru is used by an educational organization called "Netology group", which includes the following structures:
1) Foxford - online school for schoolchildren and their parents ( https://foxford.ru )
2) Foxford for teachers ( https://teacher.foxford.ru/ ), which provides programs and advanced training courses for teachers.
3) University of internet-professions "Netology" ( https://netology.ru/ ). It is a university for training and additional training for specialists in the field of Internet marketing, project management, design, interface design and web development.

Netology group has an educational license: https://netology-group.ru/documents/license_for_educational_activities.pdf

University of internet-professions "Netology" has both offline and online training programs of varying duration:
* Profession Data Scientist https://netology.ru/programs/data-scientist (held on the campus of the Netology - Russia, Moscow, Nizhnyaya Krasnoselskaya str. 35, p. 59, Campus "Netology")
* Profession Python Developer https://netology.ru/programs/python (413 days, held online)
* Profession Product Manager https://netology.ru/programs/pm (385 days, held online)
* Head of a digital product https://netology.ru/programs/product-lead (held on Campus "Netology")
* and many others professions and courses.