### PR TITLE
Add St Ambrose College

### DIFF
--- a/lib/domains/uk/org/stambrosecollege.txt
+++ b/lib/domains/uk/org/stambrosecollege.txt
@@ -1,0 +1,1 @@
+St Ambrose College


### PR DESCRIPTION
Grammar School and Sixth form in Hale Barns, Greater Manchester.
Email address format as:  @st-ambrosecollege.org.uk