### PR TITLE
added "Gewerblich-industrielles Bildungszentrum Zug"

### DIFF
--- a/lib/domains/ch/gibz.txt
+++ b/lib/domains/ch/gibz.txt
@@ -1,0 +1,1 @@
+Gewerblich-industrielle Bildungszentrum Zug


### PR DESCRIPTION
official site: http://www.gibz.ch

for example we provide the ability to study computer science: https://www.zg.ch/behoerden/volkswirtschaftsdirektion/gibz/grundbildung/02-technik-informatik/informatiker-in-efz

here you find the documentation about the course for 4 years: https://www.zg.ch/behoerden/volkswirtschaftsdirektion/gibz/grundbildung/02-technik-informatik/informatiker-in-efz/downloads/lektionentafel-infm-2008-2013-mh.pdf/download

here you find a list of the teachers: https://www.zg.ch/behoerden/volkswirtschaftsdirektion/gibz/personen/lehrpersonen/lehrpersonen-gibz/Lehrpersonen%20GIBZ%20ohne%20KursLP_2017-01-16.pdf/download
 as you can see the most of them have the e-mail address @gibz.ch which is the official school address