### PR TITLE
Add UAA domain

### DIFF
--- a/lib/domains/mx/uaa/correo.txt
+++ b/lib/domains/mx/uaa/correo.txt
@@ -1,0 +1,1 @@
+Universidad Autónoma de Aguascalientes


### PR DESCRIPTION
University official website URL: http://uaa.mx
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: http://www.uaa.mx/direcciones/dgdp/catalogo/ciencias_basicas/ing_sist_computacionales.pdf
URL of a page showing that the university recognizes the domain submitted as an official email domain for the enrolled students: http://www.uaa.mx/centros/ccb/directorio.php