### PR TITLE
Add NIT, Tsuyama College

### DIFF
--- a/lib/domains/jp/kosen-ac/tsuyama.txt
+++ b/lib/domains/jp/kosen-ac/tsuyama.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Tsuyama College


### PR DESCRIPTION
Please add the domain of National Institute of Technology, Tsuyama College.
This collage is affiliated with the National Institude of Technology.
So, Whois Infomation is the same of Hachinohe Collage.