### PR TITLE
University of West Hungary changed its name

### DIFF
--- a/lib/domains/hu/uni-sopron.txt
+++ b/lib/domains/hu/uni-sopron.txt
@@ -1,0 +1,1 @@
+University of Sopron


### PR DESCRIPTION
University of West Hungary changed its name to University of Sopron