### PR TITLE
Add new University of Waterloo email

### DIFF
--- a/lib/domains/ca/uwaterloo/edu.txt
+++ b/lib/domains/ca/uwaterloo/edu.txt
@@ -1,0 +1,2 @@
+University of St. Jerome's College
+University of Waterloo


### PR DESCRIPTION
https://uwaterloo.ca/email

University of Waterloo changed the email system from `@uwaterloo.ca` to `@edu.uwaterloo.ca`, and redirects `@uwaterloo.ca` to `@edu.uwaterloo.ca`