### PR TITLE
Add Åland University of Applied Sciences

### DIFF
--- a/lib/domains/ax/ha.txt
+++ b/lib/domains/ax/ha.txt
@@ -1,0 +1,1 @@
+Åland University of Applied Sciences


### PR DESCRIPTION
Åland University of Applied Sciences: http://www.ha.ax
Degree programmes (including Computer Science): http://old.ha.ax/text.con?iPage=327&m=2210
A "get in touch" page with some official e-mail adresses in the domain: https://www.ha.ax/kontakt/
