### PR TITLE
Added ICT College of Vocational Studies (ict.txt)

### DIFF
--- a/lib/domains/rs/edu/ict.txt
+++ b/lib/domains/rs/edu/ict.txt
@@ -1,0 +1,1 @@
+Visoka ICT škola (ICT College of Vocational Studies)


### PR DESCRIPTION
School website: https://ict.edu.rs/
Name: Visoka ICT Škola (eng. ICT College of Vocational Studies)
Full name: Visoka škola strukovnih studija za informacione i komunikacione tehnologije
IT studies: https://ict.edu.rs/studijski-programi/osnovne-studije/internet-tehnologije/plan-studija-2017-0

Site containing all schools and universities in Serbia, link to this school: http://fakulteti.edukacija.rs/drzavne-visoke-skole/beograd/visoka-skola-strukovnih-studija-za-informacione-i-komunikacione-tehnologije/

There is also an English version of the website en.ict.edu.rs but it is not updated as frequently as local version.
