### PR TITLE
Add maricopa.txt - obtaining non-student addresses through maricopa is no longer possible

### DIFF
--- a/lib/domains/edu/maricopa.txt
+++ b/lib/domains/edu/maricopa.txt
@@ -1,0 +1,10 @@
+Chandler-Gilbert Community College
+Estrella Mountain Community College
+GateWay Community College
+Glendale Community College
+Mesa Community College
+Paradise Valley Community College
+Phoenix College
+Rio Salado College
+Scottsdale Community College
+South Mountain Community College


### PR DESCRIPTION
**In reference to #4537, #2393 and #1673:**

**The instructions in the post referenced by #1673 are no longer valid and MCC has completely deprecated any functionality allowing non-students and non-faculty members from obtaining an email under maricopa.edu** - these changes were made years ago, and the instructions afforded in the post referenced by #1673 haven't been valid for nearly 5 years.

### Original PR:

Maricopa Community Colleges encompasses 10 different schools in Maricopa County, Arizona, all of which are listed here: https://www.maricopa.edu/why-maricopa/colleges - all 10 of these schools utilize the maricopa.edu SLD for student email.

Each college has a course catalog available at their respective website, each school offers multi-semester and multi-year courses in CIS and CS. Rio Salado, for example, offers multiple courses for certificates of completion and degrees in Computer Science, such as their Mobile Apps programming course. Rio's catalog can be found here: http://www.riosalado.edu/catalog/Documents/College-Catalog-2017-2018.pdf

Of those 10, Mesa and Glendale both have public pages describing maricopa.edu as the primary email domain for students, with steps for setting it up:

 - https://www.mesacc.edu/enroll/student-email
 - http://www.gccaz.edu/technology-help/student-email