### PR TITLE
Added IMT Atlantique

### DIFF
--- a/lib/domains/fr/imt-atlantique.txt
+++ b/lib/domains/fr/imt-atlantique.txt
@@ -1,0 +1,1 @@
+IMT Atlantique Bretagne-Pays de la Loire École Mines-Télécom


### PR DESCRIPTION
IMT Atlantique results from the merge of Télécom Bretagne and École des Mines de Nantes. For more information see http://www.imt-atlantique.fr/en.

Note that at some point in the future, the old names should be removed (eu/telecom-bretagne.txt and fr/mines-nantes.txt).

Hope to help
Fabien
