### PR TITLE
Add Zhejiang University City College

### DIFF
--- a/lib/domains/cn/edu/stu.zucc.txt
+++ b/lib/domains/cn/edu/stu.zucc.txt
@@ -1,0 +1,2 @@
+Student for Zhejiang University City College
+浙江大学城市学院，学生邮箱。

--- a/lib/domains/cn/edu/stu.zucc.txt
+++ b/lib/domains/cn/edu/stu.zucc.txt
@@ -1,2 +1,0 @@
-Student for Zhejiang University City College
-浙江大学城市学院，学生邮箱。

--- a/lib/domains/cn/edu/zucc.txt
+++ b/lib/domains/cn/edu/zucc.txt
@@ -1,0 +1,2 @@
+Zhejiang University City College
+浙江大学城市学院

--- a/lib/domains/cn/edu/zucc/stu.txt
+++ b/lib/domains/cn/edu/zucc/stu.txt
@@ -1,0 +1,2 @@
+Zhejiang University City College
+浙江大学城市学院


### PR DESCRIPTION
add Zhejiang University City College
Here are the requested links:
Official web page [浙江大学城市学院](http://www.zucc.edu.cn/)
Other proofs :
[Wiki about Zhejiang University City College（Chinese Simplified）](https://zh.wikipedia.org/wiki/%E6%B5%99%E6%B1%9F%E5%A4%A7%E5%AD%A6%E5%9F%8E%E5%B8%82%E5%AD%A6%E9%99%A2)
[The email web page of Zhejiang University City College](http://webmail.zucc.edu.cn/)

Thank you!