### PR TITLE
Technical University of Gdansk has new domain: pg.edu.pl

### DIFF
--- a/lib/domains/pl/edu/pg.txt
+++ b/lib/domains/pl/edu/pg.txt
@@ -1,0 +1,1 @@
+Technical University of Gdansk


### PR DESCRIPTION
http://pg.gda.pl is redirecting to new domain https://pg.edu.pl
and here is an example page with the informations about Computer Science courses:
https://eti.pg.edu.pl/field-3