### PR TITLE
Added ipag.fr

### DIFF
--- a/lib/domains/fr/ipag.txt
+++ b/lib/domains/fr/ipag.txt
@@ -1,0 +1,1 @@
+IPAG business school - Paris, Nice

--- a/lib/domains/fr/ipag.txt
+++ b/lib/domains/fr/ipag.txt
@@ -1,1 +1,1 @@
-IPAG business school - Paris, Nice
+IPAG business school - Paris, Nice, France


### PR DESCRIPTION
School home page (different TL domain than requested ) : https://www.ipag.edu
long-term (>1 year) IT related course is offered by the university : https://www.ipag.edu/etudiants/formation/master-2-marketing-digital-data
School page on the domain requested : https://ipagora.ipag.fr/ (domain used as an extranet for students and teachers)