### PR TITLE
Adding Domain for South-Central University for Nationalities

### DIFF
--- a/lib/domains/cn/edu/scuec.txt
+++ b/lib/domains/cn/edu/scuec.txt
@@ -1,0 +1,1 @@
+South-Central University for Nationalities


### PR DESCRIPTION
The university official website URL : http://english.scuec.edu.cn