### PR TITLE
add Shanghai Normal University

### DIFF
--- a/lib/domains/cn/edu/shnu/smail.txt
+++ b/lib/domains/cn/edu/shnu/smail.txt
@@ -1,0 +1,1 @@
+Shanghai Normal University


### PR DESCRIPTION
Official Site(English) : http://english.shnu.edu.cn/     

URL to prove College and Courses related to IT ever exists(in Chinese) : http://xxjd.shnu.edu.cn/a4/d1/c14330a369873/page.htm    

URL to prove this domain is related to student affairs , originates from school IT Department , please check 三、学生电子邮件(in Chinese) : http://xxb.shnu.edu.cn/159/list.htm