### PR TITLE
Added email domain for students of Opole University of Technology

### DIFF
--- a/lib/domains/pl/edu/po/student.txt
+++ b/lib/domains/pl/edu/po/student.txt
@@ -1,0 +1,2 @@
+Opole University of Technologygit
+Politechnika Opolska

--- a/lib/domains/pl/edu/po/student.txt
+++ b/lib/domains/pl/edu/po/student.txt
@@ -1,2 +1,2 @@
-Opole University of Technologygit
+Opole University of Technology
 Politechnika Opolska


### PR DESCRIPTION
[Official website (ENG version)](http://www.po.opole.pl/lang/en/)

[URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university (ENG version)](http://www.po.opole.pl/lang/en/index.php?mod=rekrutacja;kierunki_pl;weaii_informatyka)

[URL of a page showing that the university recognizes submitted domain as an official email domain for the enrolled students(POLISH version, sadly lack ENG version)](https://uoi.po.opole.pl/index.php/uslugi/poczta-elektroniczna)

Last link have proof at quote: 
> Każdy student Politechniki Opolskiej może posiadać konto pocztowe w domenie **@student.po.edu.pl**. Studenci konta pocztowe mogą założyć poprzez uczelniany portal eStudent funkcjonujący pod adresem: https://estudent.po.opole.pl.
