### PR TITLE
Add De Smet Jesuit High School

### DIFF
--- a/lib/domains/org/desmet.txt
+++ b/lib/domains/org/desmet.txt
@@ -1,0 +1,4 @@
+De Smet Jesuit High School
+De Smet Jesuit
+DeSmet Jesuit
+DeSmet Jesuit High School


### PR DESCRIPTION
- Official URL: https://www.desmet.org/

- Proof of long term (1+ year) IT Related course offered by the University: While there isn't a direct link on the site, a year long AP Introduction to Computer Science course can be found on page 30 of the [Curriculum Guide PDF here](https://www.desmet.org/academics-arts/academics/curriculum-guide)

- URL of a page (Or some other proof) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: While I couldn't find a direct URL or any info on the website about student emails, I can attach screenshots of official school emails sent to this address (although for privacy reasons, I'd rather not attach them unless it is absolutely necessary, seeing as they might contain personal information). If it is necessary that I attach an example of these emails, please let me know and I will.

Thank you for your time, and for giving all of us students the amazing opportunity to use all of your wonderful tools for free.
-Shane