### PR TITLE
Adding cccs.edu domain

### DIFF
--- a/lib/domains/edu/cccs.txt
+++ b/lib/domains/edu/cccs.txt
@@ -1,0 +1,3 @@
+Colorado Community College System
+Arapahoe Community College
+.group


### PR DESCRIPTION
The Community College System
https://www.cccs.edu/about-cccs/cccs-colleges/
IT Programs they cover
https://www.cccs.edu/explore-college-programs/programs/information-technology/
The specific college being added (though they all use the same domain)
https://www.cccs.edu/college/arapahoe-community-college/
An example program offered at this college
https://www.arapahoe.edu/departments-and-programs/a-z-programs/game-design-and-development