### PR TITLE
Added Coast Community Colleges

### DIFF
--- a/lib/domains/cccd/student.txt
+++ b/lib/domains/cccd/student.txt
@@ -1,0 +1,1 @@
+Coast Community College District.  


### PR DESCRIPTION
This is a district consisting of three colleges, Coastline Community College, Golden West College, and Orange Coast College
Official URL: http://www.coastline.edu and http://www.orangecoastcollege.edu and http://www.goldenwestcollege.edu/
Page with IT Prgoram: http://www.coastline.edu/academics/cybersecurity-apprenticeship-program
Email Details: http://www.orangecoastcollege.edu/about_occ/Technology/student-computing/Pages/Student-Email-(Gmail).aspx