### PR TITLE
Added University of Girona domain (Spain)

### DIFF
--- a/lib/domains/edu/udg.txt
+++ b/lib/domains/edu/udg.txt
@@ -1,0 +1,2 @@
+Universitat de Girona
+University of Girona


### PR DESCRIPTION
Official website of university: www.udg.edu
If offers Bachelor's and Master's in Computer Science among others:

https://www.udg.edu/ca/study-at-the-udg

http://wenes.udg.edu/tabid/10104/Default.aspx?ID=3105G0710&language=en-us&IDE=847