### PR TITLE
Added domain for Universitat Oberta de Catalunya (uoc.edu)

### DIFF
--- a/lib/domains/edu/uoc.txt
+++ b/lib/domains/edu/uoc.txt
@@ -1,0 +1,1 @@
+Universitat Oberta de Catalunya


### PR DESCRIPTION
**Website:**
www.uoc.edu (catalan)
http://www.uoc.edu/portal/en/index.html (english)

**Courses, full list:**

http://studies.uoc.edu/en/all-courses

**Examples of 4-year IT courses (I'm sorry it's in spanish, they're not available in english)**
http://estudios.uoc.edu/es/grados/ingenieria-informatica/plan-estudios
http://estudios.uoc.edu/es/grados/multimedia/plan-estudios
http://estudios.uoc.edu/es/grados/tecnologias-telecomunicacion/plan-estudios

**Proof of students using the uoc.edu domain as an educational resource:**
http://www.uoc.edu/portal/en/_peu/avis_legal/index.html

It's a legal notice. In section 4, paragraph 3, it states:

The UOC provides all members of the Virtual Campus community with a free email account using the uoc.edu domain and provides the technological and hosting resources needed to administer it. Its use is restricted solely to the educational field and to communication between Campus users; hence using it for professional and commercial purposes is expressly forbidden
