### PR TITLE
Add Universitat Pompeu Fabra under edu domain

### DIFF
--- a/lib/domains/edu/upf.txt
+++ b/lib/domains/edu/upf.txt
@@ -1,0 +1,1 @@
+Universitat Pompeu Fabra


### PR DESCRIPTION
Main website: https://www.upf.edu/
Link showing an email of a research group coordinator: https://www.upf.edu/recercaupf/en/grups/gr-mtg.html

There is [a file](https://github.com/JetBrains/swot/blob/master/lib/domains/es/upf.txt) for the university under the _es_ domain, which is not the right one as far I as know.

It is strange because it is not the first time I ask for a edu license for PyCharm, and I never had problem with my upf.edu email before. 
I hope this PR will make the system recognize our email addresses.


Thanks you