### PR TITLE
Add Hillsborough Community College

### DIFF
--- a/lib/domains/edu/hccfl/hawkmail.txt
+++ b/lib/domains/edu/hccfl/hawkmail.txt
@@ -1,0 +1,1 @@
+Hillsborough Community College


### PR DESCRIPTION
## Hillsborough Community College
Requesting to add Hillsborough Community College to the education discount. Per your request, please see proof below:

School URL: [hccfl.edu](url)
Proof of computer science related course:[https://www.hccfl.edu/media/3509913/2018-2019-catalog-6-14-18-accessible.pdf](url) Page 44 lists Computer Science (Engineering) as an Associates Degree (2 year college program).

Proof of use of email address: [https://www.hccfl.edu/hawknet.aspx](url) Please see HawkMail365 module. This leads to [http://outlook.com/hawkmail.hccfl.edu](url) which shows that students use hawkmail.hccfl.edu domains.