### PR TITLE
Add Olin.edu, Olin College of Engineering,

### DIFF
--- a/lib/domains/edu/olin.txt
+++ b/lib/domains/edu/olin.txt
@@ -1,0 +1,1 @@
+Olin College of Engineering


### PR DESCRIPTION
Added the college Olin College of Engineering in Needham, MA, USA

Website [http://www.olin.edu/](http://www.olin.edu/)

Website Major Page [http://www.olin.edu/academics/programs-majors/](http://www.olin.edu/academics/programs-majors/)

