### PR TITLE
Added osgh.txt

### DIFF
--- a/lib/domains/nl/osgh.txt
+++ b/lib/domains/nl/osgh.txt
@@ -1,0 +1,1 @@
+Openbare Scholengemeenschap Hengelo


### PR DESCRIPTION
"osgh.nl" is the domain for school-related Microsoft-accounts (e-mail included) assigned to pupils of Openbare Scholengemeenschap Hengelo. The normal site (which is also used for teacher e-mail accounts) is osghengelo.nl