### PR TITLE
Add university of goettingen (student accounts)

### DIFF
--- a/lib/domains/de/stud.uni-goettingen.de
+++ b/lib/domains/de/stud.uni-goettingen.de
@@ -1,0 +1,3 @@
+University of Goettingen. 
+
+Students usually get an email address in the format: name@stud.uni-goettingen.de


### PR DESCRIPTION
The university of goettingen is supported by JetBrains with the domain "uni-goettingen.de". However, students accounts usually get an email address under the domain stud.uni-goettingen.de.