### PR TITLE
Add MGUTM University

### DIFF
--- a/lib/domains/ru/mgutm.txt
+++ b/lib/domains/ru/mgutm.txt
@@ -1,0 +1,5 @@
+«Московский государственный университет технологий и управления имени К.Г. Разумовского (ПКУ)»
+МГУТУ им. К.Г. Разумовского (ПКУ)
+MGUTU
+Moscow State University of Technology and Management named after K.G. Razumovsky (PKU)
+Education programm: http://www.mgutm.ru/about/chairs/it.php


### PR DESCRIPTION
«Московский государственный университет технологий и управления имени К.Г. Разумовского (ПКУ)»
МГУТУ им. К.Г. Разумовского (ПКУ)
MGUTU
Moscow State University of Technology and Management named after K.G. Razumovsky (PKU)
Education programm: http://www.mgutm.ru/about/chairs/it.php
[mgutm.txt](https://github.com/JetBrains/swot/files/2255032/mgutm.txt)
