### PR TITLE
Add Andover Public Schools from Andover, MA to the database

### DIFF
--- a/lib/domains/us/andoverma/k12.txt
+++ b/lib/domains/us/andoverma/k12.txt
@@ -1,0 +1,1 @@
+Andover Public Schools


### PR DESCRIPTION
Andover Public Schools recognizes this domain here:
https://sites.google.com/k12.andoverma.us/apsdigitallearning/for-students?authuser=0
It is the technology department's page instructing students on how to login to their school emails.

The Andover Public Schools website:
http://www.aps1.net

Email domain to be added:
@k12.andoverma.us