### PR TITLE
Shahid Beheshti University, and added Essential Directory.

### DIFF
--- a/lib/domains/ir/ac/sbu.txt
+++ b/lib/domains/ir/ac/sbu.txt
@@ -1,1 +1,0 @@
-Shahid Beheshti University

--- a/lib/domains/ir/ac/sbu/mail.txt
+++ b/lib/domains/ir/ac/sbu/mail.txt
@@ -1,0 +1,1 @@
+Shahid Beheshti University


### PR DESCRIPTION
Since the way Shahid Beheshti University emails are addressed ( e.g. "example@**mail.sbu.ac.ir**") This is the correct way of having it in lib/domains/ir/ac.