### PR TITLE
Add Brine Leas Sixth Form (BL6)

### DIFF
--- a/lib/domains/uk/org/bl6.txt
+++ b/lib/domains/uk/org/bl6.txt
@@ -1,0 +1,2 @@
+Brine Leas Sixth Form
+BL6


### PR DESCRIPTION
Website URL: http://bl6.org.uk/
Course URL: http://bl6.org.uk/course-directory/ (In the PDF document)
[Screenshot of usage](https://i.gyazo.com/21cf334a54fb6dbf23eaff4f1c8302cf.png) (email seen at top-right corner) - Note that the website shown in the screenshot (https://webmail.brineleas.co.uk) is the address used to login to email accounts, which is linked to on the homepage (http://bl6.org.uk/) in the navigation bar (EMAIL).