### PR TITLE
Update Western Brown

### DIFF
--- a/lib/domains/com/wbbroncos.txt
+++ b/lib/domains/com/wbbroncos.txt
@@ -1,0 +1,1 @@
+Western Brown High School

--- a/lib/domains/us/oh/k12/wb.txt
+++ b/lib/domains/us/oh/k12/wb.txt
@@ -1,2 +1,0 @@
-Western Brown High School
-Mount Orab Middle School


### PR DESCRIPTION
As of August 2018, Western Brown updated their domain, they went from username@wb.k12.oh.us to username@wbbroncos.com, which messed with validation on Jetbrains registration. 