### PR TITLE
Delete ungweb.txt

### DIFF
--- a/lib/domains/no/ungweb.txt
+++ b/lib/domains/no/ungweb.txt
@@ -1,1 +1,0 @@
-Møre og Romsdal Fylkeskommune


### PR DESCRIPTION
This school doesn't use anymore @unweb.no webmails. Confirmed by one teacher from this school.