### PR TITLE
Create granitesd.txt

### DIFF
--- a/lib/domains/org/granitesd.txt
+++ b/lib/domains/org/granitesd.txt
@@ -1,0 +1,1 @@
+Granite School District (students)


### PR DESCRIPTION
Thanks for approving that so fast.

My apologizes though, but I didn't realize that Granite School District also uses the domain granitesd.org for student emails.  This is hosted by gmail so the students can use their email easily with school issued Chromebooks.

See graniteschools.org for their main website.  See my previous patch-2 for more information.