### PR TITLE
Add Saint Stephen's Episcopal School

### DIFF
--- a/lib/domains/org/sstx.txt
+++ b/lib/domains/org/sstx.txt
@@ -1,0 +1,16 @@
+Saint Stephen's Episcopal School
+Saint Stephens Episcopal School
+St. Stephen's Episcopal School
+St. Stephens Episcopal School
+Saint Stephen's Episcopal School of Austin
+Saint Stephens Episcopal School of Austin
+St. Stephen's Episcopal School of Austin
+St. Stephens Episcopal School of Austin
+Saint Stephen's Episcopal School, Austin
+Saint Stephens Episcopal School, Austin
+St. Stephen's Episcopal School, Austin
+St. Stephens Episcopal School, Austin
+Saint Stephen's Episcopal School, Austin TX
+Saint Stephens Episcopal School, Austin TX
+St. Stephen's Episcopal School, Austin TX
+St. Stephens Episcopal School, Austin TX


### PR DESCRIPTION
High school in Austin, Texas. Website sstx.org