### PR TITLE
Add Ermysted's Grammar School

### DIFF
--- a/lib/domains/uk/sch/n-yorks/ermysteds.txt
+++ b/lib/domains/uk/sch/n-yorks/ermysteds.txt
@@ -1,0 +1,1 @@
+Ermysted's Grammar School


### PR DESCRIPTION
School website is https://ermysteds.co.uk but it is accessible through https://ermysteds.n-yorks.sch.uk and you can see how we use the email address here: https://www.ermysteds.co.uk/contact-us/

School in Skipton, North Yorkshire, England.

Thanks for your help!

Adds lib/domains/uk/sch/n-yorks/ermysteds.txt