### PR TITLE
Create pja.txt

### DIFF
--- a/lib/domains/pl/edu/pja.txt
+++ b/lib/domains/pl/edu/pja.txt
@@ -1,0 +1,1 @@
+Polish-Japanese Academy of Information Technology in Warsaw


### PR DESCRIPTION
https://www.pja.edu.pl/en/

`pja.edu.pl` is an alias for `pjwstk.edu.pl` which is the domain the academy used before, when it was called an institute.