### PR TITLE
Shrewsbury Colleges Group

### DIFF
--- a/lib/domains/uk/ac/shrewsbury.txt
+++ b/lib/domains/uk/ac/shrewsbury.txt
@@ -1,0 +1,1 @@
+Shrewsbury Colleges Group


### PR DESCRIPTION
Interesting situation here, 2 colleges (Shrewsbury College and Shrewsbury Sixth Form College) merged - as far as I can tell, they used the infrastructure from Shrewsbury College. Up until recently both colleges retained their separate websites, though that is no longer the case and a single site is used for the group.

Currently emails are given out on the shrewsbury.ac.uk domain, though there may still be some students/staff on the ssfc.ac.uk domain. It may also be the case that they use scg.ac.uk in the future. Frankly, I don't know. Though I'd be willing to update the PR to include all 3, there's no rush on this - I'm just getting prepared for renewal in October :)

Group Site: https://www.scg.ac.uk/
Legacy SSFC Site: https://www.ssfc.ac.uk/ (redirects to the group site, not used for emails AFAIK)
Legacy SCAT Site: https://www.shrewsbury.ac.uk/ (redirects to the group site, used for (at least some) emails)

I'm fairly certain given the domain has the ac.uk tld there won't be must contention with merging the PR, though as the website is on a different domain - you might want some additional proof. The only use of a shrewsbury.ac.uk email I could find on there website is under the contact email, found in the sidebar. This can be seen on https://www.scg.ac.uk/about-us/governance-and-leadership/the-shrewsbury-colleges-group