### PR TITLE
Update Shrewsbury Colleges Groups domains

### DIFF
--- a/lib/domains/uk/ac/ssfc.txt
+++ b/lib/domains/uk/ac/ssfc.txt
@@ -1,0 +1,1 @@
+Shrewsbury Colleges Group


### PR DESCRIPTION
Follow up to #5233, it turns out that there are indeed students/staff
with emails using the legacy @ssfc.ac.uk domain.