### PR TITLE
Add WHPS

### DIFF
--- a/lib/domains/org/whps.txt
+++ b/lib/domains/org/whps.txt
@@ -1,0 +1,2 @@
+West Hartford Public Schools
+.group


### PR DESCRIPTION
# Institution/School Name
West Hartford Public Schools

No specific document exists stating student email domains, but it is quite evident the district uses these emails due to them being repeatedly stated for use by teachers and students in various guidebooks/handbooks and district documents. If additional proof is required, I will look into acquiring specific documents from the district. 
https://www.whps.org/uploaded/Schools/High_Schools/Hall_High_School/News/Files/2018-2019_Student_Handbook_V2.pdf

# Institution/School Website
http://www.whps.org

# Email Domains
@whps.org              (For staff)
@student.whps.org (For students)

# Computer Science (or equivalent) courses
http://www.whps.org/page.cfm?p=3825

Education Levels
- [x] High School or equivalent
- [x] Elementary School or equivalent