### PR TITLE
Add talnet.nl

### DIFF
--- a/lib/domains/nl/talnet.txt
+++ b/lib/domains/nl/talnet.txt
@@ -1,0 +1,1 @@
+Roc Van Amsterdam


### PR DESCRIPTION
Talnet is the email domain students use with theire school account (goes via outlook)

If needed, i can and im willing to verify