### PR TITLE
Add FEDAC Schools

### DIFF
--- a/lib/domains/cat/fedac.txt
+++ b/lib/domains/cat/fedac.txt
@@ -1,0 +1,1 @@
+Escoles FEDAC


### PR DESCRIPTION
All FEDAC schools in Catalonia use the http://fedac.cat domain.

Some schools offer the scientific/technological baccalaureate. (For example: http://www.fedac.cat/horta.php)

Email adresses are of style studentname@fedac.cat or studentname@schoolname.fedac.cat