### PR TITLE
Adding domains for Uka Tarsadia University

### DIFF
--- a/lib/domains/in/ac/utu.txt
+++ b/lib/domains/in/ac/utu.txt
@@ -1,0 +1,1 @@
+Uka Tarsadia University


### PR DESCRIPTION
Added email domain for Uka Tarsadia University. More details about university can be found at http://utu.ac.in