### PR TITLE
Add BBS2 Wolfsburg

### DIFF
--- a/lib/domains/de/bbs2wob.txt
+++ b/lib/domains/de/bbs2wob.txt
@@ -1,0 +1,1 @@
+Berufsbildende Schulen 2 Wolfsburg


### PR DESCRIPTION
Link to computer science course: https://bbs2-wob.de/bildungsangebot/berufsschule/informationstechnik/
Note, that the official school website has a dash, where the proposed domain doesn't. This is not a mistake, as the school's mail server is located at https://bbs2wob.de/