### PR TITLE
Adding CHARUSAT domains.

### DIFF
--- a/lib/domains/in/ac/charusat.txt
+++ b/lib/domains/in/ac/charusat.txt
@@ -1,0 +1,1 @@
+Charotar University Of Science And Technology

--- a/lib/domains/in/edu/charusat.txt
+++ b/lib/domains/in/edu/charusat.txt
@@ -1,0 +1,1 @@
+Charotar University Of Science And Technology


### PR DESCRIPTION
Hi team, 
The above university has different domains for administrative purpose and student enrolment. 
- [https://charusat.ac.in](https://charusat.ac.in) is main domain which is used for administrative purpose and 
https://charusat.edu.in is used for students enrolment. 


  - https://www.charusat.ac.in/all-courses/ug-programs/   
Link of all undergrad/postgrad/PhD programs.
  - https://www.charusat.ac.in/CSPIT/about-us/    
Link of one of the institute (Engineering Institute) under the university.
  - https://www.charusat.ac.in/CSPIT/computer-engineering/   
Link to Computer Engineering department details.
 

