### PR TITLE
Added XXXI LO High School [Łódź, Poland]

### DIFF
--- a/lib/domains/pl/edu/elodz/lo31.txt
+++ b/lib/domains/pl/edu/elodz/lo31.txt
@@ -1,0 +1,2 @@
+﻿XXXI Liceum Ogólnokształcące im. Ludwika Zamenhofa w Łodzi
+Ludwik Zamenhof 31st High School in Lodz


### PR DESCRIPTION
aka Ludwik Zamenhof 31st High School in Lodz
More and more pupils received their licenses in other ways, such as ID submission. Official pupils' email can be much easier option for them.

Official website: http://lo31.pl/
Wiki, PL only: https://pl.wikipedia.org/wiki/XXXI_Liceum_Og%C3%B3lnokszta%C5%82c%C4%85ce_im._Ludwika_Zamenhofa_w_%C5%81odzi