### PR TITLE
add german school Lessing

### DIFF
--- a/lib/domains/de/lgbk.txt
+++ b/lib/domains/de/lgbk.txt
@@ -1,0 +1,1 @@
+Lessing Gymnasium | Berufskolleg


### PR DESCRIPTION
Name: Lessing Gymnasium | Berufskolleg
URL: http://lgbk.de
Schooltype: Highschool or equivalent
Email users: (students and) teachers
Proof of Email-adress usage by school: http://www.lgbk.de/das-lessing/das-kollegium/