### PR TITLE
added university of edinburgh alumni email

### DIFF
--- a/lib/domains/net/ed-alumni.txt
+++ b/lib/domains/net/ed-alumni.txt
@@ -1,0 +1,2 @@
+University of Edinburgh
+University of Edinburgh


### PR DESCRIPTION
When students graduate from the University of Edinburgh, their student email ending in .ac.ed.uk gets disconnected and they are given an alumni email ending in ed-alumni.net