### PR TITLE
Add another domain for University of Auckland

### DIFF
--- a/lib/domains/nz/ac/aucklanduni.txt
+++ b/lib/domains/nz/ac/aucklanduni.txt
@@ -1,0 +1,1 @@
+University of Auckland


### PR DESCRIPTION
Website: https://www.auckland.ac.nz/en.html