### PR TITLE
www.yschools.fr

### DIFF
--- a/lib/domains/eu/yschools.txt
+++ b/lib/domains/eu/yschools.txt
@@ -1,0 +1,1 @@
+Yschools

--- a/lib/domains/fr/yschools.txt
+++ b/lib/domains/fr/yschools.txt
@@ -1,0 +1,1 @@
+Yschools


### PR DESCRIPTION
Groupe ESC Troyes changed name to Yschools (www.yschools.fr)