### PR TITLE
Université Polytechnique des Hauts de France

### DIFF
--- a/lib/domains/fr/uphf.txt
+++ b/lib/domains/fr/uphf.txt
@@ -1,0 +1,1 @@
+Université Polytechnique des Hauts de France


### PR DESCRIPTION
Université Polytechnique des Hauts de France (**uphf**) is already registered but with **etu.uphf.fr** subdomain only (used for studiants). **uphf.fr** is for teachers.