### PR TITLE
Added University of Auckland student email

### DIFF
--- a/lib/domains/nz/ac/aucklanduni.txt
+++ b/lib/domains/nz/ac/aucklanduni.txt
@@ -1,0 +1,1 @@
+University of Auckland


### PR DESCRIPTION
Website: https://www.auckland.ac.nz/en.html
The student email domain is aucklanduni.ac.nz instead of auckland.ac.nz

Cheers