### PR TITLE
added Walther-Rathenau Gewerbeschule Freiburg

### DIFF
--- a/lib/domains/de/wara.txt
+++ b/lib/domains/de/wara.txt
@@ -1,0 +1,1 @@
+Walther-Rathenau Gewerbeschule Freiburg


### PR DESCRIPTION
Name: Walther-Rathenau Gewerbeschule
Website: http://www.wara.de/
Computer science course: http://www.wara.de/index.php/berufsschule/fachinformatikerin
Email proof: http://www.wara.de/index.php/impressum