### PR TITLE
Add mpia-hd

### DIFF
--- a/lib/domains/de/mpg/mpia-hd.txt
+++ b/lib/domains/de/mpg/mpia-hd.txt
@@ -1,0 +1,1 @@
+International Max Planck Research School for Astronomy and Cosmic Physics at the University of Heidelberg


### PR DESCRIPTION
Hello!

https://www.imprs-hd.mpg.de/

IMPRS-HD is an independent part of HGSFP 
http://www.fundamental-physics.uni-hd.de/

IMPRS-HD is uniting many institutes in Heidelberg, each one provides its own email. Max Planck Institute for Astronomy is the HQ and the biggest of them.

https://www.imprs-hd.mpg.de/3521/IMPRS-officials

Computing and programming, in general, is a vital part of astrophysics, and astronomers, especially students, spend a lot of time programming.

MPE, that plays the same role in Munich, is already in the repository.