### PR TITLE
Add domain hawk.de

### DIFF
--- a/lib/domains/de/hawk.txt
+++ b/lib/domains/de/hawk.txt
@@ -1,0 +1,1 @@
+HAWK Hochschule für angewandte Wissenschaft und Kunst


### PR DESCRIPTION
The domain belongs to HAWK Hochschule für angewandte Wissenschaften und Kunst Hildesheim Holzminden Göttingen. Thank you for adding it !