### PR TITLE
add ahk.nl domain

### DIFF
--- a/lib/domains/nl/ahk.txt
+++ b/lib/domains/nl/ahk.txt
@@ -1,0 +1,1 @@
+Amsterdam University Of The Arts


### PR DESCRIPTION
The domain: student.ahk.nl was already added to this repository a long time ago, but that leaves out teachers which have an ahk.nl email address.

Official website: https://www.ahk.nl/en/
Long term course: https://www.filmacademie.ahk.nl/en/study-programmes/visual-effects-immersive-media (interactive media uses Unity)
Not sure how to proof the domain other than that it's used for a general contact email address: https://www.filmacademie.ahk.nl/en/about-the-academy/contact/