### PR TITLE
Adding Twynham School

### DIFF
--- a/lib/domains/com/twynhamschool.txt
+++ b/lib/domains/com/twynhamschool.txt
@@ -1,0 +1,1 @@
+Twynham School


### PR DESCRIPTION
Adding Twynham School, Secondary School/Sixth Form.

http://www.twynhamschool.com
http://www.twynhamschool.com/197/subjects/subject/14/computing

http://www.twynhamsixthform.com/
http://www.twynhamsixthform.com/388/subjects/subject/32/computer-science

Students have twynhamschool.com as their domain emails.

Thanks.
