### PR TITLE
Added Tibble Gymnasium, a Swedish high school in Täby outside of Stocholm

### DIFF
--- a/lib/domains/nu/tibble.txt
+++ b/lib/domains/nu/tibble.txt
@@ -1,0 +1,1 @@
+Tibble Gymnasium

--- a/lib/domains/nu/tibble/edu.txt
+++ b/lib/domains/nu/tibble/edu.txt
@@ -1,0 +1,1 @@
+Tibble Gymnasium, students emails


### PR DESCRIPTION
tibble.nu for faculty and edu.tibble.nu for students.