### PR TITLE
Added domain mail.kreuzgymnasium.de

### DIFF
--- a/lib/domains/de/kreuzgymnasium/mail.txt
+++ b/lib/domains/de/kreuzgymnasium/mail.txt
@@ -1,0 +1,1 @@
+Evangelisches Kreuzgymnasium Dresden


### PR DESCRIPTION
mail.kreuzgymnasium.de belongs to the "Evangelisches Kreuzgymnasium Dresden" in Dresden/Saxony/Germany