### PR TITLE
Added Radyr Comprehensive School

### DIFF
--- a/lib/domains/net/radyr.txt
+++ b/lib/domains/net/radyr.txt
@@ -1,0 +1,2 @@
+Radyr Comprehensive School
+Radyr Comprehensive School


### PR DESCRIPTION
Added Radyr Comprehensive School, a comprehensive school and Sixth Form college in Cardiff, Wales. Computing is offered to GSCE students and Sixth Form students.

School website: [radyrcs.co.uk](http://radyrcs.co.uk)
Internal email domain (as found in website footer): [radyr.net](http://radyr.net)

Computing on the prospectus: [Sixth Form Computing Page](https://www.radyrsixthform.org/computing-and-ict) - [Sixth Form Computing Video](https://www.youtube.com/watch?v=Pkq0axxfZrw)