### PR TITLE
Add itlg.be

### DIFF
--- a/lib/domains/be/itlg/portail.txt
+++ b/lib/domains/be/itlg/portail.txt
@@ -1,0 +1,1 @@
+Institut de Technologie de Liège


### PR DESCRIPTION
Adding ITLG domain for http://webitlg.portail.itlg.be/
The long-term IT related formation: http://webitlg.portail.itlg.be/nos-formations/bachelier-en-informatique-industrielle

