### PR TITLE
Renaming domain for Gdynia Maritime University/Academy

### DIFF
--- a/lib/domains/pl/edu/umg.txt
+++ b/lib/domains/pl/edu/umg.txt
@@ -1,0 +1,1 @@
+Gdynia Maritime University

--- a/lib/domains/pl/gdynia/am.txt
+++ b/lib/domains/pl/gdynia/am.txt
@@ -1,1 +1,0 @@
-Gdynia Maritime Academy


### PR DESCRIPTION
Renaming domain for Gdynia Maritime University/Academy

was am.gdynia.pl
is umg.edu.pl

The university changed its name and domain.
A proper university which issues diplomas: http://umg.edu.pl/en/Studies
Has studies for Computer Science (Polish only): http://www.we.umg.edu.pl/specjalnosc/4238 and http://www.we.umg.edu.pl/specjalnosc/4237

Already in repo, just renaming domain.