### PR TITLE
Added PCVO Vormingsleergang voor Sociaal en Pedagogisch Werk Gent

### DIFF
--- a/lib/domains/be/vspw.txt
+++ b/lib/domains/be/vspw.txt
@@ -1,0 +1,1 @@
+PCVO Vormingsleergang voor Sociaal en Pedagogisch Werk Gent


### PR DESCRIPTION
PCVO VSPW - PCVO Vormingsleergang voor Sociaal en Pedagogisch Werk Gent
Website: www.vspw.be