### PR TITLE
Heinrich-Heine-Gymnasium Kaiserslautern

### DIFF
--- a/lib/domains/de/hhg-kl
+++ b/lib/domains/de/hhg-kl
@@ -1,0 +1,1 @@
+Staatliches Heinrich-Heine-Gymnasium Kaiserslautern


### PR DESCRIPTION
Added hhg-kl.de (Heinrich-Heine-Gymnasium [Heinrich-Heine-Highschool] Kaiserslautern)