### PR TITLE
Adding Mahanakorn University of Technology

### DIFF
--- a/lib/domains/com/mutacth.txt
+++ b/lib/domains/com/mutacth.txt
@@ -1,0 +1,2 @@
+มหาวิทยาลัยเทคโนโลยีมหานคร
+Mahanakorn University of Technology


### PR DESCRIPTION
University Name: Mahanakorn University of Technology
Main URL (different from e-mail domain): http://www.mut.ac.th/
IT related course URL: http://www.it.mut.ac.th/