### PR TITLE
Added Staatl. Heinrich-Heine-Gymnasium KL

### DIFF
--- a/lib/domains/de/hhg-kl.txt
+++ b/lib/domains/de/hhg-kl.txt
@@ -1,0 +1,1 @@
+Staatliches Heinrich-Heine-Gymnasium Kaiserslautern


### PR DESCRIPTION
Heinrich-Heine-Gymnasium is a German Highschool located in Kaiserslautern. It offers computer sience classes for students in grades 7 to 13. The classes last one year (grades 7 to 10) or three years (grades 11 to 13).
The PDF https://hhg-kl.de/images/stories/pdf/faecherinformationen/Informatik.pdf contains information about the way computer sience is lectured at Heinrich-Heine-Gymnasium.