### PR TITLE
Add Max Planck Institute for Brain Research

### DIFF
--- a/lib/domains/de/mpg/brain.txt
+++ b/lib/domains/de/mpg/brain.txt
@@ -1,0 +1,1 @@
+Max Planck Institute for Brain Research


### PR DESCRIPTION
The Max Planck Institute for Brain Research is part of the
"International Max Planck Research Schools" (IMPRS) program.

Relevant links
* Homepage: https://brain.mpg.de
* Educational program: https://brain.mpg.de/graduate-studies/edu.html