### PR TITLE
Queen Elizabeth School

### DIFF
--- a/lib/domains/org/qes.txt
+++ b/lib/domains/org/qes.txt
@@ -1,0 +1,1 @@
+Queen Elizabeth School

--- a/lib/domains/org/qes.txt
+++ b/lib/domains/org/qes.txt
@@ -1,1 +1,0 @@
-Queen Elizabeth School

--- a/lib/domains/org/uk/qes.txt
+++ b/lib/domains/org/uk/qes.txt
@@ -1,0 +1,1 @@
+Queen Elizabeth School


### PR DESCRIPTION
QES renamed their email from queenelizabeth.cumbria.sch.uk to qes.org.uk
