### PR TITLE
Add Otago Polytechnic

### DIFF
--- a/op.txt
+++ b/op.txt
@@ -1,0 +1,1 @@
+Otago Polytechnic


### PR DESCRIPTION
Otago Polytechnic is an academic institute of New Zealand.
URL: www.op.ac.nz
Thank you for adding this in the academic institution list