### PR TITLE
Revert "Added Galvanize to education list"

### DIFF
--- a/lib/domains/com/galvanize.txt
+++ b/lib/domains/com/galvanize.txt
@@ -1,1 +1,0 @@
-Galvanize


### PR DESCRIPTION
Reverts JetBrains/swot#3241, i.e. remove galvanize.com from the list.
Reason: Galvanize stop its MS Data Science Program.
Proof: https://www.quora.com/Why-did-Galvanize-stop-its-MS-Data-Science-Program-GalvanizeU
http://galvanizeu.newhaven.edu/