### PR TITLE
Added Veleučilište u Bjelovaru

### DIFF
--- a/lib/domains/hr/vub.txt
+++ b/lib/domains/hr/vub.txt
@@ -1,0 +1,2 @@
+Veleučilište u Bjelovaru
+Bjelovar University of Applied Sciences


### PR DESCRIPTION
University official website URL:
https://vub.hr

URL of a page on the official website where an IT-related long-term (>1 year) course is offered by the university:
https://vub.hr/strucni-studij-racunarstvo/