### PR TITLE
Add Universidad Católica de Murcia

### DIFF
--- a/lib/domains/edu/ucam.txt
+++ b/lib/domains/edu/ucam.txt
@@ -1,1 +1,1 @@
-Universidad CatÃ³lica San Antonio
+Universidad Católica San Antonio de Murcia

--- a/lib/domains/es/ucam.txt
+++ b/lib/domains/es/ucam.txt
@@ -1,0 +1,1 @@
+Universidad Católica San Antonio de Murcia

--- a/lib/domains/es/ucam.txt
+++ b/lib/domains/es/ucam.txt
@@ -1,1 +1,0 @@
-Universidad Católica San Antonio de Murcia


### PR DESCRIPTION
Add `ucam.edu` domain for Universidad Católica San Antonio, in Murcia, Spain

University URL: http://www.ucam.edu

Official IT-related Courses: 
* https://www.ucam.edu/estudios/grados/informatica-presencial - Bachelor's degree in Computer Science Engineering [*(English version)*](http://international.ucam.edu/studies/bachelor-in-computer-engineering-on-campus)
* https://www.ucam.edu/estudios/grados/sistemas-presencial - Bachelor's degree in Telecommunication Systems Engineering [*(English version)*](http://international.ucam.edu/studies/bachelor-in-telecommunications-engineering-on-campus)