### PR TITLE
Added colval.qc.ca

### DIFF
--- a/lib/domains/ca/qc/colval.txt
+++ b/lib/domains/ca/qc/colval.txt
@@ -1,0 +1,1 @@
+Collège de Valleyfield


### PR DESCRIPTION
-official website URL: [https://www.colval.qc.ca/](https://www.colval.qc.ca/)
-URL of a page where a long-term IT related course is offered: [https://www.colval.qc.ca/index.php/programmes-etudes/du-cegep/informatique](https://www.colval.qc.ca/index.php/programmes-etudes/du-cegep/informatique)
