### PR TITLE
Added Stedelijk Gymnasium Nijmegen

### DIFF
--- a/lib/domains/nl/stedelijkgymnijmegen.txt
+++ b/lib/domains/nl/stedelijkgymnijmegen.txt
@@ -1,0 +1,1 @@
+Stedelijk Gymnasium Nijmegen


### PR DESCRIPTION
Website: [https://stedelijkgymnijmegen.nl](https://stedelijkgymnijmegen.nl) (same domain)

Link to proof that course exists: [Page](https://www.scholenopdekaart.nl/Middelbare-scholen/2036/1087/Stedelijk-Gymnasium-Nijmegen/Examencijfers)
This pages lists the course 'Informatica' (translation: Informatics)

Acceptance of email domain: [Contact page of institute](https://www.stedelijkgymnijmegen.nl/contact): Shows the email domain used on their website
