### PR TITLE
Please add ipgp.fr

### DIFF
--- a/lib/domains/fr/ipgp.txt
+++ b/lib/domains/fr/ipgp.txt
@@ -1,0 +1,1 @@
+Institut de Physique du Globe de Paris


### PR DESCRIPTION
The Institut de Physique du Globe de Paris (IPGP; French for "Paris Institute of Earth Physics") is a French governmental, non-profit research and **higher education establishment** located in Paris, dedicated to the study of earth and planetary sciences by combining observations, laboratory analysis and construction of conceptual analogical and numerical models.

Web page: www.ipgp.fr

[This page](http://www.ipgp.fr/fr/master/international-master-in-solid-earth-sciences) shows that several IT related classes are given at Master level, for instance:

-  Inverse Problems & Signal Processing
-  Scientific Computing for Geophysical Problems
-  Advanced Numerical Modelling
-  Geophysical Data Acquisition

The `@ipgp.fr` domain is used for master students emails. Attached is a screenshot from an internal student database (sorry, only in French and no public link) where the card for an "M1" (Master 1) student is shown. I edited for privacy all sensitive data.

![ipgp_student_card](https://user-images.githubusercontent.com/1390993/52718385-9b1c2b00-2fa3-11e9-8c2b-889b5627439f.png)
