### PR TITLE
Adding carlsbadusd.net

### DIFF
--- a/lib/domains/net/carlsbadusd.txt
+++ b/lib/domains/net/carlsbadusd.txt
@@ -1,2 +1,2 @@
-carlsbadusd
+Carlsbad Unified School District
 .group

--- a/lib/domains/net/carlsbadusd.txt
+++ b/lib/domains/net/carlsbadusd.txt
@@ -1,0 +1,2 @@
+carlsbadusd
+.group


### PR DESCRIPTION
URL to official website: https://www.carlsbadusd.k12.ca.us/

URL to IT courses offered (different because it is a district email). Additionally, you need to click on the 2020 academic plan and ctrl f "computer science" which will list the computer science classes offered.: https://carlsbadhs.schoolloop.com/pf4/cms2/view_page?d=x&group_id=1530973341864&vdid=i13c2b1w8thb2id

URL proving that the school recognizes this email. My high school has the same email for students and teachers, but only teacher names are allowed to be listed: https://carlsbadhs.schoolloop.com/pf4/cms2/view_page?d=x&group_id=1530973342012&vdid=i13b51wythb4c0