### PR TITLE
Added St John's College

### DIFF
--- a/lib/domains/za/co/stjohnscollege.txt
+++ b/lib/domains/za/co/stjohnscollege.txt
@@ -1,0 +1,2 @@
+St John's College
+St John's College


### PR DESCRIPTION
St John's College, South Africa offers IT as a subject and is physically located in Houghton, Johannesburg.
https://www.stjohnscollege.co.za/