### PR TITLE
Add the Nelson Marlborough Institute of Technology

### DIFF
--- a/lib/domains/nz/ac/nmit/live.txt
+++ b/lib/domains/nz/ac/nmit/live.txt
@@ -1,0 +1,1 @@
+Nelson Marlborough Institute of Technology


### PR DESCRIPTION
A polytech in New Zealand, which offers several multi-year IT courses