### PR TITLE
Add file for pe.senai.br

### DIFF
--- a/lib/domains/br/senai/pe.txt
+++ b/lib/domains/br/senai/pe.txt
@@ -1,0 +1,1 @@
+Serviço Nacional de Aprendizagem Industrial - SENAI


### PR DESCRIPTION
PE represents the Brazilian state of Pernambuco. We would like to add this domain so the teachers and students from Pernambuco could have access to the free license of JetBrains products.