### PR TITLE
created hr/mef

### DIFF
--- a/lib/domains/hr/mef.txt
+++ b/lib/domains/hr/mef.txt
@@ -1,0 +1,2 @@
+Medicinski fakultet
+School of Medicine


### PR DESCRIPTION
* Official url:
hr version: http://mef.unizg.hr/
en version: http://mef.unizg.hr/en/

* Classes that use programming:
http://mef.unizg.hr/en/studies/class?studij=Medicina&kol=5503&kolegij=Medicinska%20informatika&semestar=10&pid=440
http://mef.unizg.hr/en/studies/class?studij=Medicina&kol=3403&kolegij=Medicinska%20statistika&semestar=10&pid=440
(more information about the classes is available *only* in hr version of the page)

* Recognizing the `@mef.hr` domain:
http://mef.unizg.hr/o-nama/ustroj/strucne-sluzbe/odsjek-za-informaticku-djelatnost
On this url there are a number of official email addresses that use the `@mef.hr` domain.