### PR TITLE
Poltava University of Economics and Trade

### DIFF
--- a/lib/domains/ua/edu/puet.txt
+++ b/lib/domains/ua/edu/puet.txt
@@ -1,0 +1,1 @@
+Poltava University of Economics and Trade

--- a/lib/domains/ua/edu/pusku.txt
+++ b/lib/domains/ua/edu/pusku.txt
@@ -1,1 +1,0 @@
-Poltava University of Consumer Cooperatives in Ukraine


### PR DESCRIPTION
Name and domain of university was changed from "Poltava University of Consumer Cooperatives in Ukraine" to "Poltava University of Economics and Trade".  http://en.puet.edu.ua/