### PR TITLE
Belarusian State University of Transport added

### DIFF
--- a/lib/domains/by/bsut.txt
+++ b/lib/domains/by/bsut.txt
@@ -1,0 +1,2 @@
+Белорусский государственный университет транспорта
+Belarusian State University of Transport


### PR DESCRIPTION
**Belarusian State University of Transport** is a non-profit public higher education institution located in Gomel (Republic of Belarus)
**Website:** [http://bsut.by](http://bsut.by)