### PR TITLE
Adding PWSZ Leszno

### DIFF
--- a/lib/domains/pl/edu/m.txt
+++ b/lib/domains/pl/edu/m.txt
@@ -1,2 +1,0 @@
-PWSZ im. J.A. Komeńskiego w Lesznie
-Jan Amos Komeński State School of Higher Vocational Education in Leszno

--- a/lib/domains/pl/edu/m.txt
+++ b/lib/domains/pl/edu/m.txt
@@ -1,0 +1,2 @@
+PWSZ im. J.A. Komeńskiego w Lesznie
+Jan Amos Komeński State School of Higher Vocational Education in Leszno

--- a/lib/domains/pl/edu/pwsz/student/m.txt
+++ b/lib/domains/pl/edu/pwsz/student/m.txt
@@ -1,0 +1,2 @@
+PWSZ im. J.A. Komeńskiego w Lesznie
+Jan Amos Komeński State School of Higher Vocational Education in Leszno


### PR DESCRIPTION
Jan Amos Komeński State School of Higher Vocational Education in Leszno, Poland
https://pwsz.edu.pl/index.php/en/
@m.student.pwsz.edu.pl