### PR TITLE
Added the teachers email domain for SintLucas.

### DIFF
--- a/lib/domains/nl/sintlucas.txt
+++ b/lib/domains/nl/sintlucas.txt
@@ -1,0 +1,1 @@
+SintLucas


### PR DESCRIPTION
Added the domain for teachers of SintLucas. The students already had the domain sintlucasedu.nl added but teachers have emails that use the sintlucas.nl domain.