### PR TITLE
Adding etu.Unidistance.ch

### DIFF
--- a/lib/domains/ch/unidistance/etu.txt
+++ b/lib/domains/ch/unidistance/etu.txt
@@ -1,0 +1,2 @@
+Unidistance / FernUni
+Unidistance


### PR DESCRIPTION
Adding the swiss university Unidistance (also named FernUni)
https://unidistance.ch/