### PR TITLE
add ara.txt

### DIFF
--- a/lib/domains/nz/ac/ara.txt
+++ b/lib/domains/nz/ac/ara.txt
@@ -1,0 +1,1 @@
+Ara Institute of Canterbury


### PR DESCRIPTION
add Ara Institute of Canterbury
The domain of this Institute is www.ara.ac.nz, and its student mail account domain is arastudent.ac.nz, and its teacher mail domain is ara.ac.nz 