### PR TITLE
Agregado IRICE (CONICET/ UNR) -Instituto Rosario de Investigaciones e…

### DIFF
--- a/lib/domains/ar/gov/irice-conicet.txt
+++ b/lib/domains/ar/gov/irice-conicet.txt
@@ -1,0 +1,1 @@
+IRICE (CONICET/ UNR) - Instituto Rosario de Investigaciones en Ciencias de la Educación


### PR DESCRIPTION
Added domain irice-conicet.gov.ar

The domain belongs to the Instituto Rosario de Investigaciones en Ciencias de la Educación.
The institute depends of Conicet
http://www.irice-conicet.gov.ar