### PR TITLE
Added CQUniversity to domain list.

### DIFF
--- a/lib/domains/au/com/cqumail.txt
+++ b/lib/domains/au/com/cqumail.txt
@@ -1,0 +1,1 @@
+CQUniversity [https://www.cqu.edu.au/]


### PR DESCRIPTION
- Link to University [https://www.cqu.edu.au/](url)
- Email Domain cqumail.com or cqumail.com.au
