### PR TITLE
Added Ballakermeen High School

### DIFF
--- a/lib/domains/im/sch/online.txt
+++ b/lib/domains/im/sch/online.txt
@@ -1,0 +1,1 @@
+Ballakermeen High School


### PR DESCRIPTION
Ballakermeen High School is a Secondary School located on the Isle of Man.

All manx schools use "@online.sch.im" emails for their school accounts.