### PR TITLE
Adding The Hang Seng University of Hong Kong

### DIFF
--- a/lib/domains/hk/edu/hsu.txt
+++ b/lib/domains/hk/edu/hsu.txt
@@ -1,1 +1,0 @@
-The Hang Seng University of Hong Kong

--- a/lib/domains/hk/edu/hsu.txt
+++ b/lib/domains/hk/edu/hsu.txt
@@ -1,0 +1,1 @@
+The Hang Seng University of Hong Kong


### PR DESCRIPTION
[The Hang Seng University of Hong Kong](https://www.hsu.edu.hk/en/) is the second private university in Hong Kong and also have offer 4-year degree programmes regarding to IT. See [here](https://www.hsu.edu.hk/en/academics/).

Their email address domain is hsu.edu.hk (Note they used hsmc.edu.hk before but since the have status upgraded to university, it became hsu.edu.hk instead)
See [https://itsc.hsu.edu.hk/user-services/account-service/](https://itsc.hsu.edu.hk/user-services/account-service/)

