### PR TITLE
Add Cegep de la Gaspesie et des Iles

### DIFF
--- a/lib/domains/ca/cegepgim.txt
+++ b/lib/domains/ca/cegepgim.txt
@@ -1,0 +1,1 @@
+Cégep de la Gaspésie et des Îles


### PR DESCRIPTION
Adding Cégep de la Gaspésie et des Îles to allowed domains.

Official website (Montreal Campus website): http://www.cegepgim.ca/montreal/
IT programs: http://www.cegepgim.ca/montreal/certifications/technology
Contact info as proof of email domain: http://www.cegepgim.ca/montreal/contact.php 

Cheers and thanks to the whole team!