### PR TITLE
Adding "ibs-ol.de" IBS IT & Business School Oldenburg

### DIFF
--- a/lib/domains/de/ibs-ol.txt
+++ b/lib/domains/de/ibs-ol.txt
@@ -1,0 +1,2 @@
+IBS IT & Business School Oldenburg e. V.
+Berufsakademie für IT & Wirtschaft Oldenburg


### PR DESCRIPTION
Added the domain "ibs-ol.de" for the IBS IT & Business School Oldenburg e. V. ([Website](https://ibs-ol.de/)). IBS offers long-term (3.5 years) economic computer science courses (see [https://www.ibs-ol.de/studium/duales-studium-wirtschaftsinformatik/](https://www.ibs-ol.de/studium/duales-studium-wirtschaftsinformatik/)).

This domain is used for email addresses of professors. Students use the subdomain "student.ibs-ol.de", so they are included.

Please let me know if you need anything else. Thank you! 