### PR TITLE
Added utcw.co.uk

### DIFF
--- a/lib/domains/uk/co/utcw.txt
+++ b/lib/domains/uk/co/utcw.txt
@@ -1,0 +1,1 @@
+UTC Warrington


### PR DESCRIPTION
School Name: UTC Warrington
Website: https://utcw.co.uk/
IT Related Course: https://utcw.co.uk/sixth-form-curriculum/ [SEE Cyber Pathway]
Evidence:
![img](https://user-images.githubusercontent.com/30216679/59044813-bb376900-8876-11e9-9008-fd6134ce1e61.png)
