### PR TITLE
Added Rotkreuz-Institut Berufsbildungswerk

### DIFF
--- a/lib/domains/de/bbw-rki-berlin.txt
+++ b/lib/domains/de/bbw-rki-berlin.txt
@@ -1,0 +1,3 @@
+Rotkreuz-Institut Berufsbildungswerk
+Homepage:https://www.rkibbw.de/
+IT-Course example: https://www.rkibbw.de/angebote/berufsausbildung/fachinformatiker-anwendungsentwicklung.html


### PR DESCRIPTION
official website: https://www.rkibbw.de/
URL of a page where a long-term (>1 year) IT related course is offered: https://www.rkibbw.de/angebote/berufsausbildung/fachinformatiker-anwendungsentwicklung.html

URL of a page showing that the community college recognizes the domain as an official email domain for the enrolled students and staff: https://www.rkibbw.de/angebote/berufsschule.html. The email addresses is shown on the right side under "Kontakt".

Thanks in advance.