### PR TITLE
+ school La Bruyère Sainte Isabell, Paris, France

### DIFF
--- a/lib/domains/fr/lbsi14.txt
+++ b/lib/domains/fr/lbsi14.txt
@@ -1,0 +1,1 @@
+La Bruyère Sainte Isabelle


### PR DESCRIPTION
Please add my school, the school website is https://labruyeresainteisabelle.fr/ and our mails use the lbsi14.fr domain.