### PR TITLE
Berufskolleg Hilden des Kreises Mettmann

### DIFF
--- a/lib/domains/de/berufskolleg.txt
+++ b/lib/domains/de/berufskolleg.txt
@@ -1,0 +1,2 @@
+Berufskolleg Hilden des Kreises Mettmann
+Berufskolleg Hilden

--- a/lib/domains/de/berufskolleg/schueler.txt
+++ b/lib/domains/de/berufskolleg/schueler.txt
@@ -1,0 +1,2 @@
+Berufskolleg Hilden
+Berufskolleg Hilden des Kreises Mettmann


### PR DESCRIPTION
Name of the University:
Berufskolleg Hilden des Kreises Mettmann
(Berufskolleg Hilden) 

Official Link:
https://www.berufskolleg.de/

Links with IT related course:
https://www.berufskolleg.de/it/start
https://www.berufskolleg.de/ita/start
https://www.berufskolleg.de/itb/start
https://www.berufskolleg.de/it/fachinformatiker/fiae
