### PR TITLE
create Chiba University of Commerce

### DIFF
--- a/lib/domains/com/ciiri/cuc.txt
+++ b/lib/domains/com/ciiri/cuc.txt
@@ -1,0 +1,2 @@
+千葉商科大学
+Chiba University of Commerce


### PR DESCRIPTION
Name of the University:
Chiba University of Commerce

Official Link:
https://www.cuc.ac.jp/