### PR TITLE
Added ksbg.ch

### DIFF
--- a/lib/domains/ch/ksbg.txt
+++ b/lib/domains/ch/ksbg.txt
@@ -1,0 +1,1 @@
+Kantonsschule am Burggraben St. Gallen


### PR DESCRIPTION
Name: Kantonsschule am Burggraben St. Gallen
Website: https://www.ksbg.ch
English landing page: https://www.ksbg.ch/sprachen/en/ (no other pages translated)
Course: https://www.ksbg.ch/portraet/faecher/fachgruppen/informatik/fg-informatik/
Education level: High school or equivalent
Email format: firstname.lastname@ksbg.ch