### PR TITLE
Add this school to the list, please

### DIFF
--- a/ltpsaintjoseph.txt
+++ b/ltpsaintjoseph.txt
@@ -1,0 +1,1 @@
+LTP Saint Joseph


### PR DESCRIPTION
Saint Joseph High School, 
26 Route de Calais, 62280 Saint-Martin-Boulogne, FRANCE