### PR TITLE
Added TH OWL

### DIFF
--- a/lib/domains/de/th-owl.txt
+++ b/lib/domains/de/th-owl.txt
@@ -1,0 +1,2 @@
+Technische Hochschule Ostwestfalen-Lippe
+OWL University of Applied Sciences


### PR DESCRIPTION
It is the new name of the former Hochschule Ostwestfalen-Lippe (HS OWL), which already is part of this repo.