### PR TITLE
Add definition for ibw-schule.ch

### DIFF
--- a/lib/domains/ch/ibw-schule.txt
+++ b/lib/domains/ch/ibw-schule.txt
@@ -1,0 +1,1 @@
+Hohere Fachschule Sudostschweiz


### PR DESCRIPTION
**Institution/School Name**
ibW Hohere Fachschule Sudostschweiz

**Instiution/School Website**

[https://ibw.ch](https://ibw.ch)

**Email Users**
_Please place an x between the square brackets if yes_

- [x] Students
- [x] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

**Education Levels**

_Please place an x between the square brackets if yes_

- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent

**Example course**
[https://www.ibw.ch/angebote/technik-informatik/informatik/dipl-techniker-in-hf-informatik/](https://www.ibw.ch/angebote/technik-informatik/informatik/dipl-techniker-in-hf-informatik/)
\> [Flyer](https://www.ibw.ch/fileadmin/user_upload/customers/ibw/Dokumente/Broschueren/Technik_Informatik/ibW_Flyer_HF-Informatik.pdf)

**Additional info**
The official website is [ibw.ch](https://ibw.ch). For the domain ibw-schule.ch there isn't much public information available (most of it is kept on an intranet), except that the official Citrix remote access documented on the [official website](https://www.ibw.ch/schul-betrieb/schulbetrieb/links-schulbetrieb/) is hosted on a subdomain (citrix.ibw-schule.ch) and the whois information available at [https://www.nic.ch/whois/](https://www.nic.ch/whois/) clearly denotes, that the domain belongs to the ibW.
