### PR TITLE
Add Escuela Virgen de Guadalupe

### DIFF
--- a/lib/domains/es/evg/correo.txt
+++ b/lib/domains/es/evg/correo.txt
@@ -1,0 +1,1 @@
+Escuela Virgen de Guadalupe


### PR DESCRIPTION
Add Escuela Virgen de Guadalupe, Badajoz (Spain).

School link: www.evg.es