### PR TITLE
Add LRCCD (apps.losrios.edu)

### DIFF
--- a/lib/domains/edu/losrios/apps.txt
+++ b/lib/domains/edu/losrios/apps.txt
@@ -1,0 +1,8 @@
+Los Rios Community College District
+=======
+American River College
+Cosumnes River College
+Folsom Lake College
+Sacramento City College
+.group
+


### PR DESCRIPTION
Hello! This is the same as #4919 except instead of `losrios.edu`, it is `apps.losrios.edu`.

> Hi there. Would like to add the Los Rios Community College District (California).
> 
> losrios.edu
> 
> * http://www.losrios.edu/
> 
> American River College
> 
> * http://www.arc.losrios.edu/
> * http://www.arc.losrios.edu/Documents/Catalog_PDFs/ComputerInfoSci.pdf
> 
> Consumnes River College
> 
> * http://crc.losrios.edu/
> * http://crc.losrios.edu/catalog/areas/cis
> 
> Folsom Lake College
> 
> * http://flc.losrios.edu/
> * http://www.flc.losrios.edu/academics/computer-information-science/cis-degrees-and-certificates
> 
> Sacramento City College
> 
> * http://scc.losrios.edu/
> * https://www.scc.losrios.edu/cis/
> 
> Thanks.