### PR TITLE
Add American River College - Los Rios Community College District.

### DIFF
--- a/lib/domains/edu/losrios/apps.txt
+++ b/lib/domains/edu/losrios/apps.txt
@@ -1,0 +1,1 @@
+American River College - Los Rios Community College District


### PR DESCRIPTION
Add American River College - Los Rios Community College District.
Website: https://losrios.edu/
Google Maps: https://goo.gl/maps/RgtdAbAqHDrogMuF9
Courses: https://losrios.edu/academics/programs-and-majors
