### PR TITLE
Fix misspelling in kth.se

### DIFF
--- a/lib/domains/se/kth.txt
+++ b/lib/domains/se/kth.txt
@@ -1,1 +1,1 @@
-Royal lnstitute of Technology
+Royal Institute of Technology


### PR DESCRIPTION
The Royal Institute is currently referred to as a "lnstitute", this just fixes the misspelling