### PR TITLE
Add NIT Rourkela

### DIFF
--- a/lib/domains/in/ac/nitrkl.txt
+++ b/lib/domains/in/ac/nitrkl.txt
@@ -1,0 +1,1 @@
+National Institute Of Technology Rourkela


### PR DESCRIPTION
Add National Institute of Technology Rourkela (nitrkl.ac.in) domain.