### PR TITLE
Add University of Tsukuba, Japan (tsukuba.ac.jp)

### DIFF
--- a/lib/domains/jp/ac/tsukuba.txt
+++ b/lib/domains/jp/ac/tsukuba.txt
@@ -1,0 +1,1 @@
+University of Tsukuba


### PR DESCRIPTION
This PR adds "University of Tsukuba" in Japan.
Here is the official website of the university: <http://www.tsukuba.ac.jp/en/>

Thank you.