### PR TITLE
Add Virginia's Community Colleges

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,4 @@
+Virginia's Community Colleges
+Lord Fairfax Community College
+Central Virginia Community College
+.group


### PR DESCRIPTION
Virginia's Community Colleges includes 23 community colleges including my college - Lord Fairfax Community College (https://i.imgur.com/qhnwEss.png)

The university official website URL:
https://www.apply.vccs.edu/
https://lfcc.edu/

URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
https://lfcc.edu/degree/computer-science-specialization/
https://centralvirginia.edu/Programs-Classes/Science,-Technology,-Engineering,-and-Math/Computer-and-Electronic-Technology-Computer-Netw