### PR TITLE
Add domain email.vccs.edu

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,1 @@
+Virginia's Community Colleges


### PR DESCRIPTION
School Name: Virginia's Community Colleges
Website: http://www.vccs.edu
The domain is: @email.vccs.edu