### PR TITLE
Add Tarrant County College domain.

### DIFF
--- a/lib/domains/edu/tccd/my.txt
+++ b/lib/domains/edu/tccd/my.txt
@@ -1,0 +1,1 @@
+Tarrant County College


### PR DESCRIPTION
Add tccd.edu as Tarrant County College domain.