### PR TITLE
Create cna-qatar.txt

### DIFF
--- a/lib/domains/qa/edu/cna-qatar.txt
+++ b/lib/domains/qa/edu/cna-qatar.txt
@@ -1,0 +1,1 @@
+College of the North Atlantic


### PR DESCRIPTION
College of the North Atlantic, Qatar, uses the domain @cna-qatar.edu.qa

3-year software course: https://www.cna-qatar.com/programs/SchoolofInformationTechnology/WebDeveloper

Sample college emails: https://www.cna-qatar.com/aboutcnaq/campusinformation