### PR TITLE
Update and rename iespaucasesnoves.txt to paucasesnovescifp.txt

### DIFF
--- a/lib/domains/cat/iespaucasesnoves.txt
+++ b/lib/domains/cat/iespaucasesnoves.txt
@@ -1,1 +1,0 @@
-IES Pau Casesnoves

--- a/lib/domains/cat/paucasesnovescifp.txt
+++ b/lib/domains/cat/paucasesnovescifp.txt
@@ -1,0 +1,1 @@
+CIFP Pau Casesnoves


### PR DESCRIPTION
The name of the school has changed and now is CIFP Pau Casesnoves and its new domain is paucasesnovescifp.cat

Website: http://paucasesnovescifp.cat (the old website http://iespaucasesnoves.cat has a link pointing here)

Courses urls: 

- https://paucasesnovescifp.cat/?page_id=1249

- https://paucasesnovescifp.cat/?page_id=1402

Thank you!