### PR TITLE
Add King's College School Wimbledon

### DIFF
--- a/lib/domains/uk/org/kcs.txt
+++ b/lib/domains/uk/org/kcs.txt
@@ -1,0 +1,1 @@
+King's College School Wimbledon


### PR DESCRIPTION
KCSW is a private school in South London, and it does go through Sixth Form (ages 16-18).
School website: https://www.kcs.org.uk/
Email domain usage: https://www.kcs.org.uk/useful-information/contact