### PR TITLE
Olathe Public Schools USD 233

### DIFF
--- a/lib/domains/org/olatheschools.txt
+++ b/lib/domains/org/olatheschools.txt
@@ -1,0 +1,1 @@
+Olathe Public Schools USD 233


### PR DESCRIPTION
An entry already exists for Olathe Public Schools at "/lib/domains/com/olatheschools/students.txt" however, that is the domain used for students. This is the domain used by educators.