### PR TITLE
Tech Valley High School, Albany NY USA

### DIFF
--- a/lib/domains/org/techvalleyhigh.txt
+++ b/lib/domains/org/techvalleyhigh.txt
@@ -1,0 +1,1 @@
+Tech Valley High School


### PR DESCRIPTION
This is the domain for Tech Valley High School, in Albany NY.

Additional info requested:

1. Official URL (Same as PR): https://www.techvalleyhigh.org
2. Link to Courses Offered https://www.techvalleyhigh.org/course-catalog/ -- As this is a HS Computer Science (now in both Python for 11th grade, and Java for 12th grade) is offered, but listed together as "Computer Science". (Page pending updates for this fall's courses.)
3. Unfortunately we don't have a page that lists that students will get email addresses on this domain (tho they do). As they are minors and HS students it's not something the school advertises. If needed I can get a letter on school letterhead to that effect.