### PR TITLE
Additions and Changes - APSVA

### DIFF
--- a/lib/domains/us/apsva.txt
+++ b/lib/domains/us/apsva.txt
@@ -1,1 +1,2 @@
 Washington-Lee High School
+Arlington Career Center

--- a/lib/domains/us/apsva.txt
+++ b/lib/domains/us/apsva.txt
@@ -1,2 +1,2 @@
-Washington-Lee High School
+Washington-Liberty High School
 Arlington Career Center


### PR DESCRIPTION
This changes the name of Washington-Lee to Washington-Liberty as seen here:[https://www.apsva.us/post/new-school-names-and-buildings-for-the-2019-20-school-year/](url)
This also adds the Arlington Career Center to the list.
