### PR TITLE
Trying to add Arapahoe High School to the accepted list of schools. T…

### DIFF
--- a/lib/domains/org/lpsk12.txt
+++ b/lib/domains/org/lpsk12.txt
@@ -1,0 +1,2 @@
+Arapahoe High School
+Arapahoe High School


### PR DESCRIPTION
…he domain lpsk12.org is the domain the the student use. The domain the the faculty and staff use is lps.k12.co.us.

The home page for Arapahoe High School is https://littletonpublicschools.net/schools/arapahoe-high-school.

The home page for the Littleton Public School district is https://littletonpublicschools.net.