### PR TITLE
Adding bcw-gruppe-net

### DIFF
--- a/lib/domains/de/bcw-gruppe-net.txt
+++ b/lib/domains/de/bcw-gruppe-net.txt
@@ -1,0 +1,1 @@
+bcw-gruppe-net


### PR DESCRIPTION
Adding the domain bcw-gruppe-net.de (Domain from FOM Hochschule für Oekonomie und Management)