### PR TITLE
Added Tudor Grange Academy Solihull

### DIFF
--- a/lib/domains/uk/org/tgacademy/solihull.txt
+++ b/lib/domains/uk/org/tgacademy/solihull.txt
@@ -1,0 +1,1 @@
+Tudor Grange Academy Solihull


### PR DESCRIPTION
Main website: https://solihull.tgacademy.org.uk

It is both a secondary school and a sixth form (11-16, 16-18) and offer Computer Science for both