### PR TITLE
merge Telemark and Vestfold County into "Vestfold and Telemark County"

### DIFF
--- a/lib/domains/no/t-fk.txt
+++ b/lib/domains/no/t-fk.txt
@@ -1,1 +1,0 @@
-Porsgrunn Videregaende Skole

--- a/lib/domains/no/vfk.txt
+++ b/lib/domains/no/vfk.txt
@@ -1,1 +1,0 @@
-Vestfold Fylkeskommune

--- a/lib/domains/no/vtfk.txt
+++ b/lib/domains/no/vtfk.txt
@@ -1,0 +1,1 @@
+Vestfold og Telemark Fylkeskommune


### PR DESCRIPTION
While Telemark and Vestfold County is not offically merging until the first of January all accounts were moved into a dedicated domain this summer, so both t-fk.no and vfk.no are now defunct. 

All students and teachers in both counties have been moved onto the new domain: `vtfk.no`.

The teaches have their mails on `*@vtfk.no` and students on `*@skole.vtfk.no`