### PR TITLE
add Kantonsschule am Brühl

### DIFF
--- a/lib/domains/ch/ksb-sg.txt
+++ b/lib/domains/ch/ksb-sg.txt
@@ -1,0 +1,1 @@
+Kantonsschule am Brühl


### PR DESCRIPTION
Kantonsschule am Brühl offers a 4 year CS course called IMS (Informatikmittelschule) which roughly translates to "Computer Science Highschool". 

Link to the School: https://ksb-sg.ch/
Link to the CS course in particular: https://ksb-sg.ch/ims/allgemein/

List of staff with Email adresses for proof that the domain belongs to the School: 
https://ksb-sg.ch/portrait/lehrerschaft/