### PR TITLE
Create mopipi.txt

### DIFF
--- a/lib/domains/bw/ub/mopipi.txt
+++ b/lib/domains/bw/ub/mopipi.txt
@@ -1,0 +1,1 @@
+University of Botswana


### PR DESCRIPTION
University of Botswana of Botswana has a separate subdomain for staff. Students are on ub.ac.bw , Staff on mopipi.ub.bw