### PR TITLE
Adding Zaporizhzhya Institute of Economics and Information Technology

### DIFF
--- a/lib/domains/ua/edu/zieit.txt
+++ b/lib/domains/ua/edu/zieit.txt
@@ -1,0 +1,1 @@
+Zaporizhzhya Institute of Economics and Information Technology

--- a/lib/domains/ua/zp/econom.txt
+++ b/lib/domains/ua/zp/econom.txt
@@ -1,0 +1,1 @@
+Zaporizhzhya Institute of Economics and Information Technology


### PR DESCRIPTION
The institute official website URLs:
    Old commercial domain: http://econom.zp.ua/
    New government domain: https://zieit.edu.ua/
A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the institute:
    https://zieit.edu.ua/?page_id=213
A URL of a page showing that the institute recognizes the domain which you are submitting as an official email domain:
    https://www.zieit.edu.ua/?page_id=283

You can choose English in the footer of the websites. Just look for "Мова" there and choose an option "англійська".