### PR TITLE
updated name

### DIFF
--- a/lib/domains/cz/mendelu.txt
+++ b/lib/domains/cz/mendelu.txt
@@ -1,1 +1,1 @@
-Mendel University of Agriculture and Forestry
+Mendel University in Brno


### PR DESCRIPTION
The correct name of the University is "Mendel University in Brno". The "Mendel University of Agriculture and Forestry" is old naming.