### PR TITLE
add Jiangxi Vocational College of Finance and Economis

### DIFF
--- a/lib/domains/cn/jx/jxvc.txt
+++ b/lib/domains/cn/jx/jxvc.txt
@@ -1,0 +1,2 @@
+江西财经职业学院
+Jiangxi Vocational College of Finance and Economis


### PR DESCRIPTION
add Jiangxi Vocational College of Finance and Economis

School website：[www.jxvc.cn](http://www.jxvc.jx.cn/)

School courses lists: [http://www.jxvc.jx.cn/zsjy/zszy.htm](http://www.jxvc.jx.cn/zsjy/zszy.htm)
![Snipaste_2019-10-04_22-08-08.png](https://i.loli.net/2019/10/04/PUzBVFaO8Thx29j.png)


Official email domain for the enrolled students `318255030110@st.jxvc.jx.cn` :
![official email domain for the enrolled students.](https://i.loli.net/2019/10/04/W15EBaVUJZf73zw.png)