### PR TITLE
Added Openbaar Onderwijs Zwolle

### DIFF
--- a/lib/domains/nl/ooz.txt
+++ b/lib/domains/nl/ooz.txt
@@ -1,0 +1,2 @@
+Openbaar Onderwijs Zwolle
+.group


### PR DESCRIPTION
This is a request in addition to the existing record: capellen.txt
The ooz.nl domain is used by us, new teachers.
See also https://ooz.nl/onze-scholen/van-der-capellen/