### PR TITLE
Add hri.res.in

### DIFF
--- a/lib/domains/in/res/hri.txt
+++ b/lib/domains/in/res/hri.txt
@@ -1,0 +1,1 @@
+Harish-Chandra Research Institute


### PR DESCRIPTION
* lib/domains/in/res/hri.txt: New file.  Adds the domain of
  Harish-Chandra Research Institute (HRI), Allahabad, India.

Information that may be relevant:

- The [official Web site](http://www.hri.res.in/) of HRI.
- HRI runs a  [doctoral program in mathematics (five years or longer)](http://www.hri.res.in/~math/mathgradp/), and [masters (two years) and doctoral programs (five years or longer) in theoretical physics](http://www.hri.res.in/~physgradp/).
- The graduate study and  research areas at HRI include cryptography, and [quantum information and computing ](http://www.hri.res.in/~qic/).
