### PR TITLE
adding Virginia Community College System

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,25 @@
+Virginia Community College System
+Blue Ridge Community College
+Central Virginia Community College
+Dabney S. Lancaster Community College
+Danville Community College
+Eastern Shore Community College
+Germanna Community College
+J. Sargeant Reynolds Community College
+John Tyler Community College
+Lord Fairfax Community College
+Mountain Empire Community College
+New River Community College
+Northern Virginia Community College
+Patrick Henry Community College
+Paul D. Camp Community College
+Piedmont Virginia Community College
+Rappahannock Community College
+Southside Virginia Community College
+Southwest Virginia Community College
+Thomas Nelson Community College
+Tidewater Community College
+Virginia Highlands Community College
+Virginia Western Community College
+Wytheville Community College
+.group


### PR DESCRIPTION
Virginia Community College System has multiple colleges that use `email.vccs.edu` as their email domain.
- web: http://www.vccs.edu
- NVCC (https://nvcc.edu) is one of the community colleges in the system.
- CS program url: https://catalog.nvcc.edu/preview_program.php?catoid=2&poid=194&returnto=62

![Screenshot_101719_062119_PM](https://user-images.githubusercontent.com/17791499/67052379-fd699480-f10b-11e9-8309-9d699f5fb793.jpg)