### PR TITLE
Add domain of The Academic College of Tel Aviv-Yaffo

### DIFF
--- a/lib/domains/il/ac/mta.txt
+++ b/lib/domains/il/ac/mta.txt
@@ -1,0 +1,5 @@
+The Academic College of Tel Aviv-Yaffo
+
+The Academic College of Tel Aviv-Yaffo (MTA)
+
+המכללה האקדמית תל אביב-יפו


### PR DESCRIPTION
- The [School of Computer Science](https://www.int.mta.ac.il/school-of-computer-science) offers B.Sc in Computer Science (>= 3 years)
  and the [School of Economics and Management](https://www.int.mta.ac.il/school-of-economics-and-management) offers B.Sc in Information
  Systems (>= 3 years).
- All [academic staff](https://www.mta.ac.il/he-il/about_us/staff) and students emails are using @mta.ac.il domain.