### PR TITLE
at/htl-saalfelden.txt

### DIFF
--- a/lib/domains/at/htl-saalfelden.txt
+++ b/lib/domains/at/htl-saalfelden.txt
@@ -1,0 +1,1 @@
+Höhere Technische Bundeslehranstalt Saalfelden am Steinernen Meer


### PR DESCRIPTION
Höhere Technische Bundeslehranstalt Saalfelden am Steinernen Meer

http://www.htl-saalfelden.at/ITFachschule.html
