### PR TITLE
GSO-BK-Cologne

### DIFF
--- a/lib/domains/koeln/schule.txt
+++ b/lib/domains/koeln/schule.txt
@@ -1,0 +1,2 @@
+Georg-Simon-Ohm-Berufskolleg
+Georg-Simon-Ohm-Vocational College


### PR DESCRIPTION
Added the Georg-Simon-Ohm Berufskolleg in Cologne.