### PR TITLE
Add King Edwards VI School, Stratford

### DIFF
--- a/lib/domains/net/kes.txt
+++ b/lib/domains/net/kes.txt
@@ -1,0 +1,1 @@
+King Edwards VI School, Stratford


### PR DESCRIPTION
Domain:
...@kes.net

[Institution Website](http://kes.net)

As a sixth form and secondary school based in Stratford, UK, the school offers both GCSE and A-Level computing courses, which are each over 1 year in study duration. The institution is a physical entity with student attendance and is recognized as providing a learning curriculum for the UK educational system. 