### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,1 @@
+Tidewater Community  College


### PR DESCRIPTION
https://www.tcc.edu/programs/career-pathways/computer-science-it/
I am uncertain where to find a link stating that .email.vccs.edu is a valid email for the school but .tcc.edu is only for staff members. Students all share the email domain with other vccs (Virginia Community College System) schools. 