### PR TITLE
add the domain for University of South Wales (prifysgol De Cymru)

### DIFF
--- a/lib/domains/cymru/edu/usw.txt
+++ b/lib/domains/cymru/edu/usw.txt
@@ -1,0 +1,2 @@
+ University of South Wales (prifysgol De Cymru)
+ University of South Wales


### PR DESCRIPTION
add the domain for University of South Wales (prifysgol De Cymru)