### PR TITLE
new domain for bict

### DIFF
--- a/lib/domains/ch/bict.txt
+++ b/lib/domains/ch/bict.txt
@@ -1,0 +1,1 @@
+BiCT AG, Die Berufsbildner


### PR DESCRIPTION
Dear Master
the BiCT is an educational institute in the field of computer science and multimedia education. More than 200 apprentices in these area are between 1 and 4 years in study and learn the ict handcraft. I was in contact with Natalia Kuznetsova (Sales) and she gives me a teachers (e*****.b****@bict.ch) license. But we need the students licenses for all of our developer students. 
Thanks a lot for your acceptance.
Kind regards
Enrico

