### PR TITLE
Add Additional Fulton Country Schools (FCS) Domain

### DIFF
--- a/lib/domains/org/fcs.txt
+++ b/lib/domains/org/fcs.txt
@@ -1,0 +1,1 @@
+Fulton County Schools

--- a/lib/domains/org/fcs.txt
+++ b/lib/domains/org/fcs.txt
@@ -1,1 +1,0 @@
-Fulton County Schools

--- a/lib/domains/org/fcstu.txt
+++ b/lib/domains/org/fcstu.txt
@@ -1,0 +1,1 @@
+Fulton County Schools


### PR DESCRIPTION
Fulton County Schools (Already approved under fultonschools.txt) has an additional domain (fcstu.org for students)