### PR TITLE
Create nsd131.txt

### DIFF
--- a/lib/domains/org/nsd131.txt
+++ b/lib/domains/org/nsd131.txt
@@ -1,0 +1,2 @@
+Columbia High School
+.group


### PR DESCRIPTION
added .group to nsd131.txt to include Nampa School District

Active websites are https://www.nsd131.org/ which is for the district level
https://columbiahigh.nsd131.org/ is for Columbia High School
Visit https://columbiahigh.nsd131.org/apps/staff/ to find my listing under Robert Hibbard
I am listed as the IT/Business Teacher. I am part of the CTE program. I teach two Pathway programs. Desktop Support and Programming and Software Development.
You can view my credentials at https://apps2.sde.idaho.gov/CertificationLookup/Search
There is two Robert Hibbard's, of course mine is the Nampa School District(131).