### PR TITLE
Add Virginia's Community Colleges Domain

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,2 @@
+Virginia's Community Colleges
+Virginia's Community Colleges


### PR DESCRIPTION
Add Virginia's Community Colleges mail domain
Virginia's Community Colleges were created in 1966

this domain brings together 23 colleges on 40 campuses across the Commonwealth, Virginia’s Community Colleges offer many educational choices, including many information technology related courses.
 
About link
http://www.vccs.edu/about/

Related TI courses:
https://courses.vccs.edu/programs/11.0701-Computer%20Science

https://courses.vccs.edu/programs/major/299-18.Information%20Systems%20Technology%20(Programming%20and%20Mobile%20Applications%20Development)