### PR TITLE
integration of th-ab.de

### DIFF
--- a/lib/domains/de/th-ab.txt
+++ b/lib/domains/de/th-ab.txt
@@ -1,0 +1,2 @@
+Technische Hochschule Aschaffenburg
+University of applied sciences Aschaffenburg


### PR DESCRIPTION
for the university of applied sciences Aschaffenburg/ Technische Hochschule Aschaffenburg
the Faculty that is having mandatory computer science modules is the engineering one(IW Fakultät). You can visit the offical website under www.th-ab.de. The engineering courses available can be seen under https://www.th-ab.de/ueber-uns/organisation/fakultaeten/ingenieurwissenschaften/. The fact that @th-ab.de is the domain for this institution can be seen under https://helpdesk.th-ab.de/otrs/customer.pl?Action=CustomerFAQZoom;ItemID=331.