### PR TITLE
Lycée Louis Pergaud - Besançon

### DIFF
--- a/lib/domains/fr/lyceepergaud
+++ b/lib/domains/fr/lyceepergaud
@@ -1,0 +1,1 @@
+Lycée Louis Pergaud - Besançon

--- a/lib/domains/fr/lyceepergaud
+++ b/lib/domains/fr/lyceepergaud
@@ -1,1 +1,0 @@
-Lycée Louis Pergaud - Besançon

--- a/lib/domains/fr/lyceepergaud.txt
+++ b/lib/domains/fr/lyceepergaud.txt
@@ -1,0 +1,1 @@
+Lycée Louis Pergaud - Besançon


### PR DESCRIPTION
Lycée Louis Pergaud 
91-93 boulevard Léon BLum
25000 Besançon
France
www.lyceepergaud.fr
https://www.lyceepergaud.fr/wp-content/uploads/2011/11/Plaq-INFORM.pdf