### PR TITLE
Add domain egb-koeln.de

### DIFF
--- a/lib/domains/de/egb-koeln.txt
+++ b/lib/domains/de/egb-koeln.txt
@@ -1,0 +1,2 @@
+Erich-Gutenberg Berufskolleg 
+


### PR DESCRIPTION
Long term IT course on official website: 
https://www.egb-koeln.de/index.php/bildungsgaenge/it-systemkaufleute-informatikkaufleute

Proof school recognizes domain: 
https://www.egb-koeln.de/index.php/adressen-ansprechpartner

Thank you!