### PR TITLE
Request to add RSG Pantarijn

### DIFF
--- a/lib/domains/nl/pantarijn/live.txt
+++ b/lib/domains/nl/pantarijn/live.txt
@@ -1,0 +1,1 @@
+RSG Pantarijn


### PR DESCRIPTION
High school RSG Pantarijn has the option to follow computer science classes from year four till six.
Website of the school: https://www.pantarijn.nl/
Special website where the students follow their computer science lessons: https://codepanta.nl/