### PR TITLE
Add domains for schools located in and near Logan, UT, USA

### DIFF
--- a/lib/domains/org/ccsdut.txt
+++ b/lib/domains/org/ccsdut.txt
@@ -1,0 +1,1 @@
+Cache County School District

--- a/lib/domains/org/ccsdut/stu.txt
+++ b/lib/domains/org/ccsdut/stu.txt
@@ -1,0 +1,1 @@
+Cache County School District

--- a/lib/domains/org/loganschools.txt
+++ b/lib/domains/org/loganschools.txt
@@ -1,0 +1,1 @@
+Logan High School


### PR DESCRIPTION
Please add loganschools.org domain for Logan High School located in Logan, UT, USA.