### PR TITLE
Adds Harrow International School Beijing

### DIFF
--- a/lib/domains/cn/harrowbeijing.txt
+++ b/lib/domains/cn/harrowbeijing.txt
@@ -1,0 +1,2 @@
+北京哈罗国际学校
+Harrow International School Beijing


### PR DESCRIPTION
北京哈罗国际学校
Harrow International School Beijing
www.harrowbeijing.cn