### PR TITLE
add Virginia's Community Colleges

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,2 @@
+Virginia's Community Colleges
+Virginia's Community Colleges


### PR DESCRIPTION
New River college is a sub-college under Virginia's Community Colleges.

https://www.nr.edu/degrees/computers.php, here is the computer science website.
https://www.vccs.edu/. this is the vccs main website.