### PR TITLE
Added Gymnasium Hummelsbuettel, Hamburg, Germany

### DIFF
--- a/lib/domains/de/gymhum.txt
+++ b/lib/domains/de/gymhum.txt
@@ -1,0 +1,1 @@
+Gymnasium Hummelsbüttel


### PR DESCRIPTION
Official web site:
https://www.gymnasium-hummelsbuettel.de

IT course:
See the following URL. Scroll down to "Informatik: Programmieren kann jeder" and also note the PDF "Fachcurriculum Informatik" that describes the course in the final two years of education (there are also computer science courses in earlier years).
 https://www.gymnasium-hummelsbuettel.de/unterricht/unterrichtsf%C3%A4cher/naturwissenschaften/

Proof for mail domain:
That's a bit tough because the e-mail domain "gymhum.de" is different from the web site domain "gymnasium-hummelsbuettel.de" (a short form of it, obviously).
Also, the e-mail system's web ui is only visible for logged-in users. However, see for example  the web page at the following URL and notice the e-mails links:
https://www.gymnasium-hummelsbuettel.de/menschen/schulleitung-abteilungsleiter/