### PR TITLE
Added Downingtown S.T.E.M. Academy.

### DIFF
--- a/lib/domains/org/dasd/student.txt
+++ b/lib/domains/org/dasd/student.txt
@@ -1,0 +1,1 @@
+Downingtown S.T.E.M. Academy


### PR DESCRIPTION
- Official website URL: https://www.dasd.org/STEM
- IT related course: https://www.dasd.org/Page/2328
- URL to proof the dasd.org domain name: https://www.dasd.org/domain/1623