### PR TITLE
Add Cornwall Hill College

### DIFF
--- a/lib/domains/org/cornwallhill.txt
+++ b/lib/domains/org/cornwallhill.txt
@@ -1,0 +1,1 @@
+Cornwall Hill College


### PR DESCRIPTION
https://www.cornwall.co.za/ is the official website for Cornwall Hill College.

https://www.cornwall.co.za/index.php/contact/contact-form shows that @cornwallhill.org is used for official emails

@cornwallhill.org is hosted on Gmail.  There is an option to "Create Account" on http://www.cornwallhill.org/, but it allows the public to create @gmail.com accounts, not @cornwallhill.org addresses.