### PR TITLE
Add Santa Barbara City College.

### DIFF
--- a/lib/domains/edu/sbcc.txt
+++ b/lib/domains/edu/sbcc.txt
@@ -1,0 +1,2 @@
+Santa Barbara City College
+Santa Barbara City College


### PR DESCRIPTION
Add Santa Barbara City College.

Email-addresses: username@pipeline.sbcc.edu

- the university official website URL: https://www.sbcc.edu/


- a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:

https://catalog.sbcc.edu/academic-departments/computer-science/#programsofstudytext

- a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students:

http://www.sbcc.edu/it/files/find_username_via_gmail.pdf