### PR TITLE
Added EUC North school to the list of highschools to access jetbrains student subscriptions

### DIFF
--- a/lib/domains/dk/euclive.txt
+++ b/lib/domains/dk/euclive.txt
@@ -1,0 +1,2 @@
+EUC Nord HTX Frederikshavn
+EUC North HTX Frederikshavn


### PR DESCRIPTION
I added the domain of EUC North high school. The primary use of the subscription is to be used in our programming and information technology classes. We primary work in PHP, Ruby and upcoming database work