### PR TITLE
Add CUSD 200 in Wheaton, IL

### DIFF
--- a/lib/domains/org/cusd200.txt
+++ b/lib/domains/org/cusd200.txt
@@ -1,0 +1,1 @@
+Community Unit School District 200 (Wheaton, IL, USA)


### PR DESCRIPTION
The district's main website is https://www.cusd200.org

Both of the high schools have business and programming classes as listed under the _Career and Technical Education Program_ part of the [course catalog](https://www.cusd200.org/site/Default.aspx?PageID=364).

I do not have documentation supporting it but all staff and students share the same domain name (cusd200.org) for their email accounts.