### PR TITLE
Add City College of San Francisco

### DIFF
--- a/mail.txt
+++ b/mail.txt
@@ -1,0 +1,1 @@
+City College of San Francisco


### PR DESCRIPTION
Please add City College of San Francisco to the list of schools for free software.