### PR TITLE
Added Los Rios Community College District in Northern California.

### DIFF
--- a/lib/domains/edu/losrios/apps.txt
+++ b/lib/domains/edu/losrios/apps.txt
@@ -1,0 +1,4 @@
+Cosumnes River College
+American River College
+Folsom Lake College
+Sacramento City College


### PR DESCRIPTION
There are 4 colleges in Los Rios community colleges district in Northern California.