### PR TITLE
Add Western Sierra Collegiate Academy high school to list of school domains

### DIFF
--- a/lib/domains/org/rafos.txt
+++ b/lib/domains/org/rafos.txt
@@ -1,0 +1,1 @@
+Rocklin Academy Family of Schools


### PR DESCRIPTION
Western Sierra Collegiate Academy in Rocklin, CA uses the domain rafos.org for their email servers. They are the **R**ocklin **A**cademy **F**amily **o**f **S**chools (rafos.org).

Official Website: https://www.wscacademy.org/