### PR TITLE
Add St Louis High School to IE domain

### DIFF
--- a/lib/domains/ie/stlouishighschool.txt
+++ b/lib/domains/ie/stlouishighschool.txt
@@ -1,0 +1,1 @@
+St Louis High School


### PR DESCRIPTION
@philipto The high school URL is [St Louis High School](https://stlouishighschool.ie). It runs a Computer Club (information available under [Extra Curricular Activities](https://www.stlouishighschool.ie/list/extra-curricular/Extra-Curricular-Activities)).