### PR TITLE
Added Gavilan College domain

### DIFF
--- a/lib/domains/edu/gavilan/my.txt
+++ b/lib/domains/edu/gavilan/my.txt
@@ -1,0 +1,1 @@
+Gavilan College


### PR DESCRIPTION
As per the instructions on the JetBrains website ( https://www.jetbrains.com/shop/eform/students/contributeUniversity?email=ann.orman%40my.gavilan.edu ) added the EDU domain name for gavilan.edu

Our college website is https://www.gavilan.edu/