### PR TITLE
Add Universidade Paulista, Brazil

### DIFF
--- a/lib/domains/br/edu/unipinterativa.txt
+++ b/lib/domains/br/edu/unipinterativa.txt
@@ -1,0 +1,1 @@
+Universidade Paulista


### PR DESCRIPTION
Alternative domain for Universidade Paulista e-learning mailbox.