### PR TITLE
added Terenure College to ie domain

### DIFF
--- a/lib/domains/ie/terenurecollege.txt
+++ b/lib/domains/ie/terenurecollege.txt
@@ -1,0 +1,1 @@
+Terenure College


### PR DESCRIPTION
@philipto 

Adding Terenure College to the ie domain. Terenure College is one of the pilot schools for a two-year Computer Science course at Leaving Certificate level.

[State Exam Commission Doc showing pilot schools](https://www.examinations.ie/misc-doc/BI-EX-69048771.pdf)

[Terenure College website showing Computer Studies](http://www.terenurecollege.ie/index.php/school-information/academic/leaving-cert-curriculum)





