### PR TITLE
Add Ostrovsky High School

### DIFF
--- a/lib/domains/org/eduil/raanana.txt
+++ b/lib/domains/org/eduil/raanana.txt
@@ -1,0 +1,2 @@
+Ostrovsky High School
+.group


### PR DESCRIPTION
Ostrovsky High School
Website: http://ostrov.schooly.co.il

The school offers a [3-year CS program](http://ostrov.schooly.co.il/2016/01/12/תחרות-מחשבים-וסייבר-אפריל2015/).

All students use an email with a `@raanana.eduil.org` domain which belongs to the municipality's online education program.
