### PR TITLE
Adding simonsen.txt

### DIFF
--- a/lib/domains/br/simonsen.txt
+++ b/lib/domains/br/simonsen.txt
@@ -1,0 +1,1 @@
+Faculdades Integradas Simonsen


### PR DESCRIPTION
Adding [Simonsen.txt](http://www.simonsen.br) as an instituition

You can find some information about the institution on [Wikipedia](http://pt.wikipedia.org/wiki/Faculdades_Integradas_Simonsen)

Here is its specific course page: http://www.simonsen.br/2.0/TADS

P.S.: Links in pt_br