### PR TITLE
Use wrong host name to check my school mail server.  plz check again

### DIFF
--- a/lib/domains/tw/edu/asis/live.txt
+++ b/lib/domains/tw/edu/asis/live.txt
@@ -1,0 +1,2 @@
+Asia University, Taiwan
+Asia University, Taiwan


### PR DESCRIPTION
Hi, Philipto

You use wrong host name to check my school mail server
The currect domain was  **live.asia.edu.tw.**

https://github.com/JetBrains/swot/pull/7904#issuecomment-598574051

https://github.com/JetBrains/swot/pull/7895#issuecomment-597460892

#### Institution/School Name 
  Asia University, Taiwan

#### Instiution/School Website
  https://www.asia.edu.tw/

#### Email Users
  e.g. StudentsID@live.asia.edu.tw
  98030030@live.asia.edu.tw

*Please place an x between the square brackets if yes*
- [x] Students
- [ ] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent

