### PR TITLE
Add Ministry of Education and Science student domain

### DIFF
--- a/lib/domains/bg/mon/edu.txt
+++ b/lib/domains/bg/mon/edu.txt
@@ -1,0 +1,1 @@
+Ministry of Education and Science - Bulgaria


### PR DESCRIPTION
This is a bit of a weird one - almost every student in Bulgaria is going to recieve an Office 365 account, which includes an email address ending in `@edu.mon.bg`. The addresses are owned by the Ministry of Education and Science, which controls all the educational institutions here.

