### PR TITLE
Added novi-education.nl

### DIFF
--- a/lib/domains/nl/novi-education.txt
+++ b/lib/domains/nl/novi-education.txt
@@ -1,0 +1,2 @@
+Hogeschool NOVI b.v.
+University of Applied Science NOVI


### PR DESCRIPTION
NOVI University is rebranding to NOVI Education for its students. The coming months the novi-education.nl domain will start replacing noviuniversity.com.