### PR TITLE
Add PUM University in Szczecin, Poland

### DIFF
--- a/lib/domains/pl/szczecin/pum.txt
+++ b/lib/domains/pl/szczecin/pum.txt
@@ -1,0 +1,2 @@
+Pomorski Uniwersytet Medyczny
+Pomeranian Medical University


### PR DESCRIPTION
This University has new name - old name is PAM which is already in the folder.

https://www.pum.edu.pl/