### PR TITLE
Add The Vale Academy

### DIFF
--- a/lib/domains/uk/org/valeacademy.txt
+++ b/lib/domains/uk/org/valeacademy.txt
@@ -1,0 +1,1 @@
+The Vale Academy


### PR DESCRIPTION
Proof of email: http://mail.valeacademy.org.uk/
This school provides Secondary education to GCSE's but also up to A levels as a part of Brigg Sixth Form. The Computer Science classes (Both at GCSE and A level) are held at The Vale Academy.
http://www.briggsixthform.co.uk/