### PR TITLE
Add pspo.edu.pl domain

### DIFF
--- a/lib/domains/pl/edu/pspo.txt
+++ b/lib/domains/pl/edu/pspo.txt
@@ -1,0 +1,1 @@
+Liceum Ogólnokształcące Niepubliczne nr 43 z Oddziałami Dwujęzycznymi


### PR DESCRIPTION
A domain for high school Liceum Ogólnokształcące Niepubliczne nr 43 z Oddziałami Dwujęzycznymi
http://pspo.edu.pl/o-nas/nauczyciele/