### PR TITLE
Request to add Nam Dinh University of Nursing

### DIFF
--- a/lib/domains/vn/edu/ndun.txt
+++ b/lib/domains/vn/edu/ndun.txt
@@ -1,0 +1,2 @@
+Trường Đại học Điều dưỡng Nam Định
+Nam Dinh University of Nursing


### PR DESCRIPTION
We are Nam Dinh University of Nursing - a public university in Vietnam, research and teaching in medicine. We are very interested in JetBrains' tools and we want to use your tools for our teachers and students. Thank you very much!
Our information:
- Vietnamese name: Trường Đại học Điều dưỡng Nam Định
- English name: Nam Dinh University of Nursing
- English acronym: NDUN
- Type of education: Higher Education
- Official website: http://ndun.edu.vn
- Email: dieuduong@ndun.edu.vn
- Address: 257, Han Thuyen street, Nam Dinh city, Nam Dinh province, Vietnam