### PR TITLE
Request to add Srednja tehniška šola Koper

### DIFF
--- a/lib/domains/si/sts.txt
+++ b/lib/domains/si/sts.txt
@@ -1,0 +1,1 @@
+Srednja tehniška sola Koper


### PR DESCRIPTION
Full name: Srednja tehniška šola Koper
Abbreviation: STŠ
Official website: http://www.sts.si
Contact person - IT courses: Katarina Novoselec
Email: katarina.novoselec@sts.si
Address: Šmarska cesta 4, 6000 Koper - Capodistria, Slovenia