### PR TITLE
PR for WMG Academy

### DIFF
--- a/lib/domains/uk/org/wmgacademy.txt
+++ b/lib/domains/uk/org/wmgacademy.txt
@@ -1,0 +1,1 @@
+WMG Academy for Young Engineers


### PR DESCRIPTION
https://coventry.wmgacademy.org.uk/students/curriculum/

Detailed on this page are the curriculum listings for both KS4 (2-year) and KS5 (2-year) courses, both of which include Computer Science