### PR TITLE
Request to add Ichthus Lyceum

### DIFF
--- a/lib/domains/nl/ichthuslyceum.txt
+++ b/lib/domains/nl/ichthuslyceum.txt
@@ -1,0 +1,1 @@
+Ichtus Lyceum


### PR DESCRIPTION
This is a high school in Driehuis, The Netherlands
Official site: [www.ichthuslyceum.nl](https://ichthuslyceum.nl)
Contact person: M. Hoogstoevenbeld (One of my IT teachers)
Email: m.hoogstoevenbeld@ichthuslyceum.nl
Address: Wolff en Dekenlaan 1 1985 HP Driehuis