### PR TITLE
add domain of IMM UB RAS imm.uran.ru

### DIFF
--- a/lib/domains/ru/uran/imm.txt
+++ b/lib/domains/ru/uran/imm.txt
@@ -1,0 +1,2 @@
+Институт математики и механики им. Н.Н.Красовского УрО РАН
+N.N. Krasovskii Institute of Mathematics and Mechanics (IMM UB RAS)


### PR DESCRIPTION
N.N. Krasovskii Institute of Mathematics and Mechanics (IMM UB RAS)
https://www.imm.uran.ru/rus/Pages/default.aspx