### PR TITLE
Add domain of Haute École Robert Schuman hers.be

### DIFF
--- a/lib/domains/be/hers.txt
+++ b/lib/domains/be/hers.txt
@@ -1,0 +1,1 @@
+Haute École Robert Schuman


### PR DESCRIPTION
- **the university official website URL, if it is different from the domain you are submitting**: <https://hers.be>
- **a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university**: <http://progcours.hers.be/cocoon/en/programmes/E1INFO01_C.html>
- **a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.**: <https://hers.be/vie-etudiante/organisation/office-365-pour-tous>