### PR TITLE
Adding domain lit1533.ru

### DIFF
--- a/lib/domains/ru/lit1533.txt
+++ b/lib/domains/ru/lit1533.txt
@@ -1,0 +1,8 @@
+Государственное бюджетное общеобразовательное учреждение города Москвы "Школа № 1533 "ЛИТ" 
+State Budget General Educational Institution of Moscow "School № 1533" LIT"
+Лицей информационных технологий 1533
+Lyceum of Information Technologies 1533
+
+Mail domain: lit1533.ru (scolars and teachers has e-mails at this domain)
+Web-site (with forward from lit1533.ru): https://www.lit.msu.ru
+Web-site at Moscow Department of Eduraction and Science: https://lyc1533.mskobr.ru

--- a/lib/domains/ru/lit1533.txt
+++ b/lib/domains/ru/lit1533.txt
@@ -5,4 +5,4 @@ Lyceum of Information Technologies 1533
 
 Mail domain: lit1533.ru (scolars and teachers has e-mails at this domain)
 Web-site (with forward from lit1533.ru): https://www.lit.msu.ru
-Web-site at Moscow Department of Eduraction and Science: https://lyc1533.mskobr.ru
+Web-site at Moscow Department of Education and Science: https://lyc1533.mskobr.ru


### PR DESCRIPTION
Mail domain: lit1533.ru (scolars and teachers have e-mails at this domain)
Web-site (with forward from lit1533.ru): https://www.lit.msu.ru
Web-site at Moscow Department of Education and Science: https://lyc1533.mskobr.ru