### PR TITLE
Create agsb.txt

### DIFF
--- a/lib/domains/uk/co/agsb.txt
+++ b/lib/domains/uk/co/agsb.txt
@@ -1,0 +1,1 @@
+Altrincham Grammar School for Boys


### PR DESCRIPTION
This adds [Altrincham Grammar School for Boys](https://agsb.co.uk) to the list of supported schools. 

The sixth form offers a computer science A-Level which runs for 2 years. https://agsb.co.uk/media/95899/sixth-form-2019-20-prospectus-oct-19-20-final-version-aj.pdf. Page 20 details the course's content.

![sixth-form-2019-20-prospectus-oct-19-20-final-version-aj (dragged)-1](https://user-images.githubusercontent.com/50501825/80826413-133b3480-8bda-11ea-89e8-845fc47f4e9e.jpg)

