### PR TITLE
Add Dominicus College

### DIFF
--- a/lib/domains/nl/dominicuscollege.txt
+++ b/lib/domains/nl/dominicuscollege.txt
@@ -1,0 +1,1 @@
+Dominicus College


### PR DESCRIPTION
This PR adds DominicusCollege.nl, which is used for both the [website](http://www.dominicuscollege.nl/onze-school/over-het-dominicus-college) and e-mailaccounts (see page footer).
