### PR TITLE
Add AMC Metropolitan College professors accounts

### DIFF
--- a/lib/domains/gr/edu/mitropolitiko.txt
+++ b/lib/domains/gr/edu/mitropolitiko.txt
@@ -1,0 +1,2 @@
+Μητροπολιτικό Κολλέγιο
+AMC - Metropolitan College


### PR DESCRIPTION
Metropolitan College student e-mails were previously added, I would like to add our professors mail acount.

College homepage: https://mitropolitiko.edu.gr/
Article confirming the e-mail domain is what it is: https://www.newsbeast.gr/greece/arthro/5521119/giorgos-paxinos-athanasios-fokas-dyo-koryfaioi-epistimones-syzitoyn-sto-mitropolitiko-kollegio

Thanks for giving us the best tools! We appreciate it.