### PR TITLE
Added Gymnasium Johanneum

### DIFF
--- a/lib/domains/de/schulbistum/gjo.txt
+++ b/lib/domains/de/schulbistum/gjo.txt
@@ -1,0 +1,2 @@
+Gymnasium Johanneum
+"Die Loburg"


### PR DESCRIPTION
This adds support for the "Gymnasium Johanneum", which is more commonly known as "Die Loburg" (Gymnasium is equivalent to High School).

Website: https://die-loburg.de
Course Site for IT: https://die-loburg.de/informatik

As the school is part of the "Schulbistum" network, teachers of this school are assigned an email-account at the sub-domain gjo.schulbistum.de. Other schools in this network have other subdomains, e.g. the already merged "St. Michael Gymnasium Ahlen" (https://github.com/JetBrains/swot/blob/master/lib/domains/de/schulbistum/gsma.txt).

Thanks!