### PR TITLE
Add FSG Muenster

### DIFF
--- a/lib/domains/de/ms/stein.txt
+++ b/lib/domains/de/ms/stein.txt
@@ -1,0 +1,1 @@
+Freiherr-vom-Stein Gymnasium Muenster


### PR DESCRIPTION
This adds the Freiherr-vom-Stein Gymnasium Muenster, which is the local Gymnasium (equivalent to american High School).

School Website: [fsg-ms.de](http://fsg-ms.de/) or [freiherr-vom-stein-gymnasium-muenster.de](http://www.freiherr-vom-stein-gymnasium-muenster.de/)

As the mail server for local schools is managed by the municipality, every school gets a subdomain of `ms.de` in our case it is `stein.ms.de`. Teachers as well as students get an email adress following the `lastname@school_subdomain` scheme.

Thanks!