### PR TITLE
add tzfonet

### DIFF
--- a/lib/domains/il/org/tzfonet.txt
+++ b/lib/domains/il/org/tzfonet.txt
@@ -1,0 +1,2 @@
+tzafonet
+.group


### PR DESCRIPTION
It's not a typo: the domain is tzfonet but the name is tzafonet.
i.e: example@tzfonet.org.il
Proof: [youtube video](https://youtu.be/WrcF4iT4d9M) tzafonet is a well known educational organization in Israel
it includes a group of schools.