### PR TITLE
Add numazu-vtc.ac.jp domain

### DIFF
--- a/lib/domains/jp/ac/numazu-vtc.txt
+++ b/lib/domains/jp/ac/numazu-vtc.txt
@@ -1,0 +1,1 @@
+Numazu Vocational Training Center


### PR DESCRIPTION
Numazu Vocational Training Center
Website: http://numazu-vtc.ac.jp/