### PR TITLE
Nanjing No.29 High School

### DIFF
--- a/lib/domains/net/29zx.txt
+++ b/lib/domains/net/29zx.txt
@@ -1,0 +1,2 @@
+南京市第二十九中学
+Nanjing No.29 High School

--- a/lib/domains/net/nj29jt.txt
+++ b/lib/domains/net/nj29jt.txt
@@ -1,0 +1,2 @@
+南京市第二十九中学
+Nanjing No.29 High School


### PR DESCRIPTION
After another two months' attempt, we finally got the paper you need.
Sorry for the inconvenience. The domain 29zx.net is usually used to allocate email accounts for our teachers and students. For that reason, we usually don't make it accessible as a website.(In China, it's really tough to make a website available for a long period of time: you need to BeiAn, a very complicate matter.) That's why you can't access the domain 29zx.net.
At present, as we have got the paper you need, the website 29zx.net will be available for a few days for you to validate.
![IMG_20200527_001950](https://user-images.githubusercontent.com/39629131/82928324-ac305600-9fb4-11ea-9c48-9adae59c9e64.jpg)
