### PR TITLE
Added Liceo Galileo Galilei Catania

### DIFF
--- a/lib/domains/it/edu/liceogalileicatania.txt
+++ b/lib/domains/it/edu/liceogalileicatania.txt
@@ -1,0 +1,1 @@
+Liceo Scientifico Statale Galileo Galilei - http://www.liceogalileicatania.edu.it/


### PR DESCRIPTION
There is no mention of the school email on the website itself, however, the domain is the same. 
I hope that is enough.