### PR TITLE
Add Banting Memorial High School text file

### DIFF
--- a/lib/domains/ca/on/scdsb.txt
+++ b/lib/domains/ca/on/scdsb.txt
@@ -1,0 +1,1 @@
+Banting Memorial High School


### PR DESCRIPTION
The school website is http://ban.scdsb.on.ca/. The student domain is scdsb.on.ca, as it is a part of the Simcoe Country District School Board. Thank you.