### PR TITLE
Add Northport High School

### DIFF
--- a/lib/domains/us/ny/k12/northport.txt
+++ b/lib/domains/us/ny/k12/northport.txt
@@ -1,0 +1,1 @@
+Northport High School


### PR DESCRIPTION
Add Northport High School.

E-Mail Domain: `@northport.k12.ny.us`.