### PR TITLE
add univ-catholille.fr back

### DIFF
--- a/lib/domains/fr/univ-catholille.txt
+++ b/lib/domains/fr/univ-catholille.txt
@@ -1,0 +1,1 @@
+Université Catholique de Lille


### PR DESCRIPTION
official website : http://www.univ-catholille.fr/
it courses : https://www.univ-catholille.fr/formations/fiche/3182
email address domain : @univ-catholille.fr

Note: The domain used to be in this repo before it was renamed to "lacatholille.fr" (commit 478148c1), however teachers still have their emails with the univ-catholille.fr domain as you can see on that IT course page with "Julie Jacques" who is the head of this course.