### PR TITLE
Add EEP Domain

### DIFF
--- a/lib/domains/br/eep.txt
+++ b/lib/domains/br/eep.txt
@@ -1,0 +1,1 @@
+Escola de Engenharia de Piracicaba


### PR DESCRIPTION
- The university official website URL: https://www.eep.br/
- URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
https://www.eep.br/informacoes-ciecomputacao
https://www.eep.br/informacoes-engenharia-comp
- URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students:
https://sway.office.com/KVbEhdMOGw4JTb7T?ref=Link