### PR TITLE
Add Hau Giang edu to domains

### DIFF
--- a/lib/domains/vn/edu/haugiang.txt
+++ b/lib/domains/vn/edu/haugiang.txt
@@ -1,0 +1,1 @@
+Department of Education and Training of Hau Giang province


### PR DESCRIPTION
- I am adding the domain name of The academic center's  website is http://haugiang.edu.vn
This is a website for Department of Education and Training of Hau Giang province in Vietnam

