### PR TITLE
Include TWGHs Li Ka Shing College

### DIFF
--- a/lib/domains/hk/edu/twghlkss.txt
+++ b/lib/domains/hk/edu/twghlkss.txt
@@ -1,0 +1,1 @@
+Tung Wah Group of Hospitals Li Ka Shing College


### PR DESCRIPTION
Adding the school above whose official website is: https://twghlkss.edu.hk/