### PR TITLE
add Johnson High School for Hays CISD

### DIFF
--- a/lib/domains/net/hayscisd/g.txt
+++ b/lib/domains/net/hayscisd/g.txt
@@ -1,0 +1,2 @@
+Johnson High School
+Moe & Gene Johnson High School


### PR DESCRIPTION
Please add hayscisd.net for Johnson High School in Hays Consolidated Independent School District (Hays CISD) 
Official School Website https://www.hayscisd.net/Domain/2797 
Technology Classes https://www.hayscisd.net/Page/6225 
School Email Contact Info https://www.hayscisd.net/Page/7071 

School Physical Address:

Johnson High School
4260 FM 967 
Buda, TX 78610
