### PR TITLE
Add full domain for University of Belgrade, School of Electrical Engineering

### DIFF
--- a/lib/domains/rs/ac/bg/etf.txt
+++ b/lib/domains/rs/ac/bg/etf.txt
@@ -1,0 +1,1 @@
+University of Belgrade, School of Electrical Engineering


### PR DESCRIPTION
Primary domain for University of Belgrade, School of Electrical Engineering, used together with etf.rs