### PR TITLE
Update and rename u-psud.txt to universite-paris-saclay.txt

### DIFF
--- a/lib/domains/fr/u-psud.txt
+++ b/lib/domains/fr/u-psud.txt
@@ -1,2 +1,0 @@
-Ecole Supérieure d'Optique
-Université Paris Sud (Paris XI)

--- a/lib/domains/fr/universite-paris-saclay.txt
+++ b/lib/domains/fr/universite-paris-saclay.txt
@@ -1,0 +1,1 @@
+Université Paris Saclay


### PR DESCRIPTION
Paris Sud University has become Paris Saclay University since January 1, 2020