### PR TITLE
Add "teb.edu.pl" domain for TEB Edukacja

### DIFF
--- a/lib/domains/pl/edu/teb.txt
+++ b/lib/domains/pl/edu/teb.txt
@@ -1,0 +1,1 @@
+Technikum TEB Edukacja


### PR DESCRIPTION
This pull request adds the _TEB Edukacja_ school located in Poland.
Official websites: https://technikum.pl and https://teb.pl/

**VERY IMPORTANT NOTE**:
I am aware the domain in my pull request (**_teb.edu.pl_**) refers to a non-existent website that doesn't point to any school. This is really not my fault that they don't know how to redirect the user to one of their websites.

![Screenshot](https://i.imgur.com/2XGRfPg.png)

... hovewer the **_teb.edu.pl_** domain is indeed **in use by every teacher's and every student's e-mail address** (`name.surname@teb.edu.pl`), for example `krystian.kolucki@teb.edu.pl` (which is my e-mail on Outlook, for Office 365 for schools).

If you don't believe me, you can try looking the domain up on websites like https://whois.domaintools.com/teb.edu.pl, and you'll see that the domain **is** registered to https://teb.pl:
![Screenshot 2](https://i.imgur.com/opEBkiq.png)
(by clicking the little arrow you even get redirected to https://teb.pl somehow)

Please consider merging this pull request.