### PR TITLE
Add Keelung Municipal Ming Chwan Junior High School

### DIFF
--- a/lib/domains/tw/edu/kl/gm.txt
+++ b/lib/domains/tw/edu/kl/gm.txt
@@ -1,0 +1,2 @@
+基隆市立銘傳國中
+Keelung Municipal Ming Chwan Junior High School


### PR DESCRIPTION
the school official website URL
> https://mcjh.kl.edu.tw/

an URL of a page on the official website where an IT-related long-term (>1 year) course is offered by the school
> It's a junior high school and they have some STEM course, but there is no page about it.

a proof showing that the school recognizes the domain which you are submitting as an official email domain for the students.
> kl.edu.tw is the official domain of Keelung Bureau, they provide a common domain `gm.kl.edu.tw` for all the junior high school in Keelung