### PR TITLE
Se agrega el dominio misena.edu.co

### DIFF
--- a/lib/domains/co/edu/misena.txt
+++ b/lib/domains/co/edu/misena.txt
@@ -1,0 +1,1 @@
+Servicio Nacional de Aprendizaje SENA


### PR DESCRIPTION
El Servicio Nacional de Aprendizaje SENA de colombia (https://www.sena.edu.co/es-co/Paginas/default.aspx) Utiliza el dominio misena.edu.co para las cuentas estudiantiles de aprendices.