### PR TITLE
Remove Zhejiang University from stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -150,7 +150,6 @@ aurora.ekof.bg.ac.rs
 queens.ac.id
 stu.ccsu.edu.cn
 email.axc.edu.gr
-zju.edu.cn
 mail.csu.edu.cn
 zanestate.edu
 student.palomar.edu


### PR DESCRIPTION
1. the university official website URL, if it is different from the domain you are submitting
The domain is the same
2. a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
http://www.en.cs.zju.edu.cn/22145/list.htm
3. a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.
https://mail.zju.edu.cn/