### PR TITLE
delete zju.edu.cn from stoplist

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -150,7 +150,6 @@ aurora.ekof.bg.ac.rs
 queens.ac.id
 stu.ccsu.edu.cn
 email.axc.edu.gr
-zju.edu.cn
 mail.csu.edu.cn
 zanestate.edu
 student.palomar.edu


### PR DESCRIPTION
Zhejiang University is a top school in the field of computer science and its offical email is zju.edu.cn. I think There must have been some mistake that made Zhejiang University on the list.