### PR TITLE
add Chiba Institute of Technology (staff email domain)

### DIFF
--- a/lib/domains/jp/chibakoudai/p.txt
+++ b/lib/domains/jp/chibakoudai/p.txt
@@ -1,0 +1,1 @@
+Chiba Institute of Technology (staff)

--- a/lib/domains/jp/chibakoudai/p.txt
+++ b/lib/domains/jp/chibakoudai/p.txt
@@ -1,1 +1,1 @@
-Chiba Institute of Technology (staff)
+Chiba Institute of Technology


### PR DESCRIPTION
University Website:
https://www.it-chiba.ac.jp/english/

IT related courses:
https://www.it-chiba.ac.jp/english/graduate/

A page that shows p.chibakoudai.jp is used for email address for staff at the university:
https://www.it-chiba.ac.jp/career/cp_recruit/professor/

s.chibakoudai.jp is used for students and already added