### PR TITLE
Add PSN - Panhellenic School Network

### DIFF
--- a/lib/domains/gr/sch.txt
+++ b/lib/domains/gr/sch.txt
@@ -1,0 +1,1 @@
+Panhellenic School Network


### PR DESCRIPTION
The Panhellenic School Network is the online network for all public Greek schools

This includes General Senior High Schools (which provides an IT field on their 3rd year as preparation for the Panhellenic University Entry exams) as well as Vocational Senior High Schools (which provide several 2-year long + practical experience in IT positions)