### PR TITLE
Student mail domain for Universidad Fidelitas

### DIFF
--- a/lib/domains/cr/ac/ufide.txt
+++ b/lib/domains/cr/ac/ufide.txt
@@ -1,0 +1,1 @@
+Universidad Fidélitas


### PR DESCRIPTION
**Description of changes**
- Adding a second domain for Universidad Fidélitas, ufidelitas.ac.cr is already registered.
- ufide.ac.cr is used for students email addresses.

**Things you can do to verify the information**
- Go to [nic.cr/whois](https://www.nic.cr/whois/), from the drop down menu choose **`.ac.cr`** and type **`ufide`** in the search box and hit "Buscar". You'll see that this domain registered under Universidad Fidélitas.
- You can do the same with ufidelitas.ac.cr to see how both domains match.
- This is the official page with details about their program (Computer Systems Engineering): https://ufidelitas.ac.cr/carrera/bachillerato-ingenieria-sistemas-de-computacion/

**Additional Information**
- Official University Website: https://ufidelitas.ac.cr/

If there's anything else required, please lmk and I'll update the PR or add more info.