### PR TITLE
Add Government Engineering College, Thrissur

### DIFF
--- a/lib/domains/in/ac/gectcr.txt
+++ b/lib/domains/in/ac/gectcr.txt
@@ -1,0 +1,1 @@
+Government Engineering College, Thrissur


### PR DESCRIPTION
Add domain operated by Government Engineering College, Thrissur, Kerala, India.
Courses offered: http://gectcr.ac.in/academics/