### PR TITLE
Add Gymnasium Rodenkirchen

### DIFF
--- a/lib/domains/com/onmicrosoft/gymro.txt
+++ b/lib/domains/com/onmicrosoft/gymro.txt
@@ -1,0 +1,1 @@
+Gymnasium Rodenkirchen


### PR DESCRIPTION
Official Website: http://gymnasium-rodenkirchen.de (yes, still no https in 2020)
School Contact email: gymro@stadt-koeln.de