### PR TITLE
Added Albert-Einstein-Gymnasium Duisburg-Rumeln and FernUniversität in Hagen

### DIFF
--- a/lib/domains/de/aegmail.txt
+++ b/lib/domains/de/aegmail.txt
@@ -1,0 +1,1 @@
+Albert-Einstein-Gymnasium Duisburg-Rumeln

--- a/lib/domains/studium/fernuni-hagen.txt
+++ b/lib/domains/studium/fernuni-hagen.txt
@@ -1,0 +1,1 @@
+FernUniversität in Hagen


### PR DESCRIPTION
Added Albert-Einstein-Gymnasium.
Homepage: https://aeg-duisburg.de
This is only the Mail Domain for Students **and** Teachers of the Albert-Einstein-Gymnasium redirecting to I-Serv.


The other one is the Domain for the University "FernUniversität in Hagen" (fernuni-hagen.de or studium.fernuni-hagen.de) this Subdomain is only for students.