### PR TITLE
add Zhengzhou Tobacco Research Institute of CNTC

### DIFF
--- a/lib/domains/cn/com/ztri.txt
+++ b/lib/domains/cn/com/ztri.txt
@@ -1,0 +1,2 @@
+中国烟草总公司郑州烟草研究院
+Zhengzhou Tobacco Research Institute of CNTC


### PR DESCRIPTION
烟草研究院作为科研单位，培养硕士、博士研究生，做生物信息学、化学计量学等开发需要用到jetbrains全家桶，恳请增加，谢谢。