### PR TITLE
Add the Ulm University of Applied Science

### DIFF
--- a/lib/domains/de/thu.txt
+++ b/lib/domains/de/thu.txt
@@ -1,0 +1,2 @@
+Technische Hochschule Ulm
+Ulm University of Applied Science 


### PR DESCRIPTION
added the domain file for Technische Hochschule Ulm / Ulm University of Applied Science

Webpage www.thu.de which is redirected to the old domain hs-ulm.de

A link to a Computer Science Course : https://studium.hs-ulm.de/en/Pages/Studiengang_CTS.aspx

The Mail Addresses have the schema {forname}.{surname}@thu.de