### PR TITLE
Add Cals College

### DIFF
--- a/lib/domains/nl/cals/leerling.txt
+++ b/lib/domains/nl/cals/leerling.txt
@@ -1,0 +1,1 @@
+Cals College


### PR DESCRIPTION
Official website URL: https://www.cals.nl/  

Long term IT related course: https://www.cals.nl/nieuwegein/onderwijs/technasium/over-technasium/

Official email domain for the enrolled students: https://www.cals.nl/nieuwegein/wp-content/uploads/sites/2/2020/03/Cals-mail-lln-NG-instructies.pdf