### PR TITLE
Adding domain for Lafayette Parish School System a US K-12 school

### DIFF
--- a/lib/domains/com/lpssonline.txt
+++ b/lib/domains/com/lpssonline.txt
@@ -1,0 +1,1 @@
+Lafayette Parish School System


### PR DESCRIPTION
Requesting to add lpssonline.com to the Educational List.