### PR TITLE
add domian xs.ustb.edu.cn

### DIFF
--- a/lib/domains/cn/edu/ustb/xs.txt
+++ b/lib/domains/cn/edu/ustb/xs.txt
@@ -1,0 +1,2 @@
+Beijing University of Science and Technology
+University of Science and Technology Beijing


### PR DESCRIPTION
Please add student email domain of USTB(Beijing University of Science and Technology). The email domain of USTB which already exists in project belongs to teachers and faculties in USTB instead of student. In USTB， The domain which students use is 'xs.ustb.edu.cn'. Students in USTB are very needed and eager to experience and use JetBrains products with educational free. Please add domain 'xs.ustb.edu.cn', I express my sincere gratitude to you on behalf of all USTB students.