### PR TITLE
Added Madaim Rehovot high school

### DIFF
--- a/lib/domains/il/org/educ.txt
+++ b/lib/domains/il/org/educ.txt
@@ -1,0 +1,2 @@
+קרית החינוך למדעים רחובות
+Madaim School Rehovot


### PR DESCRIPTION
Added the Madaim Rehovot high school (Israel).  
The school offers a 3 year CS course, a 3 year Software Engineering course and a 3 year Robotics course.  
Each student has an email address of the following format: random_number@educ.org.il  
It's possible that this domain is also used in other schools in Israel, but I'm not sure.

School Website: [https://www.madaimschool.co.il/](https://www.madaimschool.co.il/)