### PR TITLE
Add Pontificial Catholic University of Goiás

### DIFF
--- a/lib/domains/br/edu/pucgoias.txt
+++ b/lib/domains/br/edu/pucgoias.txt
@@ -1,0 +1,2 @@
+Pontifícia Universidade Católica de Goias
+Pontifical Catholic University of Goiás


### PR DESCRIPTION
Our university has two domains, one of them was already submitted. But the main domain is this one.
Our site is: https://www.pucgoias.edu.br/