### PR TITLE
Added ifal.edu.br

### DIFF
--- a/lib/domains/br/edu/ifal.txt
+++ b/lib/domains/br/edu/ifal.txt
@@ -1,0 +1,2 @@
+Instituto Federal de Alagoas
+Federal Institute of Alagoas


### PR DESCRIPTION
Official Website (English): https://www2.ifal.edu.br/en
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www2.ifal.edu.br/en/courses/graduation
URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: http://webmail.ifal.edu.br/