### PR TITLE
Adding supagro.fr

### DIFF
--- a/lib/domains/fr/supagro.txt
+++ b/lib/domains/fr/supagro.txt
@@ -1,0 +1,1 @@
+L'institut Agro | Montpellier SupAgro


### PR DESCRIPTION
**Institution/School Name**

L'institut Agro | Montpellier SupAgro

**Institution/School Website**

https://supagro.fr/ redirects since January to https://www.montpellier-supagro.fr/

**Email Users**

- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni


<user>@supagro.fr e-mails can be found all across the website

- contact@supagro.fr in the footer
- Teaching programs have contact cards for related directors of studies and teachers like [here](https://en.montpellier-supagro.fr/programs/degree-programs/engineering-master-degrees) and [there](https://en.montpellier-supagro.fr/training/option-data-science-agronomy-and-agri-food)


**Education Levels**

- [x] Post-graduate research
- [x] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent

**IT-related course**
https://www.montpellier-supagro.fr/formations/catalogue-des-formations/recherche-d-une-formation/option-data-science-pour-lagronomie

