### PR TITLE
Update UAL access

### DIFF
--- a/lib/domains/pt/autonoma.txt
+++ b/lib/domains/pt/autonoma.txt
@@ -1,0 +1,1 @@
+Universidade Autónoma de Lisboa

--- a/lib/domains/pt/ual.txt
+++ b/lib/domains/pt/ual.txt
@@ -1,1 +1,1 @@
-Universiade Autónuma de Lisboa
+Universidade Autónoma de Lisboa

--- a/lib/domains/pt/ual/students.txt
+++ b/lib/domains/pt/ual/students.txt
@@ -1,0 +1,1 @@
+Universidade Autónoma de Lisboa


### PR DESCRIPTION
Added the new domain for Universidade Autónoma de Lisboa, and updated the existing information. We are migrating to @autonoma.pt
Institution website: https://autonoma.pt/
Computer Science Engineering BSc course information: https://autonoma.pt/cursos/engenharia-informatica/
