### PR TITLE
Salem High School

### DIFF
--- a/lib/domains/us/ga/k12/rockdale/students.txt
+++ b/lib/domains/us/ga/k12/rockdale/students.txt
@@ -1,0 +1,1 @@
+Salem High School


### PR DESCRIPTION
Salem High School in Rockdale County School District

Google Maps Link to the district
Rockdale County School District: https://www.google.com/maps/place/Rockdale+County+School+District,+GA/@33.6808979,-84.1197578,11z/