### PR TITLE
Add NaUKMA to domains

### DIFF
--- a/lib/domains/ua/edu/ukma.txt
+++ b/lib/domains/ua/edu/ukma.txt
@@ -1,0 +1,2 @@
+Національний університет «Києво-Могилянська академія»
+National University of Kyiv-Mohyla Academy


### PR DESCRIPTION
Add National University Of Kyiv-Mohyla Academy to the domains list.  
Website: https://www.ukma.edu.ua/eng/
