### PR TITLE
Include Adeleke University

### DIFF
--- a/lib/domains/ng/edu/adelekeuniversity/student.txt
+++ b/lib/domains/ng/edu/adelekeuniversity/student.txt
@@ -1,0 +1,1 @@
+Adeleke University


### PR DESCRIPTION
Official url of Adeleke University: https://adelekeuniversity.edu.ng/
The Faculty of Science page: https://adelekeuniversity.edu.ng/faculty-of-science/
![Screenshot (2)](https://user-images.githubusercontent.com/51965161/92935867-4a034000-f441-11ea-809d-c2f501014905.png)

