### PR TITLE
Add new The Herzen State Pedagogical University of Russia (HSPU) domains

### DIFF
--- a/lib/domains/org/hspu.txt
+++ b/lib/domains/org/hspu.txt
@@ -1,0 +1,2 @@
+Российский государственный педагогический университет им. А. И. Герцена
+The Herzen State Pedagogical University of Russia

--- a/lib/domains/ru/edu/herzen.txt
+++ b/lib/domains/ru/edu/herzen.txt
@@ -1,0 +1,2 @@
+Российский государственный педагогический университет им. А. И. Герцена
+The Herzen State Pedagogical University of Russia

--- a/lib/domains/ru/spb/herzen.txt
+++ b/lib/domains/ru/spb/herzen.txt
@@ -1,2 +1,2 @@
-Herzen State Pedagogical University of Russia
-Herzen State Pedagogical University of Russia
+Российский государственный педагогический университет им. А. И. Герцена
+The Herzen State Pedagogical University of Russia


### PR DESCRIPTION
Now only the domain herzen.spb.ru has been added, but it is issued only to teachers. There is a domain for students herzen.edu.ru, so I added it. But by 2025, the university plans to ditch these domains in favor of a single hspu.org. As evidence, I attached a response from the university administration by hiding my personal email (in Russian).

<details>
<summary>Email</summary>

[email-hspu.pdf](https://github.com/JetBrains/swot/files/5214574/email-hspu.pdf)

</details>

I also added the name of the university in Russian for the domain herzen.spb.ru.

- Official site: https://herzen.spb.ru/
- About hspu.org: https://eos.herzen.spb.ru/ and https://id.hspu.org/