### PR TITLE
Add new student toulouse-inp mail address

### DIFF
--- a/lib/domains/fr/toulouse-inp/etu.txt
+++ b/lib/domains/fr/toulouse-inp/etu.txt
@@ -1,0 +1,1 @@
+Institut national polytechnique de Toulouse


### PR DESCRIPTION
Hello,

The new students mail addresses now given at [INP Toulouse](https://www.inp-toulouse.fr/fr/index.html) are of the format `@etu.toulouse-inp.fr`.

Should the `lib/domains/fr/inp-toulouse.txt` be removed? Some people might still be using it...  
Some student also have an `inp-toulouse.fr`, but I am not sure if those are also given to new students.

I also do not know if there are other subdomains in `toulouse-inp.fr` that should be added. 