### PR TITLE
Add Deenbandhu Chhotu Ram University of Science and Technology

### DIFF
--- a/lib/domains/org/dcrustm.txt
+++ b/lib/domains/org/dcrustm.txt
@@ -1,0 +1,1 @@
+Deenbandhu Chhotu Ram University of Science and Technology


### PR DESCRIPTION
http://dcrustm.ac.in/departments/engineering/computer-science-and-engineering
![dcrust](https://user-images.githubusercontent.com/40319304/93179506-61993c00-f753-11ea-9b96-586e9e082b32.JPG)

Only dcrustm.org used to be there but recently(https://ernet.in/content/domain-registration) migrated to dcrustm.ac.in for website but emails still on dcrustm.org for backward compatibility