### PR TITLE
Add BMS Liechtenstein

### DIFF
--- a/lib/domains/li/schulen.txt
+++ b/lib/domains/li/schulen.txt
@@ -1,0 +1,1 @@
+BMS Liechtenstein


### PR DESCRIPTION
Berufsmaturitäts Schule Liechtenstein für Informatikzwecke