### PR TITLE
Add kathmandu engineering college

### DIFF
--- a/lib/domains/np/edu/keckist.txt
+++ b/lib/domains/np/edu/keckist.txt
@@ -1,0 +1,1 @@
+Kathmandu Engineering College


### PR DESCRIPTION
the university official website URLs: https://www.keckist.edu.np/, https://www.kecktm.edu.np/
long-term (>1 year) IT related courses:
    -- https://www.kecktm.edu.np/category/academics/computer_engineering
