### PR TITLE
Added Novi Hogeschool second domain

### DIFF
--- a/lib/domains/nl/novi-youngcapital.txt
+++ b/lib/domains/nl/novi-youngcapital.txt
@@ -1,0 +1,2 @@
+Hogeschool NOVI b.v.
+University of Applied Science NOVI


### PR DESCRIPTION
Added Novi Hogeschool second domain

First domain is: novi-education.nl

**Website:** https://www.novi.nl/
**Software development course (undergraduate) in dutch:** https://www.novi.nl/software-development/
