### PR TITLE
Added Cork College of Commerce

### DIFF
--- a/lib/domains/ie/coccork.txt
+++ b/lib/domains/ie/coccork.txt
@@ -1,0 +1,2 @@
+College of Commerce
+Cork College of Commerce


### PR DESCRIPTION
Link to site: https://corkcollegeofcommerce.ie/ 