### PR TITLE
Gymnázium Kolín - gkolin.txt

### DIFF
--- a/lib/domains/cz/gkolin.txt
+++ b/lib/domains/cz/gkolin.txt
@@ -1,0 +1,2 @@
+Gymnázium, Kolín III, Žižkova 162
+Grammar school in Kolín, the Czech Rep.


### PR DESCRIPTION
Gymnázium, Kolín III, Žižkova 162
Grammar school in Kolín, the Czech Rep.