### PR TITLE
Adding mail for students of the city of Rzeszów

### DIFF
--- a/lib/domains/pl/erzeszow/edu.txt
+++ b/lib/domains/pl/erzeszow/edu.txt
@@ -1,0 +1,2 @@
+Rzeszowskie Szkoły w Chmurze Microsoft - platforma Office 365 dla edukacji
+.group


### PR DESCRIPTION
The city of Rzeszów has an e-mail for students of public schools. Almost 30,000 students use it! In a few cases, these are also primary schools, but this function is used mainly by high schools.

The email address has the form:
{three letters of the name}{three letters of the surname}.{three random numbers}@edu.erzeszow.pl

More information can be found on the verification and account creation page in Office 365: https://edu.erzeszow.pl/o365Web
Or on the microsoft website: https://customers.microsoft.com/en-us/story/753634-rzeszow-education-office365-poland-pl

Warning! You have to use google translate, the pages are in Polish.