### PR TITLE
Add Deccan Education Society's Fergusson College (Autonomous)

### DIFF
--- a/lib/domains/org/deccansociety.txt
+++ b/lib/domains/org/deccansociety.txt
@@ -1,0 +1,1 @@
+Fergusson College


### PR DESCRIPTION
Official Website: https://www.fergusson.edu/

Computer Science Department: https://www.fergusson.edu/departments/department/id/5

Deccan Education Society's website: https://deccansociety.org/

Fergusson College (Autonomous) and Deccan Education Society share the emblem/logo which should clarify the connection.

Students of Fergusson College receive email accounts based on deccansociety.org.