### PR TITLE
Adding islington college

### DIFF
--- a/lib/domains/np/edu/islingtoncollege.txt
+++ b/lib/domains/np/edu/islingtoncollege.txt
@@ -1,0 +1,1 @@
+Islington College, Kamal Marg, Kamal Pokhari, Kathmandu, Nepal


### PR DESCRIPTION
Adding Islington College, where I am currently doing my undergraduate Networking and IT Security degree!

Islington College is located at Kamal Marg, Kamal Pokhari, Kathmandu, Nepal and is affiliated to London Metropolitan University, London.

The official domain of the institution is islington.edu.np, and the website homepage is located at https://islington.edu.np/.
