### PR TITLE
Update ESTS IPS domain

### DIFF
--- a/lib/domains/pt/ips/estsetubal.txt
+++ b/lib/domains/pt/ips/estsetubal.txt
@@ -1,0 +1,1 @@
+Escola Superior de Tecnologia de Setúbal, Instituto Politécnico de Setúbal

--- a/lib/domains/pt/ips/estudantes.txt
+++ b/lib/domains/pt/ips/estudantes.txt
@@ -1,0 +1,1 @@
+Escola Superior de Tecnologia de Setúbal, Instituto Politécnico de Setúbal


### PR DESCRIPTION
The email domain for Escola Superior de Tecnologias de Setúbal, part of Instituto Politécnico de Setúbal is @estsetubal.ips.pt
Institution website: https://www.estsetubal.ips.pt/
Computer Science BSc information page (in portuguese): https://www.estsetubal.ips.pt/cursos/licenciaturas/ei