### PR TITLE
add Suzhou College of Information

### DIFF
--- a/lib/domains/cn/szitxy.txt
+++ b/lib/domains/cn/szitxy.txt
@@ -1,0 +1,2 @@
+苏州信息学院
+Suzhou College of Information


### PR DESCRIPTION
the school official website URL :  http://www.szitxy.cn/

the school street address : 1237 Weixiang South Road, Wujiang District, Suzhou City, Jiangsu Province

an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course:
http://www.szitxy.cn/?type=newsinfo&S_id=49

the proof which shows that my school recognizes the domain as an official email domain for the students:
http://www.szitxy.cn/?type=newsinfo&S_id=47

