### PR TITLE
Removal of expired broken domains.

### DIFF
--- a/lib/domains/ac/za/cti.txt
+++ b/lib/domains/ac/za/cti.txt
@@ -1,1 +1,0 @@
-CTI Education Group

--- a/lib/domains/az/edu/tourism.txt
+++ b/lib/domains/az/edu/tourism.txt
@@ -1,1 +1,0 @@
-Azerbaijan Toursim Institute

--- a/lib/domains/be/ac/ful.txt
+++ b/lib/domains/be/ac/ful.txt
@@ -1,1 +1,0 @@
-Fondation Universitaire Luxembourgeoise

--- a/lib/domains/br/com/souenergia.txt
+++ b/lib/domains/br/com/souenergia.txt
@@ -1,1 +1,0 @@
-FEAN - Faculdades Energia

--- a/lib/domains/ca/qc/college-em.txt
+++ b/lib/domains/ca/qc/college-em.txt
@@ -1,1 +1,0 @@
-Cégep Édouardp-Montpetit

--- a/lib/domains/cl/udelmar.txt
+++ b/lib/domains/cl/udelmar.txt
@@ -1,1 +1,0 @@
-Universidad del Mar

--- a/lib/domains/cm/uninet.txt
+++ b/lib/domains/cm/uninet.txt
@@ -1,1 +1,0 @@
-Université de Yaoundé I

--- a/lib/domains/cn/edu/dlmedu.txt
+++ b/lib/domains/cn/edu/dlmedu.txt
@@ -1,1 +1,0 @@
-Dalian Medical University

--- a/lib/domains/cn/edu/shtvu.txt
+++ b/lib/domains/cn/edu/shtvu.txt
@@ -1,1 +1,0 @@
-Shanghai Television University

--- a/lib/domains/com/mbrainacademy.txt
+++ b/lib/domains/com/mbrainacademy.txt
@@ -1,1 +1,0 @@
-mBrain Academy

--- a/lib/domains/com/uva/student.txt
+++ b/lib/domains/com/uva/student.txt
@@ -1,1 +1,0 @@
-University of Amsterdam

--- a/lib/domains/dz/univ-sba.txt
+++ b/lib/domains/dz/univ-sba.txt
@@ -1,1 +1,0 @@
-Université de Sidi-Bel-Abbès (Djillali Liabès)

--- a/lib/domains/edu/csj.txt
+++ b/lib/domains/edu/csj.txt
@@ -1,1 +1,0 @@
-College of St. Joseph

--- a/lib/domains/edu/dbumn.txt
+++ b/lib/domains/edu/dbumn.txt
@@ -1,1 +1,0 @@
-Duluth Business University

--- a/lib/domains/edu/grand-canyon.txt
+++ b/lib/domains/edu/grand-canyon.txt
@@ -1,1 +1,0 @@
-Grand Canyon University

--- a/lib/domains/edu/gvc.txt
+++ b/lib/domains/edu/gvc.txt
@@ -1,1 +1,0 @@
-Grand View College

--- a/lib/domains/edu/lacc.txt
+++ b/lib/domains/edu/lacc.txt
@@ -1,1 +1,0 @@
-Los Angeles College of Chiropractic

--- a/lib/domains/edu/sci.txt
+++ b/lib/domains/edu/sci.txt
@@ -1,1 +1,0 @@
-Benedictine University, Springfield College in Illinois

--- a/lib/domains/edu/unw.txt
+++ b/lib/domains/edu/unw.txt
@@ -1,1 +1,0 @@
-University of Northern Washington

--- a/lib/domains/edu/wbcoll.txt
+++ b/lib/domains/edu/wbcoll.txt
@@ -1,1 +1,0 @@
-Williams Baptist College

--- a/lib/domains/edu/wesleyan-college.txt
+++ b/lib/domains/edu/wesleyan-college.txt
@@ -1,1 +1,0 @@
-Wesleyan College

--- a/lib/domains/fr/ens-fcl.txt
+++ b/lib/domains/fr/ens-fcl.txt
@@ -1,1 +1,0 @@
-Ecole Normale Supérieure de Fontenay-Saint Cloud

--- a/lib/domains/fr/imie-nantes.txt
+++ b/lib/domains/fr/imie-nantes.txt
@@ -1,1 +1,0 @@
-Campus Academy

--- a/lib/domains/in/veckavali.txt
+++ b/lib/domains/in/veckavali.txt
@@ -1,1 +1,0 @@
-Visvodaya Engineering College

--- a/lib/domains/info/bcltedu.txt
+++ b/lib/domains/info/bcltedu.txt
@@ -1,1 +1,0 @@
-Bangladesh College of Leather Technology

--- a/lib/domains/ir/ac/shahryariau.txt
+++ b/lib/domains/ir/ac/shahryariau.txt
@@ -1,1 +1,0 @@
-Islamic Azad University, Shahryar

--- a/lib/domains/jp/ac/fukui-med.txt
+++ b/lib/domains/jp/ac/fukui-med.txt
@@ -1,1 +1,0 @@
-Fukui Medical School

--- a/lib/domains/jp/ac/miyazaki-med.txt
+++ b/lib/domains/jp/ac/miyazaki-med.txt
@@ -1,1 +1,0 @@
-Miyazaki Medical College

--- a/lib/domains/kg/freenet.txt
+++ b/lib/domains/kg/freenet.txt
@@ -1,4 +1,0 @@
-Bishkek Humanities University
-Jalal-Abad State University
-Kyrgyz Technical University
-Osh State University

--- a/lib/domains/kh/edu/cup.txt
+++ b/lib/domains/kh/edu/cup.txt
@@ -1,1 +1,0 @@
-Chamreun University of Poly Technology

--- a/lib/domains/kz/sci.txt
+++ b/lib/domains/kz/sci.txt
@@ -1,2 +1,0 @@
-Almaty Abai State University
-Kazak National Technical University

--- a/lib/domains/lb/edu/mut.txt
+++ b/lib/domains/lb/edu/mut.txt
@@ -1,1 +1,0 @@
-Al-Manar University

--- a/lib/domains/lv/lama.txt
+++ b/lib/domains/lv/lama.txt
@@ -1,1 +1,0 @@
-Latvian Maritime Academy

--- a/lib/domains/ma/ac/um5a.txt
+++ b/lib/domains/ma/ac/um5a.txt
@@ -1,1 +1,0 @@
-Université Mohammed V - Agdal

--- a/lib/domains/ma/ac/univ-oujda.txt
+++ b/lib/domains/ma/ac/univ-oujda.txt
@@ -1,1 +1,0 @@
-Université Mohammed Ier

--- a/lib/domains/mx/edu/umontemorelos.txt
+++ b/lib/domains/mx/edu/umontemorelos.txt
@@ -1,2 +1,0 @@
-Universidad de Montemorelos
-Universidad de Montemorelos

--- a/lib/domains/my/edu/kuin.txt
+++ b/lib/domains/my/edu/kuin.txt
@@ -1,1 +1,0 @@
-Kolej Universiti Insaniah

--- a/lib/domains/mz/ac/isri.txt
+++ b/lib/domains/mz/ac/isri.txt
@@ -1,1 +1,0 @@
-Instituto Superior de Relações Internacionais (ISRI) 

--- a/lib/domains/net/infobosccoma.txt
+++ b/lib/domains/net/infobosccoma.txt
@@ -1,1 +1,0 @@
-Institut Bosc de la Coma

--- a/lib/domains/net/ishikuniversity.txt
+++ b/lib/domains/net/ishikuniversity.txt
@@ -1,1 +1,0 @@
-Ishik University

--- a/lib/domains/net/krotoszyn/zsp2.txt
+++ b/lib/domains/net/krotoszyn/zsp2.txt
@@ -1,1 +1,0 @@
-Zespół Szkół Ponadgimnazjalnych nr 2 w Krotoszynie

--- a/lib/domains/net/nicevillehighschool.txt
+++ b/lib/domains/net/nicevillehighschool.txt
@@ -1,1 +1,0 @@
-Niceville High School

--- a/lib/domains/ng/edu/ntnu.txt
+++ b/lib/domains/ng/edu/ntnu.txt
@@ -1,1 +1,0 @@
-Nigerian Turkish Nile

--- a/lib/domains/nl/roac.txt
+++ b/lib/domains/nl/roac.txt
@@ -1,1 +1,0 @@
-Roosevelt Academy University College

--- a/lib/domains/no/Spydebergskolen.txt
+++ b/lib/domains/no/Spydebergskolen.txt
@@ -1,1 +1,0 @@
-Spydeberg Ungomsskole

--- a/lib/domains/no/vfk/skole.txt
+++ b/lib/domains/no/vfk/skole.txt
@@ -1,1 +1,0 @@
-Vestfold Fylkeskommune

--- a/lib/domains/org/az-npu.txt
+++ b/lib/domains/org/az-npu.txt
@@ -1,1 +1,0 @@
-Nakhchivan Private University

--- a/lib/domains/org/ghanacu.txt
+++ b/lib/domains/org/ghanacu.txt
@@ -1,1 +1,0 @@
-Ghana Christian University College

--- a/lib/domains/org/iesfbmoll.txt
+++ b/lib/domains/org/iesfbmoll.txt
@@ -1,1 +1,0 @@
-IES Francesc de Borja Moll

--- a/lib/domains/org/pusa-sy.txt
+++ b/lib/domains/org/pusa-sy.txt
@@ -1,1 +1,0 @@
-Private University of Science and Arts

--- a/lib/domains/ph/edu/mlqu.txt
+++ b/lib/domains/ph/edu/mlqu.txt
@@ -1,1 +1,0 @@
-Manuel L. Quezon University

--- a/lib/domains/pt/cocite.txt
+++ b/lib/domains/pt/cocite.txt
@@ -1,1 +1,0 @@
-Instituto Superior de Informática e Gestão

--- a/lib/domains/ro/faa/student.txt
+++ b/lib/domains/ro/faa/student.txt
@@ -1,1 +1,0 @@
-Faculty of Administration and Business, University of Bucharest

--- a/lib/domains/ru/conservatoire.txt
+++ b/lib/domains/ru/conservatoire.txt
@@ -1,2 +1,0 @@
-Novosibirsk State Music Academy M. Glinka
-Novosibirsk State Music Academy M. Glinka

--- a/lib/domains/ru/kursk/kstu.txt
+++ b/lib/domains/ru/kursk/kstu.txt
@@ -1,2 +1,0 @@
-Kursk State Technical University
-Kursk State Technical University

--- a/lib/domains/ru/net-ustu.txt
+++ b/lib/domains/ru/net-ustu.txt
@@ -1,1 +1,0 @@
-Ural State Technical University

--- a/lib/domains/rw/ac/nur.txt
+++ b/lib/domains/rw/ac/nur.txt
@@ -1,1 +1,0 @@
-National University of Rwanda

--- a/lib/domains/sd/edu/dalanjuniversity.txt
+++ b/lib/domains/sd/edu/dalanjuniversity.txt
@@ -1,1 +1,0 @@
-Dalanj University

--- a/lib/domains/sd/edu/nilevalley.txt
+++ b/lib/domains/sd/edu/nilevalley.txt
@@ -1,1 +1,0 @@
-Nile Valley University

--- a/lib/domains/th/ac/chiangmai.txt
+++ b/lib/domains/th/ac/chiangmai.txt
@@ -1,1 +1,0 @@
-Chiang Mai University

--- a/lib/domains/tn/esprims.txt
+++ b/lib/domains/tn/esprims.txt
@@ -1,2 +1,0 @@
-Ecole Supérieur Privée d'Ingénieur de Monastir
-Monastir Private Higher School of Engineers

--- a/lib/domains/tr/edu/anka.txt
+++ b/lib/domains/tr/edu/anka.txt
@@ -1,2 +1,0 @@
-ANKA Teknoloji Üniversitesi
-ANKA University of Technology

--- a/lib/domains/uk/org/waylandacademy/student.txt
+++ b/lib/domains/uk/org/waylandacademy/student.txt
@@ -1,1 +1,0 @@
-Wayland Academy Norfolk

--- a/lib/domains/us/fuom.txt
+++ b/lib/domains/us/fuom.txt
@@ -1,1 +1,0 @@
-Florida University of Medicine

--- a/lib/domains/uz/ibs.txt
+++ b/lib/domains/uz/ibs.txt
@@ -1,1 +1,0 @@
-International Business School Kelajak ILMI

--- a/lib/domains/vn/edu/taynguyenuni.txt
+++ b/lib/domains/vn/edu/taynguyenuni.txt
@@ -1,1 +1,0 @@
-Tay Nguyen University

--- a/lib/domains/za/co/lsdc.txt
+++ b/lib/domains/za/co/lsdc.txt
@@ -1,2 +1,0 @@
-Leseding Computer Systems
-Leseding Skills Development Centre


### PR DESCRIPTION
Domains have been checked for MX and / or SOA record.

```
tourism.edu.az
ful.ac.be
souenergia.com.br
college-em.qc.ca
udelmar.cl
uninet.cm
dlmedu.edu.cn
shtvu.edu.cn
mbrainacademy.com
student.uva.com
univ-sba.dz
csj.edu
dbumn.edu
grand-canyon.edu
gvc.edu
lacc.edu
sci.edu
unw.edu
wbcoll.edu
wesleyan-college.edu
ens-fcl.fr
imie-nantes.fr
veckavali.in
bcltedu.info
shahryariau.ac.ir
fukui-med.ac.jp
miyazaki-med.ac.jp
freenet.kg
cup.edu.kh
sci.kz
mut.edu.lb
lama.lv
um5a.ac.ma
univ-oujda.ac.ma
umontemorelos.edu.mx
kuin.edu.my
isri.ac.mz
infobosccoma.net
ishikuniversity.net
zsp2.krotoszyn.net
nicevillehighschool.net
ntnu.edu.ng
roac.nl
Spydebergskolen.no
skole.vfk.no
az-npu.org
ghanacu.org
iesfbmoll.org
pusa-sy.org
mlqu.edu.ph
cocite.pt
student.faa.ro
conservatoire.ru
kstu.kursk.ru
net-ustu.ru
nur.ac.rw
dalanjuniversity.edu.sd
nilevalley.edu.sd
chiangmai.ac.th
esprims.tn
anka.edu.tr
student.waylandacademy.org.uk
fuom.us
ibs.uz
taynguyenuni.edu.vn
lsdc.co.za

cti.za.ac
```