### PR TITLE
Adding National Institute of Technology, Andhra Pradesh

### DIFF
--- a/lib/domains/in/ac/nitandhra.txt
+++ b/lib/domains/in/ac/nitandhra.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Andhra Pradesh


### PR DESCRIPTION
a link to the site:
https://nitandhra.ac.in/