### PR TITLE
Add  Institute of Higher Secondary Education "Giovanni Falcone" Loano, Italy

### DIFF
--- a/lib/domains/it/edu/isfalcone/alu.txt
+++ b/lib/domains/it/edu/isfalcone/alu.txt
@@ -1,0 +1,1 @@
+Istituto d'Istruzione Secondaria Superiore "Giovanni Falcone" Loano


### PR DESCRIPTION
Site of the school: http://isfalcone.edu.it/

Students domain:
![Identificazione](https://user-images.githubusercontent.com/42522736/94852514-4a806c80-042a-11eb-85ab-9f91c718b31b.png)
