### PR TITLE
added UE student domain

### DIFF
--- a/lib/domains/uk/ac/ed/sms.txt
+++ b/lib/domains/uk/ac/ed/sms.txt
@@ -1,0 +1,1 @@
+University of Edinburgh


### PR DESCRIPTION
Add student email domain of @sms.ed.ac.uk
Link providing info about this email domain being used for students: [https://www.ed.ac.uk/information-services/computing/comms-and-collab/email/directories](https://www.ed.ac.uk/information-services/computing/comms-and-collab/email/directories)
Link about this university having a Computer Science program: https://www.ed.ac.uk/informatics/about

Let me know if any other information is needed.
