### PR TITLE
Adding Nettur Technical Training Foundation, India 

### DIFF
--- a/lib/domains/in/co/nttf.txt
+++ b/lib/domains/in/co/nttf.txt
@@ -1,0 +1,1 @@
+Nettur Technical Training Foundation, India


### PR DESCRIPTION
Adding NTTF institute to the eligible list. 
More details about the Unversity are:
https://en.wikipedia.org/wiki/Nettur_Technical_Training_Foundation

University website: https://www.nttftrg.com/