### PR TITLE
Add Higher Nursing School of Lisbon

### DIFF
--- a/lib/domains/pt/esel/campus.txt
+++ b/lib/domains/pt/esel/campus.txt
@@ -1,0 +1,2 @@
+Escola Superior de Enfermagem de Lisboa
+Higher Nursing School of Lisbon


### PR DESCRIPTION
Add the Higher Nursing School of Lisbon from Portugal.