### PR TITLE
PWSZ Legnica new domains added

### DIFF
--- a/lib/domains/pl/edu/legnica/pwsz/gsuite.txt
+++ b/lib/domains/pl/edu/legnica/pwsz/gsuite.txt
@@ -1,0 +1,2 @@
+The Witelon State University of Applied Sciences in Legnica
+Państwowa Wyższa Szkoła Zawodowa im Witelona w Legnicy

--- a/lib/domains/pl/edu/legnica/pwsz/stud.txt
+++ b/lib/domains/pl/edu/legnica/pwsz/stud.txt
@@ -1,0 +1,2 @@
+The Witelon State University of Applied Sciences in Legnica
+Państwowa Wyższa Szkoła Zawodowa im Witelona w Legnicy


### PR DESCRIPTION
As The Witelon State University of Applied Sciences in Legnica started using GSuite, I'm adding new domains to the list:
* `@stud.pwsz.legnica.edu.pl` for students,
* `@gsuite.pwsz.legnica.edu.pl` for academic teachers.

The old ones are working too.