### PR TITLE
Add Hawthorn High School (Pontypridd, Wales, UK)

### DIFF
--- a/lib/domains/uk/org/hawthornhs.txt
+++ b/lib/domains/uk/org/hawthornhs.txt
@@ -1,0 +1,1 @@
+Hawthorn High School


### PR DESCRIPTION
Hi,

Just found out about this. My school's not on the list yet and would love to get it added. It's Hawthorn High School in Pontypridd (Wales, UK).

Thanks!
:shipit: 