### PR TITLE
Griffith University academic email domain

### DIFF
--- a/lib/domains/au/edu/griffith.txt
+++ b/lib/domains/au/edu/griffith.txt
@@ -1,0 +1,1 @@
+Griffith University

--- a/lib/domains/au/edu/gu.txt
+++ b/lib/domains/au/edu/gu.txt
@@ -1,1 +1,0 @@
-Griffith University


### PR DESCRIPTION
Main website: https://www.griffith.edu.au
IT Degree: https://www148.griffith.edu.au/programs-courses/Program/1042/Overview/Domestic
email format for staff: https://staffhelp.secure.griffith.edu.au/app/answers/detail/a_id/3188/kw/email

Students use the @griffithuni.edu.au domain that it already stored.
