### PR TITLE
Update IES El Rincon domains

### DIFF
--- a/lib/domains/es/ieselrincon.txt
+++ b/lib/domains/es/ieselrincon.txt
@@ -1,0 +1,1 @@
+IES El Rincon


### PR DESCRIPTION
We previusly only used to give students the licenses, we now have teachers on the same domain, I didnt see a way whitelist only the domain and the subdomain,

Changelog:
Added IES El Rincon Domain ( didnt remove subdomain)