### PR TITLE
Add new domain of University of Science and Technology of China

### DIFF
--- a/lib/domains/cn/ustcmail.txt
+++ b/lib/domains/cn/ustcmail.txt
@@ -1,0 +1,2 @@
+中国科学技术大学
+University of Science and Technology of China


### PR DESCRIPTION
 University official website url: https://www.ustc.edu.cn/
Educational Offers: https://www.ustc.edu.cn/yxjs.htm
Proof university recognizes the domain: http://home.ustc.edu.cn/~sa515079/
