### PR TITLE
Update tu-bs.txt and tu-braunschweig.txt so that they match

### DIFF
--- a/lib/domains/de/tu-braunschweig.txt
+++ b/lib/domains/de/tu-braunschweig.txt
@@ -1,1 +1,1 @@
-Technische Universität Braunschweig
+Technische Universität Carolo-Wilhelmina zu Braunschweig

--- a/lib/domains/de/tu-bs.txt
+++ b/lib/domains/de/tu-bs.txt
@@ -1,1 +1,1 @@
-Technische Universität Carolo-Wilhelmina Braunschweig
+Technische Universität Carolo-Wilhelmina zu Braunschweig


### PR DESCRIPTION
Both `tu-bs.de` and `tu-braunschweig.de` are owned by the same university — Technische Universität [Carolo-Wilhelmina zu] Braunschweig (Technical University of Braunschweig). So I think the names of the university should match across both domain files.

The 'Carolo-Wilhelmina' part is to be used with 'zu', this is why I also updated the `tu-bs.txt`