### PR TITLE
ADD university of Paris

### DIFF
--- a/lib/domains/fr/u-paris/etu.txt
+++ b/lib/domains/fr/u-paris/etu.txt
@@ -1,0 +1,2 @@
+Université de Paris
+University of Paris


### PR DESCRIPTION
from janurary 2020, university of Paris 5 (Descartes) and university of Paris 7 (Diderot) made an alliance and became University of Paris. Since then we students have email under the domain name of " etu.u-paris.fr "