### PR TITLE
added IMDEA Institute (imdea.org) domain

### DIFF
--- a/lib/domains/org/imdea.txt
+++ b/lib/domains/org/imdea.txt
@@ -1,0 +1,2 @@
+Instituto IMDEA
+IMDEA Institute


### PR DESCRIPTION
The IMDEA Institutes are public research centers of excellence based in the Region of Madrid. They were established as independent foundations between 2006 and 2007 at the initiative of the regional government. They are focused on seven strategic areas for society from a business, scientific and technological point of view: water, food, energy, materials, nanoscience, networks and software. 

IMDEA Software institute professors and students are the ones that will mostly use JetBrains products for teaching and research activities. 

* website of the foundation: www.imdea.org/en
* website of the software institute: www.software.imdea.org
* one of the courses taught by IMDEA professors: http://muss.fi.upm.es/en/asigCS.php

