### PR TITLE
Create new IBA Karachi

### DIFF
--- a/lib/domains/pk/edu/iba/khi.txt
+++ b/lib/domains/pk/edu/iba/khi.txt
@@ -1,0 +1,4 @@
+Institute Of Business Administration
+Institute Of Business Administration Karachi
+IBA 
+IBA Karachi


### PR DESCRIPTION
I would like to clarify that IBA does **not** give anyone apart from its students this domain's email address. Only students get it after their admission is confirmed to use for official purpose and keeping in touch with the university while studying as you can see in the screenshot we have to get them activated too.

Website: https://iba.edu.pk/
4-year CS degree link: https://cs.iba.edu.pk/programs.html#bsc
Screenshot to prove official email domain for all students:
![image](https://user-images.githubusercontent.com/68906588/96658134-3eb70480-135d-11eb-916e-7896e3951b14.png)
