### PR TITLE
Added Gothenburgs Institute of Technology (GTI) to the domains list

### DIFF
--- a/lib/domains/se/gti.txt
+++ b/lib/domains/se/gti.txt
@@ -1,0 +1,2 @@
+Göteborgs Tekniska Institut
+Gothenburgs Institute of Technology


### PR DESCRIPTION
The official website of the school: https://www.gti.se/
Technical program: https://www.gti.se/te.php
Science program: https://www.gti.se/na.php