### PR TITLE
Adding Beijing Institute of Technology

### DIFF
--- a/lib/domains/com/edu/bit.txt
+++ b/lib/domains/com/edu/bit.txt
@@ -1,0 +1,2 @@
+北京理工大学
+Beijing Institute of Technology


### PR DESCRIPTION
I'm sorry for putting the file in the wrong place. I will make the pull request again. Please check it at your convenience. Thank you!
University official website: http://www.bit.edu.cn/
URL of a page where a long-term (>1 year) IT related course is offered:
http://grd.bit.edu.cn/pygz/pyfa/index.htm
http://www.bit.edu.cn/xww/xzw/xydt2/192015.htm
http://grd.bit.edu.cn/pygz/pyfa/wjxz_pyfa/154359.htm
We have related courses and communications.
URL of a page showing that the university recognizes the domain as an official email domain for the enrolled students: http://www.bit.edu.cn/ggfw/gzyx/index.htm. You can see that all the departments working email address of our school use bit.edu.cn as the domain.
