### PR TITLE
Added htl-kaindorf.ac.at (academic email of HTBLA Kaindorf)

### DIFF
--- a/lib/domains/at/ac/htl-kaindorf.txt
+++ b/lib/domains/at/ac/htl-kaindorf.txt
@@ -1,0 +1,2 @@
+Höhere Technische Bundeslehranstalt Kaindorf
+Federal Higher Technical Institute Kaindorf


### PR DESCRIPTION
Website URL (German): [www.htl-kaindorf.at](www.htl-kaindorf.at)
Informatics Department: [https://www.htl-kaindorf.at/abteilungen/informatik](https://www.htl-kaindorf.at/abteilungen/informatik)
There already is a entry for only the `htl-kaindorf.at` email but the `ac.at` one did not exist