### PR TITLE
Add Lake Highland Preparatory School

### DIFF
--- a/lib/domains/org/lhprep.txt
+++ b/lib/domains/org/lhprep.txt
@@ -1,0 +1,1 @@
+Lake Highland Preparatory School

--- a/lib/domains/org/lhps.txt
+++ b/lib/domains/org/lhps.txt
@@ -1,0 +1,1 @@
+Lake Highland Preparatory School


### PR DESCRIPTION
Adds two domains used by current Lake Highland Preparatory School students (lhprep.org) and faculty (lhps.org). Alumni do not retain access to their email addresses. 

LHPS offers high school and college-level (AP) courses in computer science: https://www.lhps.org/academics/upper-school/curriculum 