### PR TITLE
Add @eduvaud.ch

### DIFF
--- a/lib/domains/ch/eduvaud.txt
+++ b/lib/domains/ch/eduvaud.txt
@@ -1,0 +1,3 @@
+Toutes les personnes en formation, ainsi que le personnel enseignant du Département de la formation, de la jeunesse et de la culture.
+All trainees, as well as the teaching staff of the Department of Training, Youth and Culture.
+.group


### PR DESCRIPTION
With the COVID a region of Switzerland has created a domain for all the schools, and so we have change our mail addresses.

Example:

**@epsic.educanet2.ch** become **@eduvaud.ch,** also **@educanet2.ch** will be shutdown the 31 december 2020, so a lot of the schools with _educanet2_ will use _eduvaud_ if they are in the Vaud region of Switzerland.

I don't know if you want to delete the files under lib/domains/ch/educanet2