### PR TITLE
Added Genokolleg Münster

### DIFF
--- a/lib/domains/de/genoapps.txt
+++ b/lib/domains/de/genoapps.txt
@@ -1,0 +1,1 @@
+Genokolleg Münster


### PR DESCRIPTION
URL genoapps.de resolves to genokolleg.de (Official Site)
In the footer there is a link to mail.genoapps.de for Webmail access. The Student Mails are @genoapps.de

A site that proves there are Informatic Course offers can be found here: https://genokolleg.de/bildungsangebot/informatik/