### PR TITLE
Add request Aab College

### DIFF
--- a/file/lib/domains/com/universitetiaab.txt
+++ b/file/lib/domains/com/universitetiaab.txt
@@ -1,0 +1,2 @@
+Kolegji AAB
+AAB College


### PR DESCRIPTION
AAB College uses domain https://aab-edu.net/en/ as their web page and @universitetiaab.com as email domain.

Here's the CS faculty link:
https://aab-edu.net/en/faculties/computer-sciences/