### PR TITLE
imie domains no longer active

### DIFF
--- a/lib/domains/academy/campus.txt
+++ b/lib/domains/academy/campus.txt
@@ -1,1 +1,0 @@
-Campus Academy

--- a/lib/domains/eu/campus-academy.txt
+++ b/lib/domains/eu/campus-academy.txt
@@ -1,1 +1,0 @@
-Campus Academy

--- a/lib/domains/fr/imie-nantes.txt
+++ b/lib/domains/fr/imie-nantes.txt
@@ -1,1 +1,0 @@
-Campus Academy

--- a/lib/domains/fr/imie.txt
+++ b/lib/domains/fr/imie.txt
@@ -1,1 +1,0 @@
-Campus Academy


### PR DESCRIPTION
imie domains are no longer active, with some warnings : 

- imie.fr and imie-nantes.fr shall not be used by anyone because these mailboxes are going deleted
- imie-paris.fr is not the same entity and its management shall be done on separate requests
