### PR TITLE
Add Open Colleges

### DIFF
--- a/lib/domains/au/edu/opencolleges.txt
+++ b/lib/domains/au/edu/opencolleges.txt
@@ -1,0 +1,1 @@
+Open Colleges


### PR DESCRIPTION
Hello!

Open Colleges (https://www.opencolleges.edu.au/) is a registered learning institute in Australia which provides a variety of courses including diploma courses.

It'd be great to have it added to this list so staff/students can use some of the JetBrains products. Thanks