### PR TITLE
Add LNPU to JetBrains's Swot.

### DIFF
--- a/lib/domains/cn/lnpu/edu/stu.txt
+++ b/lib/domains/cn/lnpu/edu/stu.txt
@@ -1,0 +1,2 @@
+辽宁石油化工大学
+Liaoning University of Petroleum and Chemical Technology


### PR DESCRIPTION
Formal name: [辽宁石油化工大学](https://zh.wikipedia.org/zh-hans/%E8%BE%BD%E5%AE%81%E7%9F%B3%E6%B2%B9%E5%8C%96%E5%B7%A5%E5%A4%A7%E5%AD%A6)
English name: [Liaoning University of Petroleum and Chemical Technology](https://en.wikipedia.org/wiki/Liaoning_University_of_Petroleum_and_Chemical_Technology) or Liaoning Shihua University
Official Website: [Chinese](http://www.lnpu.edu.cn/), [English](http://www.lnpu.edu.cn/english/index.htm)
