### PR TITLE
Add `Enseignement de la Province de Liège`

### DIFF
--- a/lib/domains/be/efpl.txt
+++ b/lib/domains/be/efpl.txt
@@ -1,0 +1,2 @@
+Enseignement de la Province de Liège
+.group


### PR DESCRIPTION
Domain: [efpl.be](http://efpl.be) (open in new tab)
Which points to the education section website of the Province of Liège (an administrative subdivision in Belgium), officially called "Enseignement Provincial" or "Enseignement de la Province de Liège" if you are mentioning it outside of thesaid province. This groups several public education institutes under a common network.

Example of relevant education program: [Bachelor degree in Management Information Technology](http://www.provincedeliege.be/node/2919) which is a 3-4 years college program organized by two institutes from the following network. This program is described by the following (translated from the given page):

> Develops skill sets in different axes:
> 
> Procedural, management-oriented and object-oriented programming.
> Network administration and management.
> Database management systems.
> Analysis and design of applications.
> 
> Emphasizes the development of professional skills beyond strictly technical skills:
> 
> become aware of the constant evolution of the IT and information and communication technologies professions;
> implement professional behaviors based on critical thinking, self - training and a sense of communication;
> put into practice collective skills (shared or team work) and aptitudes for fitting into quality management projects and procedures.

The screenshot given below is taken from a student profile page connected to the common online platform called "École Virtuelle". It will hopefully illustrate how the domain name is used for e-mailing. In the middle, you can read a sentence saying "Connect to École Virtuelle with your [email] identity `<name>.<surname>@student.efpl.be`. This unique account allows you to connect to [Office 365 (whose email is provided), schedules, carshare, WiFi network]." This system with the email id was only implemented a few months ago. This is why no request for it has been pulled so far.
![Screenshot_20201114_191612](https://user-images.githubusercontent.com/54140912/99154305-016d3a80-26af-11eb-971b-969433d0fc5c.png)

