### PR TITLE
Add Shekou International School

### DIFF
--- a/lib/domains/cn/org/sis.txt
+++ b/lib/domains/cn/org/sis.txt
@@ -1,0 +1,3 @@
+Shekou International School
+蛇口国际学校
+URL: https://www.sis-shekou.org/


### PR DESCRIPTION
Official school website URL: [](https://www.sis-shekou.org/)
School address: 1089-51 Wanghai Road, Nanshan, Shenzhen, Guangdong, People's Republic of China

