### PR TITLE
Add hss-wi and hss-wiesloch (Hubert-Sternberg-Schule Wiesloch)

### DIFF
--- a/lib/domains/de/hss-wi.txt
+++ b/lib/domains/de/hss-wi.txt
@@ -1,0 +1,1 @@
+Hubert-Sternberg-Schule Wiesloch

--- a/lib/domains/de/hss-wiesloch.txt
+++ b/lib/domains/de/hss-wiesloch.txt
@@ -1,0 +1,1 @@
+Hubert-Sternberg-Schule Wiesloch


### PR DESCRIPTION
Website of the school: https://www.hss-wiesloch.de/

The school changed the email from **myhss.de** to **hss-wi.de** for students and to **hss-wiesloch.de** for teachers.

You can find the new emails on this page:
https://www.hss-wiesloch.de/ueber-uns/personen/kollegium/

The domain **myhss.de** is still in use for old accounts.
Pull-Request of [de/myhss.txt](https://github.com/JetBrains/swot/blob/master/lib/domains/de/myhss.txt):
https://github.com/JetBrains/swot/pull/3088
