### PR TITLE
Added the domain of the Austrian Academy of Sciences

### DIFF
--- a/lib/domains/at/ac/oeaw.txt
+++ b/lib/domains/at/ac/oeaw.txt
@@ -1,0 +1,2 @@
+Österreichische Akademie der Wissenschaften
+Austrian Academy of Sciences


### PR DESCRIPTION
Institution website: https://www.oeaw.ac.at/
The department of digital humanities's research projects will profit immensely from access to the academic license: https://www.oeaw.ac.at/acdh/ 