### PR TITLE
Add CY Cergy Paris Université

### DIFF
--- a/lib/domains/fr/cyu.txt
+++ b/lib/domains/fr/cyu.txt
@@ -1,0 +1,2 @@
+CY Cergy Paris Université
+CY Cergy Paris Université

--- a/lib/domains/fr/cyu/etu.txt
+++ b/lib/domains/fr/cyu/etu.txt
@@ -1,0 +1,2 @@
+CY Cergy Paris Université
+CY Cergy Paris Université


### PR DESCRIPTION
https://www.cyu.fr/
Transition in progress from u-cergy.fr and eisti.fr to cyu.fr
Mail addresses for students are on etu.cyu.fr domain.