### PR TITLE
Add Palisades Charter High School

### DIFF
--- a/lib/domains/org/palihigh/pchs.txt
+++ b/lib/domains/org/palihigh/pchs.txt
@@ -1,0 +1,1 @@
+Palisades Charter Highschool


### PR DESCRIPTION
School URL: https://www.palihigh.org/
IT course URL(Look page 71 and beyond for info): https://www.palihigh.org/pdfs/Course%20Catalog%2032819.pdf 