### PR TITLE
Added @uni-a.de for University Augsburg

### DIFF
--- a/lib/domains/de/uni-a.txt
+++ b/lib/domains/de/uni-a.txt
@@ -1,0 +1,2 @@
+Universität Augsburg
+Augsburg University


### PR DESCRIPTION
university official website URL: https://www.uni-augsburg.de/en/
a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: e.g.: https://www.uni-augsburg.de/en/studium/studienangebot/uebersicht/computer-science-msc/

Proof of address, wehere you can see that I'm enrolled as a student (i'm enrolled in courses), and that my official University address is @uni-a.de
![image](https://user-images.githubusercontent.com/15928942/99880288-dfc20500-2c12-11eb-85f3-8c249104166b.png)
