### PR TITLE
Don Boscocollege Zwijnaarde

### DIFF
--- a/lib/domains/be/dbz.txt
+++ b/lib/domains/be/dbz.txt
@@ -1,0 +1,1 @@
+Don Boscocollege Zwijnaarde


### PR DESCRIPTION
https://dbz.be/ict-als-vak-en-ict-in-de-vakken