### PR TITLE
Login Berufsbildung AG added (2. try)

### DIFF
--- a/lib/domains/org/login.txt
+++ b/lib/domains/org/login.txt
@@ -1,0 +1,1 @@
+Login Berufsbildung AG

--- a/lib/domains/org/mylogin.txt
+++ b/lib/domains/org/mylogin.txt
@@ -1,0 +1,1 @@
+Login Berufsbildung AG


### PR DESCRIPTION
After your comment regarding pull request #10007 I checked the domain "mylogin.org" again and according to ICANN, it is affiliated to my Vocational school. I also tried to ping it and the website itself and it worked completely fine, but the website/server was actually down for some time.

My own results below:

![image](https://user-images.githubusercontent.com/38193572/99911412-85997080-2cf4-11eb-9db2-6a4c3dec4e81.png)

![mylogin_icann](https://user-images.githubusercontent.com/38193572/99911467-e7f27100-2cf4-11eb-9e70-aa7e78b33241.png)

But you actually drew my attention to a mistake of mine. I really forgot to add the domain "login.org" as well, which now should be correct.

I hope everything's fine now and you are now able to check my request, I'm very sorry for the inconvenience!