### PR TITLE
add domain(kobedenshi.ac.jp)

### DIFF
--- a/lib/domains/jp/ac/kobedenshi.txt
+++ b/lib/domains/jp/ac/kobedenshi.txt
@@ -1,0 +1,1 @@
+Kobe Institute of Computing


### PR DESCRIPTION
Kobe Institute of Computing(Japanese: Kobedenshi Senmon-gakko) is a technical shcool in Kobe, Japan.
