### PR TITLE
Add IES Plaiaundi BHI

### DIFF
--- a/lib/domains/com/plaiaundi.txt
+++ b/lib/domains/com/plaiaundi.txt
@@ -1,0 +1,2 @@
+IES Plaiaundi BHI
+Plaiaundi Vocational Institute

--- a/lib/domains/eus/plaiaundi.txt
+++ b/lib/domains/eus/plaiaundi.txt
@@ -1,0 +1,2 @@
+IES Plaiaundi BHI
+Plaiaundi Vocational Institute

--- a/lib/domains/net/plaiaundi.txt
+++ b/lib/domains/net/plaiaundi.txt
@@ -1,0 +1,2 @@
+IES Plaiaundi BHI
+Plaiaundi Vocational Institute


### PR DESCRIPTION
There are two domains for teacher emails (com and eus), and one for student emails (net):

-  [http://www.plaiaundi.com](http://www.plaiaundi.com)
-  [http://www.plaiaundi.net](http://www.plaiaundi.net)
-  [http://www.plaiaundi.eus](http://www.plaiaundi.eus)



![com+eus](https://user-images.githubusercontent.com/61630936/100203971-92d87a00-2f03-11eb-8bf8-3115ff066dad.png)
![net](https://user-images.githubusercontent.com/61630936/100203976-93711080-2f03-11eb-9447-e58b52eb2883.png)
