### PR TITLE
added 1lo im. J. H. Dabrowskiego w Kutnie

### DIFF
--- a/lib/domains/com/onmicrosoft/1lokutno.txt
+++ b/lib/domains/com/onmicrosoft/1lokutno.txt
@@ -1,0 +1,1 @@
+I Liceum Ogólnokształcące im. gen. J. H. Dąbrowskiego w Kutnie


### PR DESCRIPTION
1lo im. gen. J. H. Dabrowskiego is a high school in Kutno, Poland. They also offer curriculum with extended computer science, mathematics and physics. The official website of the school: https://www.dabrowszczak.pl/
Educational offer with a mention of written above educational program: https://www.dabrowszczak.pl/index.php?c=page&id=173
![image](https://user-images.githubusercontent.com/75544909/101265437-c5c20f80-3746-11eb-9670-59aa357cba19.png)

