### PR TITLE
Add Soochow University

### DIFF
--- a/lib/domains/cn/edu/suda/stu.txt
+++ b/lib/domains/cn/edu/suda/stu.txt
@@ -1,0 +1,5 @@
+Soochow University
+苏州大学
+university official website URL：http://www.suda.edu.cn/
+a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university：http://scst.suda.edu.cn/11195/list.htm
+a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.：https://its.suda.edu.cn/44/81/c2326a214145/page.htm


### PR DESCRIPTION
university official website URL：http://www.suda.edu.cn/
a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university：http://scst.suda.edu.cn/11195/list.htm
a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.：https://its.suda.edu.cn/44/81/c2326a214145/page.htm