### PR TITLE
Corrected University POLITEHNICA of Bucharest's name

### DIFF
--- a/lib/domains/ro/pub.txt
+++ b/lib/domains/ro/pub.txt
@@ -1,1 +1,1 @@
-University Politehnica of Bucharest
+University POLITEHNICA of Bucharest

--- a/lib/domains/ro/upb.txt
+++ b/lib/domains/ro/upb.txt
@@ -1,1 +1,1 @@
-University Politehnica of Bucharest
+University POLITEHNICA of Bucharest


### PR DESCRIPTION
I corrected the university name since the documents demand that the official english name has the word "POLITEHNICA" in all capitals.