### PR TITLE
Add Anatolia College

### DIFF
--- a/lib/domains/gr/edu/anatolia.txt
+++ b/lib/domains/gr/edu/anatolia.txt
@@ -1,0 +1,1 @@
+Anatolia College


### PR DESCRIPTION
1) Official URL address of Anatolia College: https://anatolia.edu.gr/en/
2) Anatolia College follows the education curriculum provided by the Greek Ministry of Education. Because of that, students are enrolled in IT and Computer Science classes during all the 6 years of gymnasium and lyceum. An outline of the Greek education system is presented in the website below:
https://en.wikipedia.org/wiki/Education_in_Greece#Lyceum
In addition, Anatolia College provides IB studies, which also include a Computer Science class. The following is a document from Anatolia College that proves my claim:
http://anatolia.edu.gr/images/highschool/IBDP/ibdp_brochure_april2019_english.pdf (page 15)
3) On [this](https://anatolia.edu.gr/en/contact) page there can be seen the e-mail addresses of some of the faculty. Teachers have the anatolia.edu.gr domain and students have the student.anatolia.edu.gr domain. I have attached a screenshot of a student's (mine) Learning Management Platform, which proves that student's email addresses actually belong in the domain student.anatolia.edu.gr.
![proof](https://user-images.githubusercontent.com/65295762/102380458-9aee7b80-3fd0-11eb-9b33-86c3fa8f88fc.png)
