### PR TITLE
Add stis.ac.id domain of STIS Polytechnic of Statistics

### DIFF
--- a/lib/domains/id/ac/stis.txt
+++ b/lib/domains/id/ac/stis.txt
@@ -1,0 +1,2 @@
+Politeknik Statistika STIS
+STIS Polytechnic of Statistics


### PR DESCRIPTION
Politeknik Statistika STIS, Jakarta, Indonesia
https://stis.ac.id/