### PR TITLE
Add teachers of non-commercial schools of ministry of education (moe)

### DIFF
--- a/lib/domains/eg/edu/moe/t3.txt
+++ b/lib/domains/eg/edu/moe/t3.txt
@@ -1,0 +1,1 @@
+The Ministry of Education


### PR DESCRIPTION
Non-commercial school's teachers belong to Ministry of Education