### PR TITLE
Added Chesterfield High School

### DIFF
--- a/lib/domains/uk/co/chesterfieldhigh.txt
+++ b/lib/domains/uk/co/chesterfieldhigh.txt
@@ -1,0 +1,1 @@
+Chesterfield High School


### PR DESCRIPTION
Note: Website is chesterfieldhigh.org.uk, email domain is chesterfieldhigh.co.uk.