### PR TITLE
Add gmet.sk

### DIFF
--- a/lib/domains/sk/gmet.txt
+++ b/lib/domains/sk/gmet.txt
@@ -1,0 +1,1 @@
+GYMNÁZIUM, Metodova 2, Bratislava


### PR DESCRIPTION
Official website: https://gmet.edupage.org/
However, teachers and studens use `@gmet.sk` emails (see https://gmet.edupage.org/contact/).