### PR TITLE
Add St Johns Academy, Marlborough

### DIFF
--- a/lib/domains/uk/org/excalibur/stjohns.txt
+++ b/lib/domains/uk/org/excalibur/stjohns.txt
@@ -1,0 +1,2 @@
+St John's Marlborough
+St John's Marlborough


### PR DESCRIPTION
Academy Website  - [St Johns Marlbrough](https://www.stjohns.excalibur.org.uk/)

St Johns offers various higher education courses such as A-Levels and BTECs. Notably it offers a two year A-Level course in Computer Science which teaches many in depth software devlopment techniques.

The course detail PDF can be found on this [Course Details](https://www.stjohns.excalibur.org.uk/sixth-form/courses/#1583486728415-e6feb5cd-f627) page

Additionally, proof of recoginzation of the domain added can be seen on the Academy [Contact](https://www.stjohns.excalibur.org.uk/about-us/contact/) page