### PR TITLE
Adding Städtisches Werner-von-Siemens-Gymnasium München

### DIFF
--- a/lib/domains/de/musin/wsg.txt
+++ b/lib/domains/de/musin/wsg.txt
@@ -1,0 +1,1 @@
+Städtisches Werner-von-Siemens-Gymnasium München


### PR DESCRIPTION
Please add our Werner-von-Siemens-Gymnasium München

the school official website URL:
http://www.wsg.musin.de/
an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course:
http://www.wsg.musin.de/unterricht/informatik
a proof, which shows that the school recognizes the domain you are submitting as an official email domain for the students:
http://www.wsg.musin.de/kontakt/kontaktformular - compare to the email domain mentioned on this page
