### PR TITLE
added Max Planck School of Cognition

### DIFF
--- a/lib/domains/de/maxplanckschools.txt
+++ b/lib/domains/de/maxplanckschools.txt
@@ -1,0 +1,1 @@
+Max Planck School of Cognition


### PR DESCRIPTION
email domain @maxplanckschools.de. Find info on the program [here](https://www.maxplanckschools.de/en/cognition).