### PR TITLE
Adding BBS1 Mainz

### DIFF
--- a/lib/domains/de/bbs1-mainz/unterricht.txt
+++ b/lib/domains/de/bbs1-mainz/unterricht.txt
@@ -1,0 +1,1 @@
+BBS 1 Mainz


### PR DESCRIPTION
Please add the BBS1 Mainz.

Official Website: http://bbs1-mainz.de/ & http://bbs1-mainz.com/
a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: http://www.bbs1-mainz.com/bildungsgaenge/berufsschule/berufsfelder-elektrotechnikinformatik.html

German: 
![image](https://user-images.githubusercontent.com/25898464/104188961-4c3ed080-541a-11eb-85ef-70fe7a82225e.png)

English (Google Translate):

![image](https://user-images.githubusercontent.com/25898464/104189018-624c9100-541a-11eb-871b-4611f4d565ec.png)


