### PR TITLE
Add Bury Grammar School

### DIFF
--- a/lib/domains/com/burygrammar.txt
+++ b/lib/domains/com/burygrammar.txt
@@ -1,0 +1,1 @@
+Bury Grammar School


### PR DESCRIPTION
Bury Grammar School is a British secondary school/sixth form college that provides GCSE Computer Science and A-Level Computer Science to its students (as can be found here - https://www.burygrammar.com/academic/academic-faculties/social-sciences-and-computer-science-faculty/computer-science).

Its main URL is https://burygrammar.com/

Proof of email using this domain: 
![image](https://user-images.githubusercontent.com/24853914/104608558-ef415580-5679-11eb-8efa-b3289726132a.png)
