### PR TITLE
Add new domain for SibSUTIS

### DIFF
--- a/lib/domains/ru/sibguti.txt
+++ b/lib/domains/ru/sibguti.txt
@@ -1,0 +1,1 @@
+Siberian State University of Telecommunications and Information Sciences


### PR DESCRIPTION
When switching to remote leaning, our university acquired a new domain for organizing work in Google services. The redirection from the new domain (sibguti.ru) to the old one (sibsutis.ru) is also configured.