### PR TITLE
Städtisches Gymnasium Olpe

### DIFF
--- a/lib/domains/com/onmicrosoft/kreisstadtolpe.txt
+++ b/lib/domains/com/onmicrosoft/kreisstadtolpe.txt
@@ -1,0 +1,1 @@
+Städtisches Gymnasium Olpe


### PR DESCRIPTION
Städtisches Gymnasium Olpe
https://gymnasium-olpe.de