### PR TITLE
add o365sen.net

### DIFF
--- a/lib/domains/net/o365sen.txt
+++ b/lib/domains/net/o365sen.txt
@@ -1,0 +1,1 @@
+Seoul Metropolitan Office for Education

--- a/lib/domains/net/o365sen.txt
+++ b/lib/domains/net/o365sen.txt
@@ -1,1 +1,2 @@
+서울특별시교육청
 Seoul Metropolitan Office for Education


### PR DESCRIPTION
Seoul Metropolitan Office for Education (서울특별시교육청), gives an account with Microsoft Office 365 subscription to students who applied for it. This domain is **not** only for a school, it's for students in Seoul, Korea.
[Link for Seoul Metropolitan Office for Education](https://www.sen.go.kr/) <-- This page may not support English.