### PR TITLE
added 'hansenberg' folder to lib/domains/de

### DIFF
--- a/lib/domains/de/hansenberg/edu.txt
+++ b/lib/domains/de/hansenberg/edu.txt
@@ -1,0 +1,2 @@
+Internatsschule Schloss Hansenberg
+Boarding School Schloss Hansenberg

--- a/lib/domains/schule/smmp-eb.txt
+++ b/lib/domains/schule/smmp-eb.txt
@@ -1,1 +1,0 @@
-Engelsburg Gymnasium Kassel

--- a/lib/domains/schule/smmp-eb.txt
+++ b/lib/domains/schule/smmp-eb.txt
@@ -1,0 +1,1 @@
+Engelsburg Gymnasium Kassel


### PR DESCRIPTION
URL of my school: https://www.hansenberg.de/
URL of the page showing my school offering an IT-Course: https://www.hansenberg.de/lernen/unterricht/faecher.html

As to the school recognising the domain: in footer of the homepage, you can see the school using the domain themselves, meaning one cannot get an email of said domain without them knowing. I hope that is enough proof for you to accept that as them recognising a student's email having their domain as an official one.