### PR TITLE
Added Garfield high school

### DIFF
--- a/lib/domains/org/seattleschools.txt
+++ b/lib/domains/org/seattleschools.txt
@@ -1,1 +1,2 @@
 Washington Middle School
+Garfield High School


### PR DESCRIPTION
Added Garfield high School to the Seattle public schools(SPS) domain.