### PR TITLE
Eichendorffschule Kelkheim

### DIFF
--- a/lib/domains/education/eichendorffschule.txt
+++ b/lib/domains/education/eichendorffschule.txt
@@ -1,0 +1,1 @@
+Eichendorffschule Kelkheim

--- a/lib/domains/net/eichendorffschule.txt
+++ b/lib/domains/net/eichendorffschule.txt
@@ -1,0 +1,1 @@
+Eichendorffschule Kelkheim


### PR DESCRIPTION
Hello!

I have added two domains, eichendorffschule.net, which is the official website and email domain of all teachers and eichendorffschule.education, which is the school's email domain for students, but also some teachers.

Eichendorffschule Kelkheim is a state comprehensive school in Hesse, Germany.

Link to the German imprint on the school's homepage, which confirms all legal details: https://www.eichendorffschule.net/Datenschutz-Kontakt-Impressum/Impressum-E1022.htm

For the domain eichendorffschule.education there is no publicly visible evidence apart from the matching WHOIS and the domain forwarding, but if you give me an email address of yours I can send you a letter from the school management confirming the domain.

Kind regards
Marvin

Note: You merged an identical pull request earlier, but a bot deleted all the commits in my fork, so you only merged an empty fork, without any files.