### PR TITLE
Added Bolnore School

### DIFF
--- a/lib/domains/uk/co/bolnoreschool.txt
+++ b/lib/domains/uk/co/bolnoreschool.txt
@@ -1,0 +1,1 @@
+Bolnore Village Primary School


### PR DESCRIPTION
School website uses different domain - https://www.bolnorevillageprimary.org.uk - the email is managed under Google Classrooms.