### PR TITLE
added unimetrocamp.edu.br

### DIFF
--- a/lib/domains/br/edu/unimetrocamp.txt
+++ b/lib/domains/br/edu/unimetrocamp.txt
@@ -1,0 +1,1 @@
+Centro Universitário UniMetrocamp


### PR DESCRIPTION
added unimetrocamp.edu.br
university official website: https://www.wyden.com.br/unimetrocamp/
URL of a page on the official website where a long-term (>1 year) IT related course: https://www.wyden.com.br/unimetrocamp/cursos/graduacao/tecnologia/ciencia-da-computacao