### PR TITLE
Add domain for USCS

### DIFF
--- a/lib/domains/br/com/uscsonline.txt
+++ b/lib/domains/br/com/uscsonline.txt
@@ -1,0 +1,1 @@
+Universidade Municipal de São Caetano do Sul


### PR DESCRIPTION
This adds [Universidade Municipal de São Caetano do Sul](https://uscs.edu.br), which recently changed their domain for students accounts.