### PR TITLE
Add MCRI

### DIFF
--- a/lib/domains/au/edu/mcri.txt
+++ b/lib/domains/au/edu/mcri.txt
@@ -1,0 +1,1 @@
+Murdoch Children's Research Institute


### PR DESCRIPTION
Request to add the Murdoch Children's Research Institute www.mcri.edu.au as a recognised non profit educational organisation.

Here is a link to information about our students and long term courses longer than one year https://www.mcri.edu.au/students. Our courses include major computing topics such as computer science, software engineering, statistics & bioinformatics.

All students receive an institute email address in the form of firstname.lastname@mcri.edu.au.