### PR TITLE
add sibs

### DIFF
--- a/lib/domains/cn/ac/sibs.txt
+++ b/lib/domains/cn/ac/sibs.txt
@@ -1,0 +1,1 @@
+Shanghai Institute of Nutrition and Health, Chinese Academy of Sciences


### PR DESCRIPTION
add sibs.txt into lib/domain/

SINH, Shanghai Institute of Nutrition and Health, is an institute of Chinese Academy of Sciences, with many Master and Ph.D candidates students who major in computational biology and bioinformatics.

university official website: https://www.ucas.ac.cn/
institute official website: http://www.sinh.cas.cn/
