### PR TITLE
Added Baze University Abuja

### DIFF
--- a/lib/domains/ng/edu/bazeuniversity.txt
+++ b/lib/domains/ng/edu/bazeuniversity.txt
@@ -1,0 +1,1 @@
+Baze University Abuja


### PR DESCRIPTION
Added Baze University Abuja, Nigeria to the list.
University Website Link: https://bazeuniversity.edu.ng
![homepage](https://user-images.githubusercontent.com/23098333/106737054-857ff000-6616-11eb-8fb9-7413974f0119.PNG)
![home2](https://user-images.githubusercontent.com/23098333/106737141-9e88a100-6616-11eb-9b2f-69c57a06ab22.PNG)

List of Full-Time Undergraduate and PG courses: https://bazeuniversity.edu.ng/search/
![courses](https://user-images.githubusercontent.com/23098333/106736984-6bdea880-6616-11eb-85cb-4738034c83f0.PNG)

List of Staff: https://bazeuniversity.edu.ng/academics/faculties-and-staff.php
![stafflist](https://user-images.githubusercontent.com/23098333/106737214-b2cc9e00-6616-11eb-80e2-f2932017d5a2.PNG)

