### PR TITLE
HTBLuVA St.Pölten

### DIFF
--- a/lib/domains/at/ac/htlstp.txt
+++ b/lib/domains/at/ac/htlstp.txt
@@ -1,0 +1,1 @@
+HTBLuVA St.Pölten


### PR DESCRIPTION
Homepage: https://www.htlstp.ac.at/
we are a higher technical school with departements of electronic, information technologie, electrical engineering, 
the duration of study is five years.