### PR TITLE
add New Berlin, WI USA school district domain

### DIFF
--- a/lib/domains/org/nbexcellence.txt
+++ b/lib/domains/org/nbexcellence.txt
@@ -1,0 +1,6 @@
+New Berlin Eisenhower Middle/High School
+New Berlin Eisenhower High School
+New Berlin Eisenhower Middle School
+New Berlin Eisenhower
+Eisenhower
+.group

--- a/lib/domains/org/nbexcellence/stu.txt
+++ b/lib/domains/org/nbexcellence/stu.txt
@@ -1,0 +1,6 @@
+New Berlin Eisenhower Middle/High School
+New Berlin Eisenhower High School
+New Berlin Eisenhower Middle School
+New Berlin Eisenhower
+Eisenhower
+.group


### PR DESCRIPTION
This Pull Request adds [New Berlin Eisenhower Middle / High School](https://www.nbexcellence.org/schools/eisenhower/) to your database. [The New Berlin school district](http://www.newberlinschooldistrict.com/) shares a common email domain that is unfortunately not a `.edu` domain. Students are identified by `@stu.nbexcellence.org` whereas teachers and staff are identified by `@nbexcellence.org`.

[The school district website](https://www.nbexcellence.org/district/information-technology.cfm) describes how it offers courses in Information Technology and Computer Science. Specifically, there is an intro to programming course offered at Eisenhower that uses Java.