### PR TITLE
add Pejuang University of Republic of Indonesia

### DIFF
--- a/lib/domains/id/ac/upri.txt
+++ b/lib/domains/id/ac/upri.txt
@@ -1,0 +1,2 @@
+Universitas Pejuang Republik Indonesia
+Pejuang University of Republic of Indonesia


### PR DESCRIPTION
Adding Pejuang University of Republic of Indonesia

University url: https://upri.ac.id/