### PR TITLE
Replace dlut.edu.cn by mail.dlut.edu.cn

### DIFF
--- a/lib/domains/cn/edu/dlut.txt
+++ b/lib/domains/cn/edu/dlut.txt
@@ -1,1 +1,0 @@
-Dalian University of Technology

--- a/lib/domains/cn/edu/dlut/mail.txt
+++ b/lib/domains/cn/edu/dlut/mail.txt
@@ -1,0 +1,1 @@
+Dalian University of Technology

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -197,7 +197,6 @@ nwafu.edu.cn
 swu.edu.cn
 snnu.edu.cn
 hnu.edu.cn
-dlut.edu.cn
 clatsopcc.edu
 tmu.edu.cn
 sch.edu.af


### PR DESCRIPTION
Add "mail.dlut.edu.cn", which is **only** assigned to students in school.

Removed "dlut.edu.cn", which is assigned to faculties.

> the university official website URL

"https://www.dlut.edu.cn" "http://en.dlut.edu.cn/"

> a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.

"http://its.dlut.edu.cn/index/jsfw/fwzn/dzyxfw/xsyxsq.htm"