### PR TITLE
Misr American College - www.mac-eg.com

### DIFF
--- a/lib/domains/com/mac-eg.txt
+++ b/lib/domains/com/mac-eg.txt
@@ -1,0 +1,1 @@
+Misr American College


### PR DESCRIPTION
Misr American College - www.mac-eg.com

Students are provided a their own school email address (xxxx@s.mac-eg.com) for their duration at Misr American College. Our main website is: www.mac-eg.com

Address: 20 Tunis St., 6th District, New Maadi. Beside Maadi Public Library، المعادى، Cairo Governorate

Misr American College a private Egyptian school based in Maadi, Cairo. This school was established in 2001. The curriculum follows American education, provided by the Massachusetts regulations, from Pre-K to Grade 12 and is accredited by the CITA board of education and the Ministry of Education in Egypt. 

We're mentioned by many websites;
https://en.wikipedia.org/wiki/Misr_American_College
https://www.easyschools.org/en/schoolProfile/misr-american-college
https://www.edarabia.com/misr-american-college-cairo-egypt/
https://www.linkedin.com/company/misramericancollege