### PR TITLE
Added Chetham's School of Music

### DIFF
--- a/lib/domains/com/chethams.txt
+++ b/lib/domains/com/chethams.txt
@@ -1,0 +1,1 @@
+Chetham's School of Music


### PR DESCRIPTION
The main website is at [chethams.com](https://chethams.com/), which is used for email addresses, but the website for the school is at [chethamsschoolofmusic.com](https://chethamsschoolofmusic.com/).

The school offers **Further Mathematics**, including **Statistics** and **Decision Mathematics**, which can be seen from [this document](https://chethamsschoolofmusic.com/wp-content/uploads/sites/2/2020/10/Sixth-Form-Curriculum-Handbook-2019-2020-final-Julia-Harrison-1.docx), detailing 6th form options, which is from the [parent's information page](https://chethamsschoolofmusic.com/admissions/parent-information/).

You can find contact information showing the chethams.com domain being used for email addresses [here](https://chethamsschoolofmusic.com/about/contact-us/).