### PR TITLE
Added school ars-leipzig (Arwed-Rossbach-Schule)

### DIFF
--- a/lib/domains/de/lernsax/ars-bsz.txt
+++ b/lib/domains/de/lernsax/ars-bsz.txt
@@ -1,0 +1,2 @@
+Arwed-Rossbach-Schule, Berufliches Schulzentrum der Stadt Leipzig
+


### PR DESCRIPTION
Official school name: Arwed-Rossbach-Schule, Berufliches Schulzentrum der Stadt Leipzig
Official website: https://ars-leipzig.de/
Lernsax is the school cloud of saxony. Students get studentname@ars-bsz.lernsax.de mail addresses.

This page shows you a map of the schools using this provider:
https://www.lernsax.de/wws/9.php#/wws/858466.php
Here's a quick guide to find the school in that mess of green circles:
https://prnt.sc/zhbnrf
You'll find the school website and address there. (www.arwed-rossbach-schule.de redirects to ars-lepizig.de)

Here's the website showing the school name when logged in:
https://prnt.sc/zhco9p