### PR TITLE
Add Pongsawadi Technological College

### DIFF
--- a/lib/domains/th/ac/pongsawadi.txt
+++ b/lib/domains/th/ac/pongsawadi.txt
@@ -1,0 +1,2 @@
+วิทยาลัยเทคโนโลยีพงษ์สวัสดิ์
+Pongsawadi Technological College


### PR DESCRIPTION
Pongsawadi Technological College domain.

College's official website URL : [https://pongsawadi.ac.th](https://pongsawadi.ac.th)