### PR TITLE
Add clf.uk

### DIFF
--- a/lib/domains/uk/clf.txt
+++ b/lib/domains/uk/clf.txt
@@ -1,0 +1,1 @@
+Cabot Learning Federation


### PR DESCRIPTION
The[ Cabot Learning Federation](https://www.clf.uk) is a collective of multiple schools. Their Post-16 branch offers a 2 year computer science course: https://post16.clf.uk/computer-science/. Also, here's an example document from one of their schools showing how to access remote learning, step 4 clearly has an email that is supposed to be a student/staff email with the ending "@clf.uk": https://bristolmetropolitanacademy.clf.uk/wp-content/uploads/How-to-Access-Home-Learning.pdf