### PR TITLE
feat: add ibmr university domain and email domain

### DIFF
--- a/lib/domains/br/edu/ibmr/alunos.txt
+++ b/lib/domains/br/edu/ibmr/alunos.txt
@@ -1,0 +1,2 @@
+Centro Universitário IBMR
+IBMR - University Center

--- a/lib/domains/br/edu/ibmr/alunos.txt
+++ b/lib/domains/br/edu/ibmr/alunos.txt
@@ -1,2 +1,3 @@
 Centro Universitário IBMR
 IBMR - University Center
+

--- a/lib/domains/br/ibmr.txt
+++ b/lib/domains/br/ibmr.txt
@@ -1,0 +1,2 @@
+Centro Universitário IBMR
+IBMR - University Center


### PR DESCRIPTION
The university has 2 domains. One main domain: https://www.ibmr.br/ and another used only for the students e-mail like my e-mail: 
alu2019100338@alunos.ibmr.edu.br

University official website: https://www.ibmr.br/
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www.ibmr.br/graduacao/big-data-e-inteligencia-analitica
URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain: https://www.ibmr.br/files/editor/files/passo-a-passo-pacote-office.pdf