### PR TITLE
Added moorheadschools.org

### DIFF
--- a/lib/domains/org/moorheadschools.txt
+++ b/lib/domains/org/moorheadschools.txt
@@ -1,0 +1,1 @@
+Moorhead High School


### PR DESCRIPTION
Added domain for Moorhead High School in Moorhead, MN, US

Official School url: https://www.moorheadschools.org/schools/high-schools/moorhead-high-school/
