### PR TITLE
Add Shanghai United International School, Wanyuan Campus

### DIFF
--- a/lib/domains/cn/com/suis/wy.txt
+++ b/lib/domains/cn/com/suis/wy.txt
@@ -1,0 +1,2 @@
+上海市民办万源城协和双语学校
+Shanghai United International School, Wanyuan Campus


### PR DESCRIPTION
URL of the school: https://wanyuan.suis.com.cn
Email address is @wy.suis.com.cn