### PR TITLE
Add XVI Liceum Wrocław

### DIFF
--- a/lib/domains/pl/wroc/lo16.txt
+++ b/lib/domains/pl/wroc/lo16.txt
@@ -1,0 +1,1 @@
+XVI Liceum Wrocław


### PR DESCRIPTION
Webpage: https://www.zs8.wroc.pl/
Explanation: Webpage is in other domain because it is combined website for "Technikum NR19" and "Ogólnokształcące Liceum Kreatywności NR XVI". As you can see on webpage you have recrutment for XVI Liceum on webpage ("Rekrutacja – Liceum Ogólnokształcące nr XVI") : https://www.zs8.wroc.pl/rekrutacja-kandydaci/