### PR TITLE
Add second email domain for minia university

### DIFF
--- a/lib/domains/eg/edu/miniauniv.txt
+++ b/lib/domains/eg/edu/miniauniv.txt
@@ -1,0 +1,2 @@
+جامعة المنيا
+Minia University


### PR DESCRIPTION
Adding the second email domain for Minia University (Already verified here) owned by the university, you can find a teacher email (with this second email domain) in this official university pages:
https://www.minia.edu.eg/minia20/Edeputy.aspx
https://mc.minia.edu.eg/research/Publications/DetailsMember/25307301601533