### PR TITLE
Add MCC KC

### DIFF
--- a/lib/domains/edu/mcckc.txt
+++ b/lib/domains/edu/mcckc.txt
@@ -1,0 +1,1 @@
+Metropolitan Community College, Kansas City, Missouri


### PR DESCRIPTION
Metropolitan Community College, Kansas City is not in your db. Please review and add the same.