### PR TITLE
Add hervormd lyceum zuid

### DIFF
--- a/lib/domains/nl/hlz.txt
+++ b/lib/domains/nl/hlz.txt
@@ -1,0 +1,1 @@
+hervormd lyceum zuid


### PR DESCRIPTION
This PR adds hlz.nl, which is used for both the website and e-mailaccounts (see page footer). https://hlz.nl

