### PR TITLE
Add Langley School District 35

### DIFF
--- a/lib/domains/ca/langleyschools.txt
+++ b/lib/domains/ca/langleyschools.txt
@@ -1,0 +1,1 @@
+Langley School District 35


### PR DESCRIPTION
`langleyschools.ca` is the domain that students of SD35 in BC Canada. District Site is at https://www.sd35.bc.ca/, and they manage DNS for this domain.