### PR TITLE
Add UNIGOIÁS to repository.

### DIFF
--- a/lib/domains/br/com/souunigoias.txt
+++ b/lib/domains/br/com/souunigoias.txt
@@ -1,0 +1,2 @@
+UNIGOIÁS - Centro Universitário de Goiás
+UNIGOIÁS - University Center of Goiás

--- a/lib/domains/br/edu/anhanguera.txt
+++ b/lib/domains/br/edu/anhanguera.txt
@@ -1,0 +1,2 @@
+UNIGOIÁS - Centro Universitário de Goiás
+UNIGOIÁS - University Center of Goiás

--- a/lib/domains/com/unigoias.txt
+++ b/lib/domains/com/unigoias.txt
@@ -1,0 +1,2 @@
+UNIGOIÁS - Centro Universitário de Goiás
+UNIGOIÁS - University Center of Goiás


### PR DESCRIPTION
Domains added:

anhanguera.edu.br (Main address)
souunigoias.com.br (Used only for email access in outlook)
unigoias.com.br (Alias for the main address)

The domain souunigoias.com.br does not have an entry of type A or CNAME, but it does have an entry of type MX, which is used to provide access to email on outlook.com.

If necessary, you can confirm this information by viewing the student's webmail configuration step by step at the link https://unigoias.com/tutorial-webmail/. This link is available in the "FOR THE STUDENT" -> "WEBMAIL" section of the main website.

If there is any problem with the domain souunigoias.com.br please explain to me how to proceed in this situation. Thanks.