### PR TITLE
Added ipag business school domain name

### DIFF
--- a/lib/domains/fr/ipag.txt
+++ b/lib/domains/fr/ipag.txt
@@ -1,0 +1,2 @@
+IPAG Business School
+IPAG Business School


### PR DESCRIPTION
Domain name ipag.fr of the ipag business school based in france (www.ipag.edu)