### PR TITLE
Add Erudio Educational Center

### DIFF
--- a/lib/domains/si/student-erudio.txt
+++ b/lib/domains/si/student-erudio.txt
@@ -1,0 +1,2 @@
+Erudio Izobraževalni Center
+Erudio Educational Center


### PR DESCRIPTION
Added Erudio Educational Center.

Website: https://www.erudio.si/en/

Domain name emails that belong to students (+ subdomains): student-erudio.si
The domain can be checked here (it belongs to the institution Erudio which belongs to erudio.si):

https://www.register.si/en/

Registrar owner screenshot: https://ibb.co/cvRsqQC