### PR TITLE
Adding Melbourne Polytechnic

### DIFF
--- a/lib/domains/au/edu/mp/students.txt
+++ b/lib/domains/au/edu/mp/students.txt
@@ -1,0 +1,1 @@
+Melbourne Polytechnic


### PR DESCRIPTION
Melbourne Polytechnic, which is a TAFE university in Australia. It provides a wide range of innovative TAFE (VET) and Higher Education (Degrees) that prepare students for the workplace. With courses that focus on practical skills and hands-on experience, our students graduate with the knowledge they need to thrive in their careers.
Website URL : https://www.melbournepolytechnic.edu.au/
All the students in this uses the extension : @students.mp.edu.au