### PR TITLE
Add unviversity BR RS Uergs

### DIFF
--- a/lib/domains/br/edu/uergs.txt
+++ b/lib/domains/br/edu/uergs.txt
@@ -1,0 +1,1 @@
+Universidade Estadual do Rio Grande do Sul


### PR DESCRIPTION
Adicionando nome da Universidade Estadual do Rio Grande do Sul (UERGS), Brasil 