### PR TITLE
Added Lowell Makes Makerspace (non profit)

### DIFF
--- a/lib/domains/com/lowelmakes.txt
+++ b/lib/domains/com/lowelmakes.txt
@@ -1,0 +1,2 @@
+Lowell Makes
+Lowell Makes Makerspace


### PR DESCRIPTION
Lowell Makes is a collection of open workshops and laboratories where members and students can collaborate to learn, share, and hone crafts of all kinds. We are focused on providing a space for education, entrepreneurship, and engagement with the community of Lowell, Massachusetts, and beyond.

https://lowellmakes.com/about/