### PR TITLE
Added mubs.ac.ug to list of Universities

### DIFF
--- a/lib/domains/ug/ac/mubs.txt
+++ b/lib/domains/ug/ac/mubs.txt
@@ -1,0 +1,1 @@
+Makerere University Business School


### PR DESCRIPTION
Makerere University Business School is a sister University to another one here, Makerere University (mak.ac.ug)
Our website is here:

[https://mubs.ac.ug](https://mubs.ac.ug)

We are in the process of revamping our website and migrating to the cloud so you might find a few errors. However, we are running a production LMS (Moodle) for our students. You can see the website here:

[https://mubsep.mubs.ac.ug](https://mubsep.mubs.ac.ug)

And you can see some of the programmes we offer (timetable)
 [Click Here](https://drive.google.com/file/d/1SZES4oQMG1DfXXV4IaVcoXdzEX5gAvIr/view)

We also have a research platform (DSpace) here:

[https://mubsir.mubs.ac.ug/](https://mubsir.mubs.ac.ug/)

As you can see, we quite a number of ICT classes.
Our students would be thrilled to be able to access JetBrains resources. Thank you very much in advance :)