### PR TITLE
Add Mark Twain, but also any New York public school that uses the nycstudents domain

### DIFF
--- a/lib/domains/net/nycstudents.txt
+++ b/lib/domains/net/nycstudents.txt
@@ -1,0 +1,1 @@
+Mark Twain I.S. 239


### PR DESCRIPTION
It seems that Mark Twain has already been added before, but they have since changed to use the general `nycstudents.net` addresses, meaning this will affect students other than those who attend Mark Twain.

[Official website](https://www.twain239.com/)
[Computer Science Course (scroll down)](https://www.twain239.com/apps/pages/index.jsp?uREC_ID=372360&type=d&termREC_ID=&pREC_ID=692623) 
![Screen Shot 2021-03-26 at 07 11 18](https://user-images.githubusercontent.com/65368815/112623513-d46e2880-8e02-11eb-90a4-c354e5ed792e.png)
This image was pretty much the only proof I could find, but you'll see that it is a message from my school (Mark Twain), asking me if I want to forward all the mail from my previous `twain239.org` address to my new `nycstudents.net` address. I have blacked out all of my personal information