### PR TITLE
Add Montfort College Rotslaar

### DIFF
--- a/lib/domains/be/montfort.txt
+++ b/lib/domains/be/montfort.txt
@@ -1,0 +1,1 @@
+Montfort College Rotselaar


### PR DESCRIPTION
School in Belgium, can be referred to as MCR

edit: extra info for easier verification:
Main website: https://www.montfort.be
We use Office365 for email addresses and only the admin can create them.