### PR TITLE
bkt.txt added and mg.txt removed due to new email address

### DIFF
--- a/lib/domains/de/siwiwissen/bkt.txt
+++ b/lib/domains/de/siwiwissen/bkt.txt
@@ -1,0 +1,1 @@
+Berufskolleg Technik des Kreises Siegen-Wittgenstein

--- a/lib/domains/de/siwiwissen/bkt/mg.txt
+++ b/lib/domains/de/siwiwissen/bkt/mg.txt
@@ -1,1 +1,0 @@
-Berufskolleg Technik des Kreises Siegen-Wittgenstein


### PR DESCRIPTION
* [Official website](https://berufskolleg-technik.de/)
* [Long-term IT related course](https://berufskolleg-technik.de/berufsschule/) (This is a German vocational school. Here the three-year apprenticeship "Fachinformatiker"/IT specialist is taught.)
* [Siwiwissen](https://www.siwiwissen.de/) (All schools of the district Siegen Wittgenstein use Siwiwissen with the abbreviation of the school as subdomain. On the Siwiwissen website, Berufskolleg Technik Siegen is also listed below.)