### PR TITLE
Add  brevardschools School District

### DIFF
--- a/lib/domains/org/brevardschools/learn.txt
+++ b/lib/domains/org/brevardschools/learn.txt
@@ -1,1 +1,88 @@
-Indialantic, Elementary
+Andersen Elementary
+Apollo Elementary
+Atlantis Elementary
+Audubon Elementary
+Cambridge Elementary Magnet
+Cape View Elementary
+Challenger 7 Elementary
+Columbia Elementary
+Coquina Elementary
+Croton Elementary
+Discovery Elementary
+Dr. W.J. Creel Elementary
+Endeavour Elementary
+Enterprise Elementary
+Fairglen Elementary
+Freedom 7 Elementary
+Gemini Elementary
+Golfview Elementary Magnet
+Harbor City Elementary
+Holland Elementary
+Imperial Estates Elementary
+Indialantic Elementary
+Jupiter Elementary
+Lewis Carroll Elementary
+Lockmar Elementary
+Longleaf Elementary
+Manatee Elementary
+McAuliffe Elementary
+Meadowlane Intermediate Elementary
+Meadowlane Primary Elementary
+MILA Elementary
+Mims Elementary
+Oak Park Elementary
+Ocean Breeze Elementary
+Palm Bay Elementary
+Pinewood Elementary
+Port Malabar Elementary
+Quest Elementary
+Riviera Elementary
+Roosevelt Elementary
+Roy Allen Elementary
+Sabal Elementary
+Saturn Elementary
+Sea Park Elementary
+Sherwood Elementary
+South Lake Elementary
+Stevenson Elementary
+Sunrise Elementary
+Suntree Elementary
+Surfside Elementary
+Tropical Elementary
+Turner Elementary
+University Park Elementary Magnet
+Viera Elementary
+West Melbourne School for Science
+Westside Elementary
+Williams Elementary
+Central Middle
+Cocoa Beach Jr/Sr High
+Cocoa High
+DeLaura Middle
+Edgewood Jr/Sr High
+Hoover Middle
+Jackson Middle
+Jefferson Middle
+Johnson Middle
+Kennedy Middle
+Madison Middle
+McNair Magnet Middle
+Southwest Middle
+Space Coast Jr/Sr
+Stone Magnet Middle
+West Shore Jr/Sr High
+Adult Education
+Brevard Virtual
+Educational Horizons
+Emma Jewel
+Imagine Schools
+Odyssey Charter
+Odyssey Preparatory Charter
+Palm Bay Academy Charter
+Pathways at Gardendale
+Pineapple Cove Classical Academy
+Pineapple Cove Classical Academy - West Melb.
+Royal Palm Charter
+Sculptor Charter
+South Alternative Learning
+Viera Charter

--- a/lib/domains/org/brevardschools/learn.txt
+++ b/lib/domains/org/brevardschools/learn.txt
@@ -1,0 +1,1 @@
+Indialantic, Elementary


### PR DESCRIPTION
> the school official website URL

https://www.brevardschools.org/

> the school street address

2700 JUDGE FRAN JAMIESON WAY
VIERA, FL 32940

> an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course

The school district doesn't have an IT-related long-term course, would you like one of an individual school?

> a proof, which shows that the school recognizes the domain you are submitting as an official email domain for the students.

Their costumer support email is: [CSC@brevardschools.org](mailto:CSC@brevardschools.org)
