### PR TITLE
New email domain for students

### DIFF
--- a/lib/domains/ca/mynbcc.txt
+++ b/lib/domains/ca/mynbcc.txt
@@ -1,0 +1,1 @@
+New Brunswick Community College


### PR DESCRIPTION
mynbcc.ca email domain is used for NBCC students