### PR TITLE
Added the following school: Budapest Technical Vocational Training Center Ottó Titusz Bláthy Informatics Technical School

### DIFF
--- a/lib/domains/hu/sulinet/blathy-bp.txt
+++ b/lib/domains/hu/sulinet/blathy-bp.txt
@@ -1,0 +1,1 @@
+Budapesti Műszaki Szakképzési Centrum Bláthy Ottó Titusz Informatikai Technikum


### PR DESCRIPTION
School page: [http://www.blathy-bp.sulinet.hu] (http://www.blathy-bp.sulinet.hu)
School  Address: Hungary - 1032 Budapest, Bécsi út 134. [Google Map] (https://goo.gl/maps/SHtGrRtVd8nviFGw7)

Proof that the email domain ** blathy-bp.sulinet.hu ** is under managment of the school.
- **The school address itself contain 'blathy-bp.sulinet.hu'** 
- **Our teachers too uses these mail domains. The page is avalible at: [http://www.blathy-bp.sulinet.hu/contact.php](http://www.blathy-bp.sulinet.hu/contact.php)**

![ContactPage](https://user-images.githubusercontent.com/30203762/113897531-3fd4d480-97cb-11eb-9da8-f484ea6e8b99.png)
