### PR TITLE
Kremenchuk Mykhailo Ostrohradskyi National University (mail)

### DIFF
--- a/lib/domains/education/ukr/kkrnu.txt
+++ b/lib/domains/education/ukr/kkrnu.txt
@@ -1,0 +1,1 @@
+Kremenchuk Mykhailo Ostrohradskyi National University


### PR DESCRIPTION
This domain is used for university mail.

Official site: http://www.kdu.edu.ua
