### PR TITLE
Sächsisches Landesgymnasium Sankt Afra

### DIFF
--- a/lib/domains/de/lernsax/afra.txt
+++ b/lib/domains/de/lernsax/afra.txt
@@ -1,0 +1,1 @@
+Sächsisches Landesgymnasium Sankt Afra zu Meißen


### PR DESCRIPTION
[Sächsisches Landesgymnasium Sankt Afra zu Meißen](https://sankt-afra.de/)
[sankt-afra.de](https://sankt-afra.de/)