### PR TITLE
Add the domain name of the University of Mascara

### DIFF
--- a/lib/domains/dz/univ-mascara.txt
+++ b/lib/domains/dz/univ-mascara.txt
@@ -1,0 +1,2 @@
+Université de Mascara - Mustapha Stambouli
+University of Mascara


### PR DESCRIPTION
This pull request adds the domain name of the Univerity of Mascara. A state-run university in the city of Mascara, western Algeria.

- URL : [Main website](https://www.univ-mascara.dz/)
- URL of the faculty of exact sciences, which houses the Informatics department: https://www.univ-mascara.dz/fse/index.php/fr/
- The Informatics department offers a three years Informatics Licence (Bachelor) program, and three, two years Master's programs, as well as multiple Ph.D. programs.
- The domain is used as an email domain for students, I know this because I study there. (Sorry, there is no proof on the website, G Suit is used for handling emails)

Thank you. 
(Sorry for the typo in the commit message)
