### PR TITLE
Adding domains for ADENFormations IT school

### DIFF
--- a/lib/domains/com/adenformations.txt
+++ b/lib/domains/com/adenformations.txt
@@ -1,0 +1,1 @@
+ADEN Formations

--- a/lib/domains/school/laclick.txt
+++ b/lib/domains/school/laclick.txt
@@ -1,0 +1,1 @@
+ADEN Formations


### PR DESCRIPTION
Hi I'm trying to add my two domains used by my school ADEN Formations for IT formations.
One of these domains is for teachers and the other for students.
The main web site is https://aden-formations.fr/
The page of our IT formations are : 
https://aden-formations.fr/formations/?_filieres[]=620
Two formations pages : 
https://aden-formations.fr/formations/analyste-developpeur-dapplications/
https://aden-formations.fr/formations/concepteur-de-systemes-dinformation/
![2021-04-13_15h28_29](https://user-images.githubusercontent.com/82454536/114560412-f7a32f80-9c6c-11eb-8961-2d7300f0b99c.png)
Attached file is a screen capture of the members of one of our IT formations