### PR TITLE
Add prof.educacao.sp.gov.br and al.educacao.sp.gov.br domains

### DIFF
--- a/lib/domains/br/gov/sp/educacao/al.txt
+++ b/lib/domains/br/gov/sp/educacao/al.txt
@@ -1,0 +1,3 @@
+Escolas Estaduais de São Paulo - Escolas da Diretoria de Ensino Região de Birigui
+State Schools of São Paulo State - Schools of Birigui Region School Board
+.group

--- a/lib/domains/br/gov/sp/educacao/prof.txt
+++ b/lib/domains/br/gov/sp/educacao/prof.txt
@@ -1,0 +1,3 @@
+Escolas Estaduais de São Paulo - Escolas da Diretoria de Ensino Região de Birigui
+State Schools of São Paulo State - Schools of Birigui Region School Board
+.group


### PR DESCRIPTION
Official Website:
https://www.educacao.sp.gov.br/

URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
https://inova.educacao.sp.gov.br/
https://inova.educacao.sp.gov.br/tecnologia-e-inovacao/