### PR TITLE
Domain itispascal.it

### DIFF
--- a/lib/domains/it/itispascal
+++ b/lib/domains/it/itispascal
@@ -1,0 +1,1 @@
+ITIS Biagio Pascal, Roma (RM)


### PR DESCRIPTION
ITIS Biagio Pascal, Roma (RM)

https://pascalroma.edu.it/index.php
https://pascalroma.edu.it/index.php?option=com_cwattachments&task=download&id=d7322ed717dedf1eb4e6e52a37ea7bcd&sid=260bfaf1c1aac8df5c8f43bdfbd25d29
https://whois.domaintools.com/itispascal.it