### PR TITLE
Added emsi.ma

### DIFF
--- a/lib/domains/ma/emsi.txt
+++ b/lib/domains/ma/emsi.txt
@@ -1,0 +1,4 @@
+École Marocaine des Sciences de l'Ingénieur
+Moroccan School of Engineering Sciences
+Marokkanische Hochschule der Ingenieurwissenschaften
+EMSI


### PR DESCRIPTION
> [**emsi.ma**](https://emsi.ma) is the domain name used by the professors and campus directors.

> [**emsi-edu.ma**](https://github.com/JetBrains/swot/blob/master/lib/domains/ma/emsi-edu.txt) is the domain name for students.