### PR TITLE
added cgu.txt

### DIFF
--- a/lib/domains/nl/cgu.txt
+++ b/lib/domains/nl/cgu.txt
@@ -1,0 +1,2 @@
+Christelijk Gymnasium Utrecht
+Christian Gymnasium Utrecht


### PR DESCRIPTION
leerling.cgu.nl already existed but my school changed to .cgu.nl leerling still works for backwards compatibility but this is better for when they remove it