### PR TITLE
Remove insite.4cd.edu from stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -217,7 +217,6 @@ tsinghua.pkumail.tech
 stu.haut.edu.cn
 sem.tsinghua.edu.cn
 mails.cust.edu.cn
-insite.4cd.edu
 cug.edu.cn
 mail.sustc.edu.cn
 alumni.usp.br


### PR DESCRIPTION
This is the domain for every student in the Contra Costa Community College District. It shouldn't have been bannned in the first place.