### PR TITLE
add hakodate.txt

### DIFF
--- a/lib/domains/jp/kosen-ac/hakodate.txt
+++ b/lib/domains/jp/kosen-ac/hakodate.txt
@@ -1,0 +1,2 @@
+函館工業高等専門学校
+National Institute of Technology, Hakodate College.


### PR DESCRIPTION
domain "hakodate.kosen-ac.jp"

College Website: https://www.hakodate-ct.ac.jp/

National Institute of Technology, Hakodate College is one of the 57 national colleges of technology in Japan. The school is designed to provide students with specialized knowledge in the field of engineering.
It is the same type as  [National Institute of Technology, Tokyo College](https://github.com/JetBrains/swot/pull/2349) and [National Institute of Technology, Numazu College](https://github.com/JetBrains/swot/pull/5028) that have been added in the past.
Here is the syllabus for the mechanical, electrical and electronic, information, chemical, and architectural fields.
https://www.hakodate-ct.ac.jp/wp-content/uploads/2019/04/%E6%95%99%E8%82%B2%E8%AA%B2%E7%A8%8B%E8%A1%A8%EF%BC%88%E7%94%9F%E7%94%A3%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E5%B7%A5%E5%AD%A6%E7%A7%91%EF%BC%89.pdf
https://www.hakodate-ct.ac.jp/wp-content/uploads/2019/04/%E6%95%99%E8%82%B2%E8%AA%B2%E7%A8%8B%E8%A1%A8%EF%BC%88%E7%89%A9%E8%B3%AA%E7%92%B0%E5%A2%83%E5%B7%A5%E5%AD%A6%E7%A7%91%EF%BC%89.pdf
https://www.hakodate-ct.ac.jp/wp-content/uploads/2019/04/%E6%95%99%E8%82%B2%E8%AA%B2%E7%A8%8B%E8%A1%A8%EF%BC%88%E7%A4%BE%E4%BC%9A%E5%9F%BA%E7%9B%A4%E5%B7%A5%E5%AD%A6%E7%A7%91%EF%BC%89.pdf

