### PR TITLE
Add 'Cuatrovientos centro integrado' to educational institutions

### DIFF
--- a/lib/domains/es/navarra/educacion.txt
+++ b/lib/domains/es/navarra/educacion.txt
@@ -1,0 +1,1 @@
+Cuatrovientos centro integrado


### PR DESCRIPTION
After the first request, you asked for some information, but you closed the first PR before we replied. So we open now a new PR with the requested info:
-the school official website URL: http://www.cuatrovientos.org/
-the school street address, including city and country: Av. de San Jorge Etorbidea, 2, 31012 Pamplona, Navarra, Spain
-an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course: -http://www.cuatrovientos.org/formacion/cfs-desarrollo-de-aplicaciones-multiplataforma/
-a proof, which shows that the school recognizes the domain you are submitting as an official email domain for the students: I attach a document for two example students proving that they have the email address "@educacion.navarra.es" (Attached pdf)
[proof.pdf](https://github.com/JetBrains/swot/files/6452110/proof.pdf)
