### PR TITLE
Request to add NYC Technical High Schools.

### DIFF
--- a/lib/domains/gov/nyc/schools.txt
+++ b/lib/domains/gov/nyc/schools.txt
@@ -1,0 +1,3 @@
+New York City Department of Education
+NYC DOE
+.group


### PR DESCRIPTION
schools.nyc.gov accounts are only teacher accounts