### PR TITLE
Adds Centro Universiátio Mário Cesar Jucá

### DIFF
--- a/lib/domains/br/edu/fat-al.txt
+++ b/lib/domains/br/edu/fat-al.txt
@@ -1,0 +1,2 @@
+Centro Universitário Mário Pontes Jucá
+Faculdade de Tecnologia de Alagoas


### PR DESCRIPTION
Formerly known as "Faculdade de Tecnologia de Alagoas". Website is http://fat-al.edu.br/.