### PR TITLE
Rotterdam School of Management, Erasmus University Rotterdam

### DIFF
--- a/lib/domains/nl/rsm.txt
+++ b/lib/domains/nl/rsm.txt
@@ -1,0 +1,1 @@
+Rotterdam School of Management, Erasmus University Rotterdam


### PR DESCRIPTION
Previously known as Faculteit Bedrijfskunde