### PR TITLE
Added correct domain for Södertörns Högskola

### DIFF
--- a/lib/domains/se/suni.txt
+++ b/lib/domains/se/suni.txt
@@ -1,0 +1,1 @@
+Södertörns Högskola


### PR DESCRIPTION
The existing domain contained in the "sh.txt" file leading to Södertörns University College is outdated and leads to nonexistent domain sh.se