### PR TITLE
Add the Paul Hankar institut in Belgium

### DIFF
--- a/lib/domains/education/paulhankar.txt
+++ b/lib/domains/education/paulhankar.txt
@@ -1,0 +1,2 @@
+Institut Paul Hankar
+Paul Hankar Institut


### PR DESCRIPTION
Add the Paul Hankar institut in Belgium to access at the free licences.