### PR TITLE
Add apizal.ro

### DIFF
--- a/lib/domains/id/ac/stiteknas.txt
+++ b/lib/domains/id/ac/stiteknas.txt
@@ -1,0 +1,1 @@
+Sekolah Tinggi Teknologi Nasional Jambi

--- a/lib/domains/ro/apizal.txt
+++ b/lib/domains/ro/apizal.txt
@@ -1,0 +1,2 @@
+Colegiul Tehnic "Alesandru Papiu Ilarian" Zalau, Romania
+"Alesandru Papiu Ilarian" Technical College from Zalau, Romania


### PR DESCRIPTION
Colegiul Tehnic "Alesandru Papiu Ilarian" Zalau, Romania
"Alesandru Papiu Ilarian" Technical College from Zalau, Romania


