### PR TITLE
Add St. Munchin's College, Corbally, Limerick, IRL

### DIFF
--- a/lib/domains/ie/stmunchinscollege.txt
+++ b/lib/domains/ie/stmunchinscollege.txt
@@ -1,0 +1,1 @@
+St. Munchin's College


### PR DESCRIPTION
http://stmunchinscollege.com

St. Munchin's College is a second-level education college located in Corbally, Limerick, Ireland. The school was founded in 1796.