### PR TITLE
Added Long Bay College, Long Bay, Auckland, New Zealand

### DIFF
--- a/lib/domains/nz/school/lbc.txt
+++ b/lib/domains/nz/school/lbc.txt
@@ -1,0 +1,1 @@
+Long Bay College


### PR DESCRIPTION
Website: https://www.longbaycollege.com/
Email domain: lbc.school.nz