### PR TITLE
Add esoft.academy

### DIFF
--- a/lib/domains/academy/esoft.txt
+++ b/lib/domains/academy/esoft.txt
@@ -1,0 +1,1 @@
+ESOFT Metro Campus


### PR DESCRIPTION
esoft.academy is another domain for student emails at ESOFT Metro Campus (esoft.lk) which is already added here.