### PR TITLE
Add entry for University of Technology, Katowice, Poland --> wst.com.pl

### DIFF
--- a/lib/domains/pl/com/wst.txt
+++ b/lib/domains/pl/com/wst.txt
@@ -1,0 +1,2 @@
+Wyższa Szkoła Techniczna w Katowicach
+University of Technology, Katowice, Poland


### PR DESCRIPTION
The University of Technology in Katowice offers  3.5 year long IT related course at first university grade (according to Polish law). The course website in English can be found here: <http://www.en.wst.com.pl/education_offer/computer_science>.