### PR TITLE
Add my school

### DIFF
--- a/lib/domains/my/edu/britishschool.txt
+++ b/lib/domains/my/edu/britishschool.txt
@@ -1,0 +1,1 @@
+The British International School of Kuala Lumpur


### PR DESCRIPTION
School website: https://www.nordangliaeducation.com/our-schools/malaysia/kuala-lumpur/british-international
School adress: No.1, Changkat Bukit Utama, Bandar Utama, 47800 Petaling Jaya, Selangor, Malaysia
Subject website (course: A level & iGCSE Computer science (2 years)) : https://www.nordangliaeducation.com/our-schools/malaysia/kuala-lumpur/british-international/learning/our-curriculum/sixth-form/subjects