### PR TITLE
Add Worcester College, University of Oxford

### DIFF
--- a/lib/domains/uk/ac/ox/worc.txt
+++ b/lib/domains/uk/ac/ox/worc.txt
@@ -1,0 +1,1 @@
+Worcester College, University of Oxford


### PR DESCRIPTION
Worcester College is one of the 39 colleges making up the University of Oxford.

Worcester College website: https://www.worc.ox.ac.uk
University of Oxford website: https://www.ox.ac.uk