### PR TITLE
adding www.shou.edu.cn

### DIFF
--- a/lib/domains/cn/edu/shou.txt
+++ b/lib/domains/cn/edu/shou.txt
@@ -1,0 +1,1 @@
+ShangHai Ocean University


### PR DESCRIPTION
!!! PLEASE 
ping www.shou.edu.cn (rather than ping shou.edu.cn), it seems our school does not open the domain without "www.", but our email is something like lmsforever@shou.edu.cn

its official website is https://www.shou.edu.cn
located in Shanghai, China.

its IT college has many courses like: Computer Sience and Technology, Software Engineering, and so on.
all courses are 4 years for bachelor degree):
https://xxxy.shou.edu.cn/6622/list.htm
https://zsjy.shou.edu.cn/2020/0714/c15533a272876/page.htm