### PR TITLE
Add Clarke International University - CIU domains

### DIFF
--- a/lib/domains/ug/ac/ciu.txt
+++ b/lib/domains/ug/ac/ciu.txt
@@ -1,0 +1,1 @@
+Clarke International University

--- a/lib/domains/ug/ac/ciu/student.txt
+++ b/lib/domains/ug/ac/ciu/student.txt
@@ -1,0 +1,1 @@
+Clarke International University

--- a/lib/domains/ug/ac/ciu/student.txt
+++ b/lib/domains/ug/ac/ciu/student.txt
@@ -1,1 +1,0 @@
-Clarke International University


### PR DESCRIPTION
This adds Clarke International University domains for **staff** and **student** email.
The University was re-branded from `ihsu.ac.ug` to `ciu.ac.ug`. 
Couldn't find any entries for `IHSU` to  change :) so here we go.

## Changelog
### Add:
- `ciu.ac.ug` - for staff emails
- `student.ciu.ac.ug` - for student emails