### PR TITLE
Add Leeds Beckett University

### DIFF
--- a/lib/domains/uk/ac/leedsbeckett/student
+++ b/lib/domains/uk/ac/leedsbeckett/student
@@ -1,0 +1,1 @@
+Leeds Beckett University


### PR DESCRIPTION
Add a new email domain ending with student.leedsbeckett.ac.uk