### PR TITLE
Add Leeds Beckett University student email domain

### DIFF
--- a/lib/domains/uk/ac/leedsbeckett/student.txt
+++ b/lib/domains/uk/ac/leedsbeckett/student.txt
@@ -1,0 +1,1 @@
+Leeds Beckett University


### PR DESCRIPTION
Add a new email domain ending with student.leedsbeckett.ac.uk