### PR TITLE
Add Jiangsu Ocean University   Delete HuaiHai Institute of Technology

### DIFF
--- a/lib/domains/cn/edu/hhit.txt
+++ b/lib/domains/cn/edu/hhit.txt
@@ -1,1 +1,0 @@
-HuaiHai Institute of Technology

--- a/lib/domains/cn/edu/jou.txt
+++ b/lib/domains/cn/edu/jou.txt
@@ -1,2 +1,1 @@
 Jiangsu Ocean University
-江苏海洋大学


### PR DESCRIPTION
HuaiHai Institute of Technology is old school name，Chinese language is 淮海工学院，Jiangsu Ocean University is new school name.Chinese language is 江苏海洋大学
![image](https://user-images.githubusercontent.com/40285666/123124498-514c8500-d47a-11eb-9c5c-6970ccca4846.png)

website: https://www.jou.edu.cn/
![无标题](https://user-images.githubusercontent.com/40285666/123124152-029eeb00-d47a-11eb-85a6-003641a089aa.png)

![屏幕截图 2021-06-23 232212](https://user-images.githubusercontent.com/40285666/123124060-edc25780-d479-11eb-8405-916a90bbe813.png)
