### PR TITLE
Add Castilla-La Mancha's education domain

### DIFF
--- a/lib/domains/es/educastillalamancha.txt
+++ b/lib/domains/es/educastillalamancha.txt
@@ -1,0 +1,3 @@
+Educación de Castilla-La Mancha
+Castilla-La Mancha's education
+.group


### PR DESCRIPTION
This is the domain used by many schools in Castilla-La Mancha's region of Spain.

The official website is www.educa.jccm.es
And this is a screenshot of my email inbox (I'm a student, showing that the emails are used by students):
![Sin título](https://user-images.githubusercontent.com/86419976/123280620-39701200-d509-11eb-8af7-610187b78b85.png)

