### PR TITLE
Add numls domain

### DIFF
--- a/lib/domains/pk/edu/numls.txt
+++ b/lib/domains/pk/edu/numls.txt
@@ -1,0 +1,5 @@
+National University of Modern Languages
+NUML 
+@numls.edu.pk is a domain for NUML students. 
+The @numl.edu.pk domain is only for staff.
+I may provide a screenshot upon request.

--- a/lib/domains/pk/edu/numls.txt
+++ b/lib/domains/pk/edu/numls.txt
@@ -1,5 +1,2 @@
 National University of Modern Languages
 NUML 
-@numls.edu.pk is a domain for NUML students. 
-The @numl.edu.pk domain is only for staff.
-I may provide a screenshot upon request.


### PR DESCRIPTION
![Numls screenshot](https://user-images.githubusercontent.com/35258654/123457020-f0998580-d5fc-11eb-9145-7f9aa0841b5d.png)
The above screenshot shows that the domain '@numls.edu.pk' is controlled by NUML. There is already a domain '@numl.edu.pk' in the registered domains list which is only for NUML Staff. The requested domain '@numls.edu.pk' is allocated for students of the university. The university offers different undergraduate and masters courses in different IT fields including Software Engineering. Different IT courses of the university can be checked through the given link below: 
https://www.numl.edu.pk/programs/functional