### PR TITLE
Add the University of Electro-Communications

### DIFF
--- a/lib/domains/jp/ac/uec.txt
+++ b/lib/domains/jp/ac/uec.txt
@@ -1,0 +1,1 @@
+The University of Electro-Communications


### PR DESCRIPTION
The University of Electro-Communications is a national university located in Chofu, Tokyo, Japan. (Website: https://www.uec.ac.jp/eng)

It has three courses related to engineering. (https://www.uec.ac.jp/eng/education/ie/)

-   Cluster I (Informatics and Computer Engineering)
-   Cluster II (Emerging Multi-interdisciplinary Engineering)
-   Cluster III (Fundamental Science and Engineering)

Information about campus email: https://www.cc.uec.ac.jp/ug/en/mail/index.html