### PR TITLE
Add domain "uec.ac.jp"

### DIFF
--- a/lib/domains/jp/ac/uec.txt
+++ b/lib/domains/jp/ac/uec.txt
@@ -1,0 +1,2 @@
+電気通信大学
+The University of Electro-Communications


### PR DESCRIPTION
Website(English): https://www.uec.ac.jp/eng/about/
This university has a faculty of related IT. https://www.uec.ac.jp/eng/education/
This university use "uec.ac.jp" as email address. https://www.cc.uec.ac.jp/ug/en/mail/index.html