### PR TITLE
Add a new domain of my school

### DIFF
--- a/lib/domains/cn/mzmail.txt
+++ b/lib/domains/cn/mzmail.txt
@@ -1,0 +1,2 @@
+内蒙古大学
+Inner Mongolia University


### PR DESCRIPTION
the university official website URL: 
https://www.imu.edu.cn/

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
https://www.imu.edu.cn/yxsz1.htm

This is a new email domain name for internal use by some specific teachers and graduate students. The SSL certificate of the website shows that the domain name belongs to the school’s official email domain ‘mail.imu.edu.cn’.
![20210630174115](https://user-images.githubusercontent.com/51038610/123939201-7ab16780-d9ca-11eb-92fc-800ebd45e005.jpg)
