### PR TITLE
Please add "limkokwing.ac.ls"

### DIFF
--- a/lib/domains/ls/ac/limkokwing.txt
+++ b/lib/domains/ls/ac/limkokwing.txt
@@ -1,0 +1,1 @@
+Limkokwing University of Creative Technology


### PR DESCRIPTION
# Request to add Limkokwing University to JetBrains

Our University's official URL is [limkokwing.net](https://www.limkokwing.net/lesotho), however we use **limkokwing.ac.ls** for our emails. And when [limkokwing.ac.ls](http://www.limkokwing.ac.ls) is typed on the web browser it redirects the user to our official url which is [imkokwing.net](https://www.limkokwing.net/lesotho).

[Here is a page](https://www.limkokwing.net/lesotho/academic/courses_details/bachelor-of-science-hons-in-information-technology) on the official website where a long-term IT related course is offered by the university.

Bellow is a screenshot of the inbox of an email address using the domain: <i>limkokwing.ac.ls</i><br/>
![limkokwing ac ls](https://user-images.githubusercontent.com/19797741/124024321-587e1080-d9ef-11eb-8757-ac3fcbb0475f.png)
