### PR TITLE
Add schools.sa.edu.au domain

### DIFF
--- a/lib/domains/au/edu/sa/schools.txt
+++ b/lib/domains/au/edu/sa/schools.txt
@@ -1,0 +1,1 @@
+Department for Education


### PR DESCRIPTION
Add in @schools.sa.edu.au for students and educators for The Department of Education in South Australia.