### PR TITLE
Please add "student.gsso.de"

### DIFF
--- a/lib/domains/de/gsso/student.txt
+++ b/lib/domains/de/gsso/student.txt
@@ -1,0 +1,1 @@
+Grafenbergschule Schorndorf


### PR DESCRIPTION
# Request to add Grafenbergschule to swot
I already got accepted to githubs student developer programm, but it would be nice to have the scool on this list.
GSSO features a profile Subject "Information Technology", which you have to attend to till your A-Levels.

https://gsso.de/index.php/events/info/2020-21/TG/freiePlaetze

Screenshot that proves that "student.gsso.de" is on the same cert then gsso.de:
![](https://i.imgur.com/CmEhLeT.png)

https://gsso.de/index.php/events/info/2020-21/TG/freiePlaetze