### PR TITLE
Add Domain for IFHE(Icfai Foundation For Higher Education)

### DIFF
--- a/lib/domains/org/ifheindia
+++ b/lib/domains/org/ifheindia
@@ -1,1 +1,0 @@
-Icfai Foundation For Higher Education(IFHE)

--- a/lib/domains/org/ifheindia
+++ b/lib/domains/org/ifheindia
@@ -1,0 +1,1 @@
+Icfai Foundation For Higher Education(IFHE)

--- a/lib/domains/org/ifheindia.txt
+++ b/lib/domains/org/ifheindia.txt
@@ -1,0 +1,1 @@
+Icfai Foundation For Higher Education(IFHE)


### PR DESCRIPTION
1. Official Website https://www.ifheindia.org/

Address:-
The ICFAI Foundation for Higher Education (IFHE), Hyderabad
IFHE Campus
Donthanapally, Shankarapalli Road
Hyderabad - 501203, Telangana, India.

3. https://icfaitech.admissions.ifheindia.org/

![image](https://user-images.githubusercontent.com/60293758/124552053-a4e2a980-de50-11eb-84dc-536c6e741af9.png)



