### PR TITLE
add embl.it domain

### DIFF
--- a/lib/domains/it/embl.txt
+++ b/lib/domains/it/embl.txt
@@ -1,0 +1,4 @@
+EMBL, Rome
+European Molecular Biology Laboratory
+URL: https://www.embl.it
+Courses: https://www.embl.org/training/


### PR DESCRIPTION
Hi, I created the file to allow EMBL Rome to get JetBrain's educational license. [EMBL Heidelberg](https://github.com/JetBrains/swot/blob/master/lib/domains/de/embl.txt) already has such access. 