### PR TITLE
Add University of Kent

### DIFF
--- a/lib/domains/uk/ac/kent.txt
+++ b/lib/domains/uk/ac/kent.txt
@@ -1,0 +1,1 @@
+University of Kent


### PR DESCRIPTION
university official website URL: https://www.kent.ac.uk/
long-term (>1 year) IT related course is offered by the university: https://www.kent.ac.uk/courses/undergraduate/124/computer-science