### PR TITLE
Added domain for Universidad Santo Tomas (Colombia)

### DIFF
--- a/lib/domains/co/edu/ustadistancia.txt
+++ b/lib/domains/co/edu/ustadistancia.txt
@@ -1,0 +1,2 @@
+Universidad Santo Tomas
+Santo Tomas University


### PR DESCRIPTION
URL: https://www.usta.edu.co
Added domain for remote students from Universidad Santo Tomas. Already added before for resident students