### PR TITLE
add lmetb domain

### DIFF
--- a/lib/domains/ie/lmetb.txt
+++ b/lib/domains/ie/lmetb.txt
@@ -1,0 +1,3 @@
+Louth and Meath Education and Training Board
+https://www.lmetb.ie/
+.group


### PR DESCRIPTION
add Louth and Meath Education and Training Board Group
This domain is used by the school in Counties Louth and Meath.