### PR TITLE
mrjaffesclass.com domain added

### DIFF
--- a/lib/domains/com/mrjaffesclass.txt
+++ b/lib/domains/com/mrjaffesclass.txt
@@ -1,0 +1,1 @@
+Patrick Henry High School


### PR DESCRIPTION
This is my (Roger Jaffe) domain for CS classes at Patrick Henry High School.  See my website at https://www.mrjaffesclass.com. The school website is https://patrickhenryhs.net -- you can find me on the staff directory page. I have a paid Jetbrains license under my personal email (rogerjaffe@gmail.com) but I would like my students to be able to get an educational license with their mrjaffesclass.com email address.