### PR TITLE
Add SPH Sixth Form

### DIFF
--- a/lib/domains/uk/co/sphcs.txt
+++ b/lib/domains/uk/co/sphcs.txt
@@ -1,0 +1,1 @@
+St Philip Howard Sixth Form


### PR DESCRIPTION
### Institution/School Name
St Philip Howard Sixth Form

### Instiution/School Website
https://www.sphsixthform.co.uk/
CS course: https://www.sphsixthform.co.uk/course.php?id=13 (scroll down)
Proof the domain is officially used: https://www.sphsixthform.co.uk/contactus.php

### Email Users
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni

### Education Levels
- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [x] High School or equivalent
- [ ]  Elementary School or equivalent
