### PR TITLE
Add Batumi State University

### DIFF
--- a/lib/domains/ge/bsu.txt
+++ b/lib/domains/ge/bsu.txt
@@ -1,0 +1,2 @@
+ბათუმის შოთა რუსთაველის სახელმწიფო უნივერსიტეტი
+Batumi Shota Rustaveli State University


### PR DESCRIPTION
**University name**
Georgian: ბათუმის შოთა რუსთაველის სახელმწიფო უნივერსიტეტი
English: Batumi Shota Rustaveli State University

**Links**
https://bsu.edu.ge/ (bsu.ge redirects here)
https://bsu.edu.ge/sub-59/news/index.html (Faculty of Exact Sciences and Education)
https://bsu.edu.ge/main/page/313/index.html (Contact information)