### PR TITLE
Add HaUI - Trường Đại học Công Nghiệp Hà Nội

### DIFF
--- a/lib/domains/vn/edu/dhcnhn.txt
+++ b/lib/domains/vn/edu/dhcnhn.txt
@@ -1,0 +1,2 @@
+Đại học Công Nghiệp Hà Nội
+Hanoi University of Industry


### PR DESCRIPTION
Add Hanoi University of Industry at: https://dhcnhn.vn/