### PR TITLE
Shavatz School domain

### DIFF
--- a/lib/domains/il/org/tad/shavatz.txt
+++ b/lib/domains/il/org/tad/shavatz.txt
@@ -1,0 +1,2 @@
+שמעון בן צבי
+Shimon Ben Tzvi


### PR DESCRIPTION
new domain for Shavatz High school (abbreviation for Shimon Ben Tzvi)
Shavatz's School Site (English): https://shavatz.co.il/shimon-ben-zvi-high-school/