### PR TITLE
add Schaffhausen Institute of Technology to the domains list

### DIFF
--- a/lib/domains/study/sit.txt
+++ b/lib/domains/study/sit.txt
@@ -1,0 +1,2 @@
+Schaffhausen Institute of Technology
+Schaffhausen Institute of Technology


### PR DESCRIPTION
Add Schaffhausen Institute of Technology (Switzerland) to the domains list.