### PR TITLE
Add boiseschools.net for student emails

### DIFF
--- a/lib/domains/net/boiseschools.txt
+++ b/lib/domains/net/boiseschools.txt
@@ -1,0 +1,1 @@
+Boise School District


### PR DESCRIPTION
boiseschools.org already exists in this repo with the same school name, but it is reserved for teachers.