### PR TITLE
Add American School of the Hague (ash.nl)

### DIFF
--- a/lib/domains/nl/ash.txt
+++ b/lib/domains/nl/ash.txt
@@ -1,0 +1,2 @@
+American School of the Hague
+American School of the Hague


### PR DESCRIPTION
School URL: https://ash.nl
Course Catalog (PDF: See pages 99-104) indicating full year Computer Science/Programming courses (IB Computer Science, AP Computer Science) https://drive.google.com/file/d/1uvHJ-TlARxTqjXo-q8nr-dvEA12LI_aO/view

Course Outlines: https://ash-nl-public.rubiconatlas.org/Atlas/Browse/View/Curriculum?BackLink=Atlas_Browse_View_Curriculum&Page=1&SchoolTypeFilter%5B%5D=2&SchoolTypeFilter%5B%5D=3&SchoolFilter%5B%5D=3&SubjectFilter%5B%5D=5&NowViewing=Atlas_Browse_View_Curriculum

Apologies for any mistakes in making this PR.
