### PR TITLE
Exclude Graduate Email for University of Hong Kong

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -232,7 +232,7 @@ stu.hnucm.edu.cn
 mail.ntust.edu.tw
 mails.qust.edu.cn
 lzjtu.edu.cn
-connect.hku.hk
+graduate.hku.hk
 stu.scu.edu.cn
 kust.edu.cn
 student.laccd.edu


### PR DESCRIPTION
ref: https://webmail.hku.hk/graduate/