### PR TITLE
Exclude Graduate Email for University of Hong Kong

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -232,7 +232,7 @@ stu.hnucm.edu.cn
 mail.ntust.edu.tw
 mails.qust.edu.cn
 lzjtu.edu.cn
-connect.hku.hk
+graduate.hku.hk
 stu.scu.edu.cn
 kust.edu.cn
 student.laccd.edu


### PR DESCRIPTION
hku.hk is include in the https://github.com/JetBrains/swot/blob/master/lib/domains/hk/hku.txt as it's the domain of the email address of The University of Hong Kong. However, graduate.hku.hk is not as it's for the graduate of the University. and it should be in the stoplist.txt
Ref: https://webmail.hku.hk/graduate/