### PR TITLE
Add public schools of the city of Lappeenranta

### DIFF
--- a/lib/domains/fi/lappee.txt
+++ b/lib/domains/fi/lappee.txt
@@ -1,0 +1,1 @@
+Lappeenrannan Lyseon lukio


### PR DESCRIPTION
The `@lappee.fi` is used by students of public schools at the city of Lappeenranta.

## Domain whois details
![image](https://user-images.githubusercontent.com/46541386/128487734-f9262737-47a4-4b25-bd1d-2545e4307077.png)

## Proof of being student email address

![image](https://user-images.githubusercontent.com/46541386/128489026-64843c4e-47f0-436f-9b33-3aae0820b043.png)

Two first search results by `lappee.fi`:

### https://saimaanmediakeskus.fi/g-suite-for-education/

Translated to English using Google Translate:

> Lappeenranta schools use Google G Suite tools. Log in to the G Suite cloud services with @ edu.lappeenranta.fi IDs (teachers) and @ lappee.fi (students).
> 
> The key tools in the G Suite are:
> 
> -Drive cloud service
> -@lappee.fi e-mail service for students
> -Office tools (Docs, Sheets, Slides)
> -Calendar (calendar.google.com doesn't sync with Outlook calendar)
> -Sites sites
> -Classroom learning environment
> -Forms questionnaires
> 
> ...

### https://www.kimpisenkoulu.fi/oppilaan-wilma-ja-lappee-fi-tunnus/

Translated to English using Google Translate:

> STUDENT WILMA AND @ LAPPEE.FI ID
> A reminder to students and their guardians.
> 
> The ID used for students at school firstname.lastname@lappee.fi is out of use on week 26, and their own Wilma ID is also out of use during that time.
> 
> From week 27 onwards, students will use their first Wilma ID as firstname.lastname@lappee.fi, which also changes the password that is delivered to the guardians.