### PR TITLE
Add Harrisonburg High School

### DIFF
--- a/lib/domains/us/va/k12/harrisonburg.txt
+++ b/lib/domains/us/va/k12/harrisonburg.txt
@@ -1,1 +1,3 @@
 Harrisonburg High School
+https://harrisonburg.k12.va.us/hhs/
+.group

--- a/lib/domains/us/va/k12/harrisonburg.txt
+++ b/lib/domains/us/va/k12/harrisonburg.txt
@@ -1,0 +1,1 @@
+Harrisonburg High School


### PR DESCRIPTION
Please add Harrisonburg High School (https://harrisonburg.k12.va.us/hhs/)
Engineering Related Course: https://www.harrisonburg.k12.va.us/hhs/Department/83-HHS-STEM