### PR TITLE
Remove Make School

### DIFF
--- a/lib/domains/com/makeschool/students.txt
+++ b/lib/domains/com/makeschool/students.txt
@@ -1,1 +1,0 @@
-Make School Students 


### PR DESCRIPTION
As of July 30th, Make School is no longer in operation.

https://www.dominican.edu/news/news-listing/dominican-welcomes-applied-computer-science-students

> The Applied Computer Science program was officially handed over to Dominican on July 30.