### PR TITLE
Add Lancaster Country Day School

### DIFF
--- a/lib/domains/org/lancastercountryday.txt
+++ b/lib/domains/org/lancastercountryday.txt
@@ -1,0 +1,1 @@
+Lancaster Country Day School


### PR DESCRIPTION
Official school website URL: lancastercountryday.org
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the school: https://www.lancastercountryday.org/curriculum-detail?fromId=240743&LevelNum=1057&DepartmentId=18765
a URL of a page or some other proof showing that the school recognizes the domain which you are submitting as an official email domain for the enrolled students: https://www.lancastercountryday.org/directory