### PR TITLE
Added Vamia, a vocational school in Vaasa, Finland.

### DIFF
--- a/lib/domains/fi/vaasa/student.txt
+++ b/lib/domains/fi/vaasa/student.txt
@@ -1,0 +1,2 @@
+Vamia
+vamia, vocational school in Vaasa, Finland


### PR DESCRIPTION
The website of the school is http://vamia.fi/.
Link to a long-term IT course offered by the school: https://vamia.fi/tutkinto/ohjelmistokehittaja/.
Here's the login page of the school. You can log in using a '*@student.vaasa.fi' account.