### PR TITLE
add Arizona virtual academy

### DIFF
--- a/lib/domains/org/azva.txt
+++ b/lib/domains/org/azva.txt
@@ -1,0 +1,1 @@
+arizona virtual academy

--- a/lib/domains/uk/org/bhcet/carmelstudent.txt
+++ b/lib/domains/uk/org/bhcet/carmelstudent.txt
@@ -1,0 +1,2 @@
+Carmel College
+Carmel College


### PR DESCRIPTION
Arizona virtual academy site https://azva.k12.com/

azva.org is the email domain for our school. 