### PR TITLE
Add NEIVCE

### DIFF
--- a/lib/domains/my/edu/djzhlc.txt
+++ b/lib/domains/my/edu/djzhlc.txt
@@ -1,0 +1,1 @@
+New Era Institute of Vocational and Continuing Education

--- a/lib/domains/my/edu/neivce.txt
+++ b/lib/domains/my/edu/neivce.txt
@@ -1,0 +1,1 @@
+New Era Institute of Vocational and Continuing Education


### PR DESCRIPTION
Adding the vocational wing of our institution.
djzhlc.edu.my was previously used before switching to the current domain name neivce.edu.my.