### PR TITLE
Adding school domain information for Cole Academy

### DIFF
--- a/lib/domains/org/coleacademy.txt
+++ b/lib/domains/org/coleacademy.txt
@@ -1,0 +1,1 @@
+Cole Academy


### PR DESCRIPTION
- Official site https://www.coleacademy.org/
- There is no page on the site that describes the programming / IT courses. Simple programming courses have been provided for students for the past couple of years, and the school wanted to see if JetBrains IDEs could help us out.
- The site does not mention the student emails, but teachers and students use emails from the same domain. The bottom footer of each page on the site shows the email address for the school uses the coleacademy.org domain.

![image](https://user-images.githubusercontent.com/2124854/129920741-b3d03468-b261-4c9a-961f-5ae0d33dc93a.png)
