### PR TITLE
Add UECREAR school to domains

### DIFF
--- a/lib/domains/ec/edu/uecrear.txt
+++ b/lib/domains/ec/edu/uecrear.txt
@@ -1,0 +1,1 @@
+Unidad Educativa CREAR


### PR DESCRIPTION
PR for adding UECREAR school domain to list

Greetings, this is a new PR for adding UECREAR school to valid list.
Here is the information requested on previous PR:

- **the school official website URL**:  http://uecrear.edu.ec/
- **the school street address, including city and country**:  Quinindé Av, Km 3 1/2, Santo Doming de los Colorados, Ecuador
- **an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course**: http://uecrear.edu.ec/programacion-para-ninos-y-jovenes/

The school is offering a long-term programming course for children and youth, It would be great if students could have an IJ license for their Java practices