### PR TITLE
Add Siikalatvan lukio

### DIFF
--- a/lib/domains/fi/siikalatva/edu.txt
+++ b/lib/domains/fi/siikalatva/edu.txt
@@ -1,0 +1,1 @@
+Siikalatvan lukio


### PR DESCRIPTION
The email addresses of `@edu.siikalatva.fi` are used by students at Siikalatva high school.

## Whois

<img width="674" alt="firefox_Q6p4TAfONs" src="https://user-images.githubusercontent.com/45627874/129925538-f0fe4451-7cbd-4364-90f2-97a4c6524135.png">

## Links

Website(s):
 - https://www.siikalatva.fi/varhaiskasvatus-ja-koulutus/siikalatvan-lukio-on-vahva-yleislukio/
 - https://peda.net/siikalatva/siikalatvan-lukio

IT courses: https://peda.net/siikalatva/siikalatvan-lukio/opinnot/lops2019/oppiaineet/tietotekniikka

Proof of domain(?): https://peda.net/siikalatva/siikalatvan-lukio/henkil%C3%B6kunta
(Apparently school staff doesn't use the `edu.` subdomain, didn't pull request that domain as it's probably used by non education employees as well)