### PR TITLE
Please enter this domain in your system 

### DIFF
--- a/lib/domains/nrw/tsst/schueler.txt
+++ b/lib/domains/nrw/tsst/schueler.txt
@@ -1,0 +1,2 @@
+Technische Schule Steinfurt (tsst)
+Technical Schools Steinfurt (tsst)


### PR DESCRIPTION
Name: Technischen Schulen des Kreises Steinfurt
Shortcut: TSST (Technische Schule Steinfurt)
State: NRW (North Rhine Westphalia)
Website: https://www.tssteinfurt.de/
Domain: @schueler.tsst.nrw
The school is a: Vocational college, vocational grammar school, technical college, technical secondary school and Vocational college (https://www.tssteinfurt.de/index.php/bildungsgaenge)