### PR TITLE
Add Centro Universitário Ruy Barbosa

### DIFF
--- a/lib/domains/br/edu/uniruy/alunos.txt
+++ b/lib/domains/br/edu/uniruy/alunos.txt
@@ -1,0 +1,2 @@
+Centro Universitário Ruy Barbosa
+University Center Ruy Barbosa

--- a/lib/domains/br/uniruy/alunos.txt
+++ b/lib/domains/br/uniruy/alunos.txt
@@ -1,2 +1,0 @@
-Centro Universitário Ruy Barbosa
-University Center Ruy Barbosa

--- a/lib/domains/br/uniruy/alunos.txt
+++ b/lib/domains/br/uniruy/alunos.txt
@@ -1,0 +1,2 @@
+Centro Universitário Ruy Barbosa
+University Center Ruy Barbosa


### PR DESCRIPTION
Domain is "alunos.uniruy.edu.br" instead of "alunos.uniruy.br"