### PR TITLE
Add Marion Dönhoff Gymnasium (High School)

### DIFF
--- a/lib/domains/de/mdg-hamburg.txt
+++ b/lib/domains/de/mdg-hamburg.txt
@@ -1,0 +1,1 @@
+Marion Dönhoff Gymnasium


### PR DESCRIPTION
School's sites:
https://www.marion-doenhoff-gymnasium.de/ (Homepage)
https://www.mdg-hamburg.de/ (IServ and E-Mail domain)