### PR TITLE
Change UMUC to UMGC

### DIFF
--- a/lib/domains/edu/umgc.txt
+++ b/lib/domains/edu/umgc.txt
@@ -1,0 +1,1 @@
+University of Maryland Global Campus

--- a/lib/domains/edu/umuc.txt
+++ b/lib/domains/edu/umuc.txt
@@ -1,1 +1,0 @@
-University of Maryland University College


### PR DESCRIPTION
The formerly University of Maryland University College changed its name to University of Maryland Global Campus. This link on the official website explains the name change: https://www.umgc.edu/about/university-of-maryland-global-campus/index.cfm