### PR TITLE
Add jamsa.mobi domain for Jämsän sivistyspalvelukeskus

### DIFF
--- a/lib/domains/mobi/jamsa.txt
+++ b/lib/domains/mobi/jamsa.txt
@@ -1,0 +1,1 @@
+Jämsän sivistyspalvelukeskus


### PR DESCRIPTION
Added jamsa.mobi to domains.
This domain is owned by Jämsä, a town in Finland.
The email addresses under jamsa.mobi are only students and teachers, other personnel of the town have @jamsa.fi domains.
We have also G Suite setupped for the domain for school purposes.