### PR TITLE
Add OA Opava

### DIFF
--- a/lib/domains/cz/oa-opava.txt
+++ b/lib/domains/cz/oa-opava.txt
@@ -1,0 +1,1 @@
+Obchodní akademie a Střední odborná škola logistická, Opava, příspěvková organizace


### PR DESCRIPTION
Obchodní akademie a Střední odborná škola logistická, Opava, příspěvková organizace
School domain: oa-opava.cz
The student's emails are on the same domain @oa-opava.cz

Address: Hany Kvapilové 20, 746 01  Opava, Czech republic
Contact information on our website: https://oa-opava.cz/index.php/kontakt

School offers an IT-related long-term (4 years) course Inforamtion Technology in Economics
Computer since subject: https://oa-opava.cz/index.php/uchazeci/obor-informacni-technologie
Education plan for Information Technology: https://oa-opava.cz/images/soubory/ke_stazeni/2019_svp_it.pdf