### PR TITLE
Munster Technological University domain: mtu.ie

### DIFF
--- a/lib/domains/ie/mtu.txt
+++ b/lib/domains/ie/mtu.txt
@@ -1,0 +1,1 @@
+Munster Technological University


### PR DESCRIPTION
New Domain for Munster Technological University. Merging of CIT and ITTralee colleges. Old domains still active. MTU.ie is new  (as of September 2021) domain for Lecturers and Researchers and will eventually replace cit.ie and ittralee.ie at some point in the future. Website for merged college: www.mtu.ie. Old websites: www.cit.ie and www.ittralee.ie