### PR TITLE
Adding Green Village School

### DIFF
--- a/lib/domains/info/ramat-gan.txt
+++ b/lib/domains/info/ramat-gan.txt
@@ -1,1 +1,0 @@
-Armonim School, Ramat-Gan City

--- a/lib/domains/info/ramat-gan.txt
+++ b/lib/domains/info/ramat-gan.txt
@@ -1,0 +1,1 @@
+Armonim School, Ramat-Gan City


### PR DESCRIPTION
Adding Green Village School (Ha-Kfar Ha-Yarok School) in Ramat Ha-Sharon, Israel.
Some info about the school: https://en.wikipedia.org/wiki/HaKfar_HaYarok#Junior_High_School.
The school site in Hebrew: https://kfaryarok.org.il/.