### PR TITLE
Add edu.uca.ma

### DIFF
--- a/lib/domains/ma/ac/uca
+++ b/lib/domains/ma/ac/uca
@@ -1,0 +1,1 @@
+Ecole supérieure de téchnologie safi


### PR DESCRIPTION
Hello there!  I have the academic Email which ends up with @edu.uca.ma
and I already got the GitHub student pack with it but now when I'm trying to apply for the JetBrains Products for Learning and they tell me this:

```
Sorry, we can't accept your email address because we are not able to identify if the people from this email domain are truly students or not.
This could have happened for the following reasons:

Your school allows registering an email address there even if you are not a student of the college.
Someone from the school sold or shared their account details or activation code publicly, which has led to a broad account misuse and license terms violation.
```
Please consider merging my pull request!