### PR TITLE
add new SCGSSM domain

### DIFF
--- a/lib/domains/school/governors.txt
+++ b/lib/domains/school/governors.txt
@@ -1,0 +1,1 @@
+South Carolina Governor's School For Science & Math


### PR DESCRIPTION
The South Carolina Governor's School for Science and Mathematics is transitioning from the previously accepted gssm.k12.sc.us to the newly updated governors.school

The old domain is in the process of being phased out and should be obsolete by the end of the 2021-2022 school year. 