### PR TITLE
Add domain eduservices.org

### DIFF
--- a/lib/domains/org/eduservices.txt
+++ b/lib/domains/org/eduservices.txt
@@ -1,0 +1,2 @@
+Eduservices
+.group


### PR DESCRIPTION
Added eduservices.org

Eduservices regroups several schools and that is the domains used for the teachers addresses.
I personally teach at MyDigitalSchool (which is already part of this repo my-digital-school.org) but I have an @eduservices.org email as a teacher.

Eduservices webpage :  http://www.groupe-eduservices.fr/en
MyDigitalSchool legal page that mention the eduservices group ownership : https://www.mydigitalschool.com/mentions-legales

Some of the MyDigitalSchool courses related to IT : 
- https://www.mydigitalschool.com/mba-architecte-web
- https://www.mydigitalschool.com/bachelor-developpeur-digital-web

Have a great day!