### PR TITLE
Add Heinrich-Hertz-Europakolleg Bonn

### DIFF
--- a/lib/domains/de/hhek.txt
+++ b/lib/domains/de/hhek.txt
@@ -1,0 +1,1 @@
+Heinrich Hertz Europakolleg


### PR DESCRIPTION
Heinrich-Hertz-Europakolleg der Bundesstadt Bonn
Address: Herseler Straße 1, 53117 Bonn, Germany
Website: https://hhek.bonn.de/

More information about IT courses offered at hhek can be found here: https://hhek.bonn.de/informationstechnik/

Heinrich-Hertz-Europakolleg is using two different domains:

hhek.bonn.de, which is used for its public website and teacher's email addresses, was already added earlier this year (https://github.com/JetBrains/swot/blob/master/lib/domains/de/bonn/hhek.txt)

hhek.de is used for internal tools and student's email addresses

As proof that hhek recognizes the domain hhek.de, you can find multiple links to it in the "Internal" page of their official website: https://hhek.bonn.de/intern/