### PR TITLE
FH Gesundheitsberufe OÖ GmbH

### DIFF
--- a/lib/domains/at/ac/fhgooe.txt
+++ b/lib/domains/at/ac/fhgooe.txt
@@ -1,0 +1,1 @@
+FH Gesundheitsberufe OÖ GmbH

--- a/lib/domains/at/ac/fhgooe/stud.txt
+++ b/lib/domains/at/ac/fhgooe/stud.txt
@@ -1,0 +1,1 @@
+FH Gesundheitsberufe OÖ GmbH


### PR DESCRIPTION
Added the domains fhgooe.ac.at and stud.fhgooe.ac.at.

The first one is used for teachers and the second one is used for students.

The IT related course is medical technology and medical informatics.

The homepage is [https://www.fh-gesundheitsberufe.at/](https://www.fh-gesundheitsberufe.at/).