### PR TITLE
Add RomeCSD

### DIFF
--- a/lib/domains/org/romecsd.txt
+++ b/lib/domains/org/romecsd.txt
@@ -1,0 +1,1 @@
+Rome City School District


### PR DESCRIPTION
This site [romecsd.org](https://romecsd.org) may not load in certain parts of the world. I am unaware as to why this problem exists, but I can provide screenshots of the site, and verification that the domain is indeed associated with a school if needed.
This screenshot of the site was taken from a school-provided Chromebook:
![image](https://user-images.githubusercontent.com/44954117/134380620-6078c899-7a8a-4724-a070-cbc0767edccd.png)

A mirror of the site appears to be hosted [here](https://romecity.ss12.sharpschool.com/), as the site is being hosted through SharpSchools.