### PR TITLE
feat: domain for iitbhu (primary)

### DIFF
--- a/lib/domains/in/ac/itbhu.txt
+++ b/lib/domains/in/ac/itbhu.txt
@@ -1,0 +1,1 @@
+Indian Institute of Technology (Banaras Hindu University)


### PR DESCRIPTION
- Official Website: https://iitbhu.ac.in/
- IT related course: https://iitbhu.ac.in/dept/cse

## Proof

On the following link https://iitbhu.ac.in/cf/cis which is our Computer Facilities Page you can find the `check mail` button in the footer whose hyperlink reference is to http://mail.itbhu.ac.in/ which is our primary domain apart from iitbhu.ac.in

The reason for the two domains is because our institute was renamed to Indian Institute of Technology in the year 2012 before that it was Institute of Technology ([Reference](https://en.wikipedia.org/wiki/Indian_Institute_of_Technology_(BHU)_Varanasi)). Hence for compatibility reasons both domains are kept in use but students are first provided itbhu.ac.in so they can only login using it but mail can be sent and received using iitbhu.ac.in as well.

![itbhu](https://user-images.githubusercontent.com/52061363/134475404-111e38a5-ab97-4517-a335-aeb1f783135d.png)

![IITBHU](https://user-images.githubusercontent.com/52061363/134475415-3ea29d53-4dda-4d45-b0a9-9ddde3b067d7.png)

