### PR TITLE
IBZ Schulen AG changed its email domain.

### DIFF
--- a/lib/domains/ch/ibz.txt
+++ b/lib/domains/ch/ibz.txt
@@ -1,1 +1,0 @@
-IBZ Schulen AG

--- a/lib/domains/ch/ipso.txt
+++ b/lib/domains/ch/ipso.txt
@@ -1,0 +1,1 @@
+ipso Bildung AG


### PR DESCRIPTION
See https://campus.ibz.ch/#section-100500