### PR TITLE
Add SABJE external email address

### DIFF
--- a/lib/domains/com/onmicrosoft/sabje.txt
+++ b/lib/domains/com/onmicrosoft/sabje.txt
@@ -1,0 +1,1 @@
+King David Schools


### PR DESCRIPTION
Please can you add SABJE's external email address.
I earlier added sabje.co.za, but have just been informed that will only work for internal mail. To use external emails we need to use sabje.onmicrosoft.com. 
King David Schools
https://kingdavid.org.za/
Sorry for any inconvenience caused.