### PR TITLE
Comberton Village College

### DIFF
--- a/lib/domains/org/combertonvc.txt
+++ b/lib/domains/org/combertonvc.txt
@@ -1,0 +1,1 @@
+comberton villlage college

--- a/lib/domains/org/combertonvc.txt
+++ b/lib/domains/org/combertonvc.txt
@@ -1,1 +1,1 @@
-comberton villlage college
+Comberton Village College


### PR DESCRIPTION
Comberton Village College has the domain https://www.combertonvc.org/ and postcode CB23 7DU, I'm not sure what verification I can give other than a test register message
![Untitled](https://user-images.githubusercontent.com/84926729/136064294-b473e78f-fdfb-4d9e-91f0-a339da0f5947.png)

