### PR TITLE
Add Albright Institute

### DIFF
--- a/lib/domains/au/edu/albrightinstitute.txt
+++ b/lib/domains/au/edu/albrightinstitute.txt
@@ -1,0 +1,1 @@
+Albright Institute of Business and Language


### PR DESCRIPTION
This PR will add Albright Institute.

Albright website: https://albrightinstitute.edu.au/
Page showing domain emails used: https://albrightinstitute.edu.au/contacts/
Information Tech course(104 weeks): https://albrightinstitute.edu.au/ict60220-advanced-diploma-of-information-technology


Image with emails from institute:
![Screen Shot 2021-10-07 at 9 59 32 pm](https://user-images.githubusercontent.com/25412194/136371619-74e335ef-faf5-48d3-9dd7-1cf680f7c0ea.png)
