### PR TITLE
Create nmit.txt

### DIFF
--- a/lib/domains/nz/ac/nmit.txt
+++ b/lib/domains/nz/ac/nmit.txt
@@ -1,0 +1,1 @@
+Nelson Marlborough Institute of Technology


### PR DESCRIPTION
Add Nelson Marlborough Institute of Technology academic staff emails

Academic staff have @nmit.ac.nz emails (students have @live.nmit.ac.nz emails, which already is in this repo).
Institution website: https://www.nmit.ac.nz/
3-year IT degree: https://www.nmit.ac.nz/study/programmes/bachelor-of-information-technology/
Proof of official email domain: One of the links here: https://www.nmit.ac.nz/search?q=%40nmit.ac.nz&action_search=Submit