### PR TITLE
Add ITS Apulia Digital Maker

### DIFF
--- a/lib/domains/it/apuliadigitalmaker/studenti.txt
+++ b/lib/domains/it/apuliadigitalmaker/studenti.txt
@@ -1,0 +1,1 @@
+ITS Apulia Digital Maker


### PR DESCRIPTION
-university official website URL: https://www.apuliadigitalmaker.it/
-URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www.apuliadigitalmaker.it/developer-4-0-bari/