### PR TITLE
Adding a file for UFOPA university, Brazil

### DIFF
--- a/lib/domains/br/edu/ufopa.txt
+++ b/lib/domains/br/edu/ufopa.txt
@@ -1,0 +1,2 @@
+Universidade Federal do Oeste do Pará (UFOPA)
+Federal University of Western Pará


### PR DESCRIPTION
As commented in the fork pull request;
According to the instructions of the "How to add the domain quicker" section of the readme, the links suggested are bellow:

Official website of the university:  http://www.ufopa.edu.br/ufopa/

Link for the avaible graduation courses:  http://www.ufopa.edu.br/ufopa/ensino/cursos-de-graduacao-2/

Link for one of the avaible IT courses, Information systems:  https://sigaa.ufopa.edu.br/sigaa/public/curso/portal.jsf?id=19&lc=pt_BR&nivel=G

Link for a page briefly talking about the UFOPA E-mail:  http://www.ufopa.edu.br/portal/banners-1/e-mail-institucional/

UFOPA's mail page:  https://mail.ufopa.edu.br/

Page talking about the necessity for students to create their institutional E-mail to access remote classes:  http://www.ufopa.edu.br/ufopa/comunica/noticias/discentes-devem-obter-e-mail-institucional-para-acessar-plataformas-de-ensino-remoto/