### PR TITLE
Use base domain 'uneatlantico.es' 

### DIFF
--- a/lib/domains/es/uneatlantico.txt
+++ b/lib/domains/es/uneatlantico.txt
@@ -1,0 +1,2 @@
+Universidad Europea del Atlántico
+European University of Atlantic

--- a/lib/domains/es/uneatlantico/alumnos.txt
+++ b/lib/domains/es/uneatlantico/alumnos.txt
@@ -1,1 +1,0 @@
-Universidad Europea del Atlántico


### PR DESCRIPTION
Hi everyone,

I'm a teacher in "European University of Atlantic". My students are abled to use educational licenses but the teachers are not, because our email uses the main domain of the school (uneatlantico.es). This commit removes the folder and file 'alumnos.txt' and adds a single file 'uneatlantico.txt' to allow both, students and teachers, use this kind of licenses.