### PR TITLE
Adding UEMG discente domain

### DIFF
--- a/lib/domains/br/uemg/discente.txt
+++ b/lib/domains/br/uemg/discente.txt
@@ -1,0 +1,1 @@
+Universidade do Estado de Minas Gerais


### PR DESCRIPTION
Adding discentes domain for UEMG (Universidade do estado de Minas Gerais).
University website: https://www.uemg.br/
