### PR TITLE
Add Givat Shmuel High School

### DIFF
--- a/lib/domains/il/org/edum/gsh.txt
+++ b/lib/domains/il/org/edum/gsh.txt
@@ -1,0 +1,2 @@
+תיכון גבעת שמואל
+Giv'at Shmuel High School


### PR DESCRIPTION
Info:
- [Website](https://sites.google.com/gsh.edum.org.il/gsh1/home)
- [This](https://www.givat-shmuel.muni.il/117/) page on the municipality website shows the schools in the city and their emails. Under "תיכון גבעת שמואל" (Givat Shmuel High School), the email address "office@gsh.edum.org.il" is also listed.