### PR TITLE
https://iticparis.com/

### DIFF
--- a/lib/domains/com/iticparis.txt
+++ b/lib/domains/com/iticparis.txt
@@ -1,0 +1,3 @@
+Institut des Techniques Informatiques et Commerciales
+Institute of Information Technology and Commercial Techniques
+ITIC Paris


### PR DESCRIPTION
- IT Courses (2yrs, 3yrs, 5yrs): https://www.iticparis.com/informatique/home/
- The domain is not yet used for students, only for trainers