### PR TITLE
Adding Lowndes County School District in Mississippi

### DIFF
--- a/lib/domains/ms/lcsd.txt
+++ b/lib/domains/ms/lcsd.txt
@@ -1,2 +1,4 @@
-Lowndes County School District, Lowndes County, Mississippi, USA
+Lowndes County School District 
+Lowndes County, Mississippi, USA
+.group
 

--- a/lib/domains/ms/lcsd.txt
+++ b/lib/domains/ms/lcsd.txt
@@ -1,0 +1,2 @@
+Lowndes County School District, Lowndes County, Mississippi, USA
+


### PR DESCRIPTION
This is a submission for the Lowndes County School District in Mississippi. 
The district's URL is https://www.lowndes.k12.ms.us/
The long-term IT related courses can be found here https://ctc.lowndes.k12.ms.us/apps/pages/index.jsp?uREC_ID=1042215&type=d&pREC_ID=1342246
And I don't have a screenshot of the domain being used.