### PR TITLE
Add National Higher Polytechnic School of Douala

### DIFF
--- a/lib/domains/cm/enspd-udo.txt
+++ b/lib/domains/cm/enspd-udo.txt
@@ -1,0 +1,2 @@
+Ecole Nationale Supérieure Polytechnique de Douala (ENSPD)
+National Higher Polytechnic School of Douala


### PR DESCRIPTION
Please add Ecole Nationale Supérieure Polytechnique de Douala (ENSPD), known in English as the National Higher Polytechnic School of Douala to your system so that I can have access to the students Privileges of JetBrains. Thank you.