### PR TITLE
add new college: FAETERJ-Paracambi

### DIFF
--- a/lib/domains/br/gov/rj/faetec/faeterj-prc/aluno.txt
+++ b/lib/domains/br/gov/rj/faetec/faeterj-prc/aluno.txt
@@ -1,0 +1,1 @@
+Faculdade de Educação Tecnológica do Estado do Rio de Janeiro (FAETERJ-Paracambi)


### PR DESCRIPTION
Add domain of institutional e-mails of students (aluno.faeterj-prc.faetec.rj.gov.br)

Official website: http://www.faeterj-paracambi.com.br/

"Faculdade de Educação Tecnológica do Estado do Rio de Janeiro (FAETERJ-Paracambi)" is a higher education institution subordinated to "Fundação de Apoio à Escola Técnica" (FAETEC), located in the municipality of Paracambi, at Rua Sebastião Lacerda, s/nº

There are two courses that run at the institution: the Environmental Management course and the Information Systems course. The request for recognition of both was registered under the protocol dated November 29, 2003 under No. E03/100.857/03. The operation of the two courses was authorized on May 24, 2005, by the State Council of Education, as per opinion CEE nº 121/2005.

For more information, contact coordinator Fausto Amaro da Silva Araujo (fausto.araujo@faeterj-prc.faetec.rj.gov.br) or the institution's secretariat (contato@faeterj-prc.faetec.rj.gov.br)