### PR TITLE
Added Pensionnat du Saint-Nom-de-Marie

### DIFF
--- a/lib/domains/ca/qc/psnm.txt
+++ b/lib/domains/ca/qc/psnm.txt
@@ -1,0 +1,2 @@
+Pensionnat du Saint-Nom-de-Marie
+Boarding School Du Saint-nom-de-Marie


### PR DESCRIPTION
Official website: https://www.psnm.qc.ca/

Address: 628, chemin de la Côte-Sainte-Catherine, Outremont (Québec) H2V 2C5