### PR TITLE
Add UTN-Facultad Regional Concepción del Uruguay

### DIFF
--- a/lib/domains/com/onmicrosoft/o365frcuutneduar.txt
+++ b/lib/domains/com/onmicrosoft/o365frcuutneduar.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica Nacional, Facultad Regional Concepción del Uruguay (UTN - FRCU)
+National Technological University, Concepción del Uruguay Regional Faculty (UTN - FRCU)


### PR DESCRIPTION
- Offical university site: http://www.frcu.utn.edu.ar/

- URL where a long-term (>1 year) IT related course is offered by the university: 
http://www.frcu.utn.edu.ar/wp-content/uploads/2018/07/Plan_ISI_2015.pdf

   This link shows the 5-year plan of the systems engineering degree

- URL of a page showing that the university recognizes the domain as an official email domain for the enrolled students:
http://www.frcu.utn.edu.ar/stics/solicitud-para-cuenta-institucional-office-365-frcu/

   on this page you can request an email where you need to provide your university student identification number (Número de Legajo)

- City/province/country/address:
Concepción del Uruguay / Entre Ríos / Argentina / Ing. Pereyra 676

The student email differs from the official website, because only the teachers get an E-Mail with the official domain. 
The student E-Mails are mainly used to get access to the office package.