### PR TITLE
Requested Otto-Nagel-Gym

### DIFF
--- a/lib/domains/berlin/ong.txt
+++ b/lib/domains/berlin/ong.txt
@@ -1,0 +1,2 @@
+Otto-Nagel-Gymnasium
+

--- a/lib/domains/de/otto-nagel-gymnasium.txt
+++ b/lib/domains/de/otto-nagel-gymnasium.txt
@@ -1,0 +1,2 @@
+Otto-Nagel-Gymnasium
+


### PR DESCRIPTION
Hello, I opened a pull request to add the Otto-Nagel-Gymnasium located in Berlin.
Some notes:
* the website otto-nagel-gymnasium.de redirects to ong.berlin
* students get student.ong.berlin for their E-Mails
* Teachers get both a ong.berlin Mail and a otto-nagel-gymnasium.de Mail
* the school offers a [2 year IT course](https://ong.berlin/wahlpflichtunterricht/) (the text is in German, and its one of an arrangement of courses that students have to pick 2 from) 

Edit:
This page proofs that student actually use these E-Mails: [Link](https://portal.ong.berlin/anleitungen/e-mail/zugriff-ueber-apple-mail-schueler/) (its a guide how to set them up)

Edit 2:
[This](https://who.is/whois/ong.berlin) whois pages proofs that the school owns the domain ong.berlin .