### PR TITLE
University add: UniNorte

### DIFF
--- a/lib/domains/br/com/sempreuninorte.txt
+++ b/lib/domains/br/com/sempreuninorte.txt
@@ -1,0 +1,2 @@
+Centro Universitário do Norte
+UniNorte - Ser Educational Group


### PR DESCRIPTION
Another domain owned by UniNorte
Centro Universitário do Norte - UniNorte is a part from Ser Educational Group