### PR TITLE
add Ecole O'clock

### DIFF
--- a/lib/domains/io/oclock.txt
+++ b/lib/domains/io/oclock.txt
@@ -1,0 +1,1 @@
+Ecole O'clock


### PR DESCRIPTION
the school official website URL :  https://oclock.io/
the school street address, including city and country : 10 RUE DE PENTHIEVRE 75008 PARIS FRANCE (O'clock is a real-time remote school )
an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course : 
https://oclock.io/formations/alternance#info
<img width="356" alt="Capture d’écran 2021-11-18 à 11 33 37" src="https://user-images.githubusercontent.com/81997531/142399197-374619d2-3c01-424c-839e-feff96755d06.png">
s
