### PR TITLE
add damnhour university domain

### DIFF
--- a/lib/domains/eg/edu/dmu.txt
+++ b/lib/domains/eg/edu/dmu.txt
@@ -1,0 +1,2 @@
+Faculty of computers and information Damnhour University
+Faculty of computers and information Damnhour University


### PR DESCRIPTION
Wiki page : https://en.wikipedia.org/wiki/Damanhour_University
University Official website : https://www.damanhour.edu.eg/en/pages/default.aspx
https://dmu.edu.eg/
http://portal.mohesr.gov.eg/en-us/Pages/governmental-universities.aspx#accordionV1Collapse19