### PR TITLE
add Heroes of Kruty State Lyceum of Lviv

### DIFF
--- a/lib/domains/education/ukr/lgk.txt
+++ b/lib/domains/education/ukr/lgk.txt
@@ -1,0 +1,1 @@
+Heroes of Kruty State Lyceum of Lviv


### PR DESCRIPTION
Heroes of Kruty State Lyceum of Lviv - is a military oriented state lyceum in Lviv (Ukraine). One of the speciality (cyber security) is orientated to form future developpers for state cyber security domain 

Official website (in ukrainian):
https://ldl-gk.lviv.ua/

Official FB page:
https://www.facebook.com/lgkrut/