### PR TITLE
Adds Semantic Technology Institute

### DIFF
--- a/lib/domains/at/sti2.txt
+++ b/lib/domains/at/sti2.txt
@@ -1,0 +1,1 @@
+Semantic Technology Institute


### PR DESCRIPTION
This PR adds Semantic Technology Institute in Innsbruck, Austria, to the repo.