### PR TITLE
Add PSD Student Email

### DIFF
--- a/lib/domains/org/puyallupsd.txt
+++ b/lib/domains/org/puyallupsd.txt
@@ -1,0 +1,1 @@
+Puyallup School District


### PR DESCRIPTION
Here's main domain for the district, https://puyallup.k12.wa.us. It can be verified of authenticity as it has an official K-12 domain provided by the Washington Office of Superintendent of Public Education (https://www.k12.wa.us/). Here is a page verifying authenticity of student email, https://puyallup.k12.wa.us/cms/One.aspx?portalId=141151&pageId=3257594. If this can still not be authenticated or added, I understand.