### PR TITLE
new domain for Shavatz high school

### DIFF
--- a/lib/domains/il/org/tad/shavatz.txt
+++ b/lib/domains/il/org/tad/shavatz.txt
@@ -1,2 +1,0 @@
-שמעון בן צבי
-Shimon Ben Tzvi

--- a/lib/domains/il/org/taded.txt
+++ b/lib/domains/il/org/taded.txt
@@ -1,0 +1,2 @@
+תיכון שמעון בן צבי
+Shimon Ben Zvi High School


### PR DESCRIPTION
https://shavatz.co.il/shimon-ben-zvi-high-school/