### PR TITLE
Add file for Hector Seminar

### DIFF
--- a/lib/domains/de/hector-seminar.txt
+++ b/lib/domains/de/hector-seminar.txt
@@ -1,0 +1,1 @@
+Hector Seminar Heidelberg, Karlsruhe, Mannheim, Pforzheim


### PR DESCRIPTION
This PR adds the domain `hector-seminar.de` to the repository.

The Hector Seminar is an institution for the promotion of highly gifted pupils at high schools in northern Baden, Germany. It promotes pupils in mathematics, computer science, natural sciences and technology. Everyone of them gets an email address for the time until their graduation and the domain seems to be missing from the swot repository.

Website of the Hector Seminar: https://hector-seminar.de/startseite