### PR TITLE
Create mboamersfoort.txt

### DIFF
--- a/lib/domains/nl/mboamersfoort.txt
+++ b/lib/domains/nl/mboamersfoort.txt
@@ -1,0 +1,1 @@
+MBO Amersfoort


### PR DESCRIPTION
- School website: https://www.mboamersfoort.nl/

Adress:
MBO Amersfoort -
School voor Techniek
Hardwareweg 15 · 033 434 5151
Geopend ⋅ Sluit om 18:00

- Example programme (>1 year):
https://www.mboamersfoort.nl/opleiding/technisch-leidinggevende/