### PR TITLE
Add HTL Mistelbach

### DIFF
--- a/lib/domains/at/ac/htlmistelbach.txt
+++ b/lib/domains/at/ac/htlmistelbach.txt
@@ -1,0 +1,2 @@
+Höhere technische Lehranstalt Mistelbach für Biomedizin und Gesundheitstechnik
+HTL Mistelbach for biomedical engineering


### PR DESCRIPTION
"HTL Mistelbach for biomedical engineering"
Karl Katschthaler-Straße 2, 2130 Mistelbach, Austria

School offers 5 years with matura.
https://www.htlmistelbach.ac.at/Fachrichtung-Biomedizin--und-Gesundheitstechnik-in-Mistelbach.html
Focus on electronics, computer science (IT) and biomedical engineering