### PR TITLE
Added BCSF sixth form

### DIFF
--- a/lib/domains/uk/org/beauchampcity.txt
+++ b/lib/domains/uk/org/beauchampcity.txt
@@ -1,0 +1,1 @@
+Beauchamp City Sixth Form


### PR DESCRIPTION
Afternoon,

Would like to add the domain for the Beauchamp City Sixth Form, Leicester.

Website is [here](https://www.beauchampcity.org.uk/), we offer Computer Science A level [here](https://www.beauchampcity.org.uk/curriculum/curriculum/course-information/computer-science/) and students can access their emails through the standard Microsoft Office Portal.