### PR TITLE
Mbeya University of Science and Technology

### DIFF
--- a/lib/domains/tz/ac/mustnet.txt
+++ b/lib/domains/tz/ac/mustnet.txt
@@ -1,0 +1,1 @@
+Mbeya University of Science and Technology


### PR DESCRIPTION
1. Currently, mustnet.ac.tz has transitioned to must.ac.tz but the emails are still under mustnet.ac.tz
2. Link to a Bachelor degree in computer science program [here](https://must.ac.tz/programmes/NDA%3D)