### PR TITLE
Add Developers Institute to Jetbrains list

### DIFF
--- a/lib/domains/nz/ac/developers.txt
+++ b/lib/domains/nz/ac/developers.txt
@@ -1,0 +1,1 @@
+Developers Institute

--- a/lib/domains/nz/ac/developersinstitute.txt
+++ b/lib/domains/nz/ac/developersinstitute.txt
@@ -1,0 +1,1 @@
+Developers Institute


### PR DESCRIPTION
Contributing an NZ accredited tertiary institution: See www.developers.ac.nz 