### PR TITLE
Istanbul University mail address extension fixed

### DIFF
--- a/lib/domains/tr/edu/iu/ogr.txt
+++ b/lib/domains/tr/edu/iu/ogr.txt
@@ -1,2 +1,2 @@
-Istanbul Tip University
-Web domain is http://istanbultip.istanbul.edu.tr, emails are xyz@ogr.iu.edu.tr
+İstanbul Universitesi
+Istanbul University - Student Spesific Mail Address Extensions


### PR DESCRIPTION
Istanbul University Web Page in English: https://www.istanbul.edu.tr/en/_

The student mail addresses specified with @ogr.iu.edu.tr

You can follow the link of [Istanbul University Student Mail System](https://ogr.iu.edu.tr/) the mail address extension top of the page.