### PR TITLE
Add ITS Alto Adriatico

### DIFF
--- a/lib/domains/it/itsaltoadriatico/stud.txt
+++ b/lib/domains/it/itsaltoadriatico/stud.txt
@@ -1,0 +1,1 @@
+ITS Alto Adriatico


### PR DESCRIPTION
https://www.tecnicosuperiorekennedy.it/

recently changed name from ITS Kennedy to ITS Alto Adriatico.
Domains: itsaltoadriatico.it and tecnicosuperiorekennedy.it