### PR TITLE
Add domain luxemburg.bo.it

### DIFF
--- a/lib/domains/it/bo/luxemburg.txt
+++ b/lib/domains/it/bo/luxemburg.txt
@@ -1,0 +1,1 @@
+Istituto Tecnico Commerciale Statale Rosa Luxemburg


### PR DESCRIPTION
The official website: [https://www.luxemburg.bo.it/](https://www.luxemburg.bo.it/)

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:

[This document](https://www.luxemburg.bo.it/pvw/app/default/pvw_img.php?sede_codice=BOIT0005&doc=2555937&inl=1) states that "Informatica" is a course that lasts for 3 years.

And in [this page](https://www.luxemburg.bo.it/pagine/informativa-g-suite) is written that the school offer a mail address for his students.

