### PR TITLE
Added domain @fci.suezuni.edu.eg Suez University

### DIFF
--- a/lib/domains/eg/edu/suezuni/fci.txt
+++ b/lib/domains/eg/edu/suezuni/fci.txt
@@ -1,0 +1,2 @@
+Suez University
+Suez University


### PR DESCRIPTION
- University name: Suez University
- City: Suez
- Country: Egypt
- Faculty: Computers and Information (Computer Science)
- Website: https://suezuni.edu.eg/index.php/en
-  Proof with a screenshot is attached.
![ver](https://user-images.githubusercontent.com/37039899/146913560-46395f2d-be48-4baf-be62-f72ea4ae0ad0.PNG)

