### PR TITLE
added Austrian Institute of Management (FH Burgenland)

### DIFF
--- a/lib/domains/at/ac/aim/stud.txt
+++ b/lib/domains/at/ac/aim/stud.txt
@@ -1,0 +1,1 @@
+Austrian Institute of Management - FH Burgenland


### PR DESCRIPTION
University website: https://aim.ac.at/en/
IT related course: https://aim.ac.at/programme/mba-it-management/
Proof of a link between FH Burgenland (AIM) and the domain "stud.aim.ac.at" (just search for the string "stud.aim.ac.at"): https://fh-burgenland.libanswers.com/faq/244284