### PR TITLE
fix: update institution name of g.educaand.es

### DIFF
--- a/lib/domains/es/educaand/g.txt
+++ b/lib/domains/es/educaand/g.txt
@@ -1,1 +1,1 @@
-IES Bajo Guadalquivir
+Andalusia

--- a/lib/domains/es/educaand/g.txt
+++ b/lib/domains/es/educaand/g.txt
@@ -1,1 +1,1 @@
-Andalusia
+Schools in Andalusia


### PR DESCRIPTION
The ``g.educaand.es`` domain is used across all Andalusia starting 2021/2022 with the intention of unifying the corporate email addresses across the whole autonomous region (""state"").

This is referenced in the official page of Junta de Andalucía: https://www.juntadeandalucia.es/educacion/eaprendizaje/gsuite/

Cite:
> (...) The Consejería de Educación y Deporte de la Junta de Andalucía, after an agreement, has created the domain g.educaand.es for the management of these accounts for the Andalusian public schools. (...)

<details>
<summary>Original (Spanish)</summary>
La Consejería de Educación y Deporte de la Junta de Andalucía, tras el convenio firmado , ha creado el dominio g.educaand.es para la gestión de estas cuentas para los centros educativos andaluces de titularidad pública.
</details>

TLDR; This domain refered to a specific school instead of the whole autonomous region.