### PR TITLE
Add Rochelle Zelle Jewish High School Domain

### DIFF
--- a/lib/domains/org/rzjhs.txt
+++ b/lib/domains/org/rzjhs.txt
@@ -1,0 +1,1 @@
+Rochelle Zelle Jewish High School


### PR DESCRIPTION
School Home Page: https://www.rzjhs.org
Address: 1095 Lake Cook Road, Deerfield, IL 60015 (Shown at bottom of home page.)
Page showing course: https://drive.google.com/file/d/15osEB73HazabsGeweEuiX0mbqCPONBNR/view (Page 9)