### PR TITLE
Add André Malraux Highschool (located in Bethune, France)

### DIFF
--- a/lib/domains/fr/malrauxbethune.txt
+++ b/lib/domains/fr/malrauxbethune.txt
@@ -1,0 +1,2 @@
+Lycée André Malraux Bethune
+André Malraux High school (Bethune)


### PR DESCRIPTION
Hi, here is the addition of André Malraux high-school located in Bethune. (: