### PR TITLE
Add Zst Sopot (Zespol Szkol Technicznych w Sopocie) from Poland

### DIFF
--- a/lib/domains/pl/edu/zst-sopot.txt
+++ b/lib/domains/pl/edu/zst-sopot.txt
@@ -1,0 +1,2 @@
+Zespół Szkół Technicznych w Sopocie
+ZSTSOPOT


### PR DESCRIPTION
**Please add Zespół Szkół Technicznych w Sopocie on Street Wejherowska 1 to school list**
*Official School Domain: http://zstsopot.pl*
*Students & Teacher domain* **zst-sopot.edu.pl**
![image](https://user-images.githubusercontent.com/49614906/149728563-e2f4e8ce-4bdf-463c-be99-8d3a571979fd.png)
![image](https://user-images.githubusercontent.com/49614906/149728612-39a85538-ceee-479c-91eb-aafb9ab45100.png)
