### PR TITLE
University add: UNAMA - Ser Educational Group

### DIFF
--- a/lib/domains/br/com/sempreunama.txt
+++ b/lib/domains/br/com/sempreunama.txt
@@ -1,0 +1,2 @@
+Universidade da Amazônia
+UNAMA - Ser Educational Group


### PR DESCRIPTION
Another domain owned by UNAMA
Universidade da Amazônia - UNAMA is a part from Ser Educational Group