### PR TITLE
Wah Yan College Hong Kong

### DIFF
--- a/lib/domains/hk/edu/wahyan.txt
+++ b/lib/domains/hk/edu/wahyan.txt
@@ -1,0 +1,1 @@
+Wah Yan College Hong Kong


### PR DESCRIPTION
Add Wah Yan College Hong Kong to JetBrains.