### PR TITLE
Add University of Rochester Email Domain

### DIFF
--- a/lib/domains/edu/rochester/u.txt
+++ b/lib/domains/edu/rochester/u.txt
@@ -1,0 +1,1 @@
+University of Rochester


### PR DESCRIPTION
Adds the University of Rochester email domain: u.rochester.edu (currently blocked)

Official site: [https://www.rochester.edu/](https://www.rochester.edu/)
CS degree program info: [https://www.cs.rochester.edu/undergraduate/degree-requirements.html](https://www.cs.rochester.edu/undergraduate/degree-requirements.html)
As for where you can find this is an official emailing domain, there's practically no information I can find on it, the closest I've found is ur.rochester.edu which as far as I know is no longer used. I signed up for github student, and have successfully enrolled using a u.rochester.edu email and cannot sign up for intellij products using my school email because its blocked (and it shouldn't be considering rochester.edu is already present in the domains).

