### PR TITLE
Add Aarhus Municipality Schools domain.

### DIFF
--- a/lib/domains/dk/aarhus/aarhus/aaks.txt
+++ b/lib/domains/dk/aarhus/aarhus/aaks.txt
@@ -1,0 +1,2 @@
+Aarhus Kommune Skoler
+Aarhus Municipality Schools


### PR DESCRIPTION
This email address applies to many schools in the Aarhus Municipality of Denmark.
https://docs.google.com/spreadsheets/d/1aTIMabB2ibMDaxDWNSeEMxBIJI8vJAUXBdvlmU7CKYA/edit#gid=0&range=D61 
This spreadsheet translated says
"@aaks.dk - shared domain for schools in Aarhus"