### PR TITLE
Add Aarhus Municipality Schools with the correct domain this time.

### DIFF
--- a/lib/domains/dk/aaks.txt
+++ b/lib/domains/dk/aaks.txt
@@ -1,0 +1,2 @@
+Aarhus Kommune Skoler
+Aarhus Municipality Schools

--- a/lib/domains/dk/aarhus/aarhus/aaks.txt
+++ b/lib/domains/dk/aarhus/aarhus/aaks.txt
@@ -1,0 +1,2 @@
+Aarhus Kommune Skoler
+Aarhus Municipality Schools

--- a/lib/domains/dk/aarhus/aarhus/aaks.txt
+++ b/lib/domains/dk/aarhus/aarhus/aaks.txt
@@ -1,2 +1,0 @@
-Aarhus Kommune Skoler
-Aarhus Municipality Schools


### PR DESCRIPTION
This should be the right domain, @aaks.dk. 

A whois lookup results in:
`Domain:               aaks.dk
DNS:                  aaks.dk
Registered:           1998-05-13
Expires:              2022-06-30
Registrar:            Eurodns S.A
Registration period:  1 year
VID:                  no
DNSSEC:               Signed delegation
Status:               Active

Registrant
Handle:               ***N/A***
Name:                 Aarhus Kommune
Attention:            Thomas Pedersen
Address:              Rådhuspladsen 2
Postalcode:           8000
City:                 Aarhus C
Country:              DK
`

Which says the domain is owned by Aarhus. 