### PR TITLE
Add Evangel Christian Seminary & College

### DIFF
--- a/lib/domains/org/ecscollege.txt
+++ b/lib/domains/org/ecscollege.txt
@@ -1,0 +1,2 @@
+ecscollege.org
+Evangel Christian Seminary & College


### PR DESCRIPTION
You can find our information and domain name in the list of schools on the official website of the National Commission on Higher Education of Liberia:http://www.nche.gov.lr/content/institutions