### PR TITLE
Add Marista Arquidiocesano

### DIFF
--- a/lib/domains/br/com/alunosmaristas.txt
+++ b/lib/domains/br/com/alunosmaristas.txt
@@ -1,0 +1,1 @@
+Colégio Marista Arquidiocesano


### PR DESCRIPTION
Add the domain for Marista Arquidiocesano school. School website: https://arquidiocesano.colegiosmaristas.com.br/