### PR TITLE
Add @sabel.education

### DIFF
--- a/lib/domains/education/sabel.txt
+++ b/lib/domains/education/sabel.txt
@@ -1,0 +1,1 @@
+GBS Schulen München


### PR DESCRIPTION
Sabel Schulen (https://sabel.com/) is a group of private schools in Germany. Students of both Sabel Schulen and GBS Schulen (which belongs to Sabel and offers vocational trainings related to IT; read more here: https://gbsschulen.de/berufsfachschule/) get a @sabel.education email-address which they can use for the time of their training.