### PR TITLE
Add Evangel Christian Seminary & College

### DIFF
--- a/lib/domains/org/ecscollege.txt
+++ b/lib/domains/org/ecscollege.txt
@@ -1,0 +1,2 @@
+ecscollege.org
+Evangel Christian Seminary & College


### PR DESCRIPTION
the school official website URL: https://www.ecscollege.org/
the school street address, including city and country: Soul Clinic First Turning Point, Paynesville 2228, Liberia
an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course: https://www.ecscollege.org/?page_id=26
a proof, which shows that the school recognizes the domain you are submitting as an official email domain for the students.: You can see our domain name in the official website of the National Commission on Higher Education of Libya(http://www.nche.gov.lr/content/institutions), about you said before to open is spam content, because the National Commission on Higher Education website may be disturbed by advertising, please refresh to enter a few more times on it! Thanks a lot
![20220126133809](https://user-images.githubusercontent.com/98089507/151109833-67890fbc-273b-4070-b529-0799e10fe802.png)
!