### PR TITLE
Rename Adams State College to Adams State University

### DIFF
--- a/lib/domains/edu/adams.txt
+++ b/lib/domains/edu/adams.txt
@@ -1,1 +1,1 @@
-Adams State College
+Adams State University


### PR DESCRIPTION
In 2012, Adams State College was renamed to Adams State University.  This commit reflects the name change

Sources: https://blogs.adams.edu/thepawprint/adams-state-takes-steps-to-change-name-to-university/, https://web.archive.org/web/20170104234838/http://www.adams.edu/news/may1214.php