### PR TITLE
Add Jianghan University

### DIFF
--- a/lib/domains/cn/edu/jhun.txt
+++ b/lib/domains/cn/edu/jhun.txt
@@ -1,0 +1,2 @@
+Jianghan University
+https://eng.jhun.edu.cn


### PR DESCRIPTION
https://eng.jhun.edu.cn/
https://www.jhun.edu.cn/ 
please visit the offical website. 
the edu.cn website normaly can not verfity by whois.
You can confirm the information through 
https://en.wikipedia.org/wiki/Jianghan_University
https://www.timeshighereducation.com/world-university-rankings/jianghan-university