### PR TITLE
Add Fumec University in 'br/' directory out of 'edu/'

### DIFF
--- a/lib/domains/br/fumec.txt
+++ b/lib/domains/br/fumec.txt
@@ -1,0 +1,2 @@
+Universidade FUMEC
+FUMEC University


### PR DESCRIPTION
Fumec University already exists, it is only in edu/ directory. The email of the students finishes with @fumec.br and not @fumec.edu.br probably this one is destined for professors.
Official Site: [http://www.fumec.br](http://www.fumec.br)
