### PR TITLE
add miit.edu.mm

### DIFF
--- a/lib/domains/mm/edu/miit.txt
+++ b/lib/domains/mm/edu/miit.txt
@@ -1,0 +1,2 @@
+မြန်မာသတင်းအချက်အလက်နည်းပညာတက္ကသိုလ်
+Myanmar Institute of Information Technology


### PR DESCRIPTION
Domain - miit.edu.mm
School Name(EN) - Myanmar Institute of Information Technology
School Name(MM) - မြန်မာသတင်းအချက်အလက်နည်းပညာတက္ကသိုလ်
