### PR TITLE
Adding afpa.fr

### DIFF
--- a/lib/domains/fr/afpa.txt
+++ b/lib/domains/fr/afpa.txt
@@ -1,0 +1,1 @@
+Agence nationale pour la Formation Professionnelle des Adultes


### PR DESCRIPTION
AFPA is a public professional reconversion university for adult.

University official website URL : https://www.afpa.fr/

URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university : https://www.afpa.fr/formation-qualifiante/concepteur-developpeur-informatique