### PR TITLE
add high school: EUCSJ HTX Køge

### DIFF
--- a/lib/domains/dk/eucsj/unv.txt
+++ b/lib/domains/dk/eucsj/unv.txt
@@ -1,0 +1,1 @@
+EUC SJÆLLAND


### PR DESCRIPTION
School URL: https://www.eucsj.dk/htx/htx-koege.aspx