### PR TITLE
@collegiumwitelona

### DIFF
--- a/lib/domains/pl/collegiumwitelona.txt
+++ b/lib/domains/pl/collegiumwitelona.txt
@@ -1,0 +1,2 @@
+Collegium Witelona Uczelnia Państwowa
+Witelon Collegium State University

--- a/lib/domains/pl/collegiumwitelona/studenci.txt
+++ b/lib/domains/pl/collegiumwitelona/studenci.txt
@@ -1,0 +1,2 @@
+Collegium Witelona Uczelnia Państwowa
+Witelon Collegium State University


### PR DESCRIPTION
As The Witelon State University of Applied Sciences in Legnica legally changed its name to Collegium Witelona Uczelnia Państwowa (:gb: Witelon Collegium State University, @collegiumwitelona), I'm requesting for adding new email domains to your list.

The new address: https://collegiumwitelona.pl/
Page about CS studies: http://www.wzi.pwsz.legnica.edu.pl/artykul-166-ki
Contact page with the domain in question included: http://www.pwsz.legnica.edu.pl/strona-684-teleadresowe-1

Domain `@collegiumwitelona.pl` is for teachers and `@studenci.collegiumwitelona.pl` for students.