### PR TITLE
Add zs1 Bochnia (Zespol Szkol Nr 1 im. Stanislawa Staszica w Bochni) from Poland

### DIFF
--- a/lib/domains/pl/bochnia/zs1.txt
+++ b/lib/domains/pl/bochnia/zs1.txt
@@ -1,0 +1,1 @@
+Zespół Szkół Nr 1  im. Stanisława Staszica w Bochni


### PR DESCRIPTION
Please add Zespół Szkół Nr 1 im. Stanisława Staszica w Bochni to school list
School Official Website: https://zs1.bochnia.pl
School Location: City: Bochnia, Street: Windakiewicza 23, Country: Poland
School offers long-term course (5 years): https://zs1.bochnia.pl/rekrutacja/oferta-dydaktyczna

Major courses offered at the school associated with computer science are:

- technik informatyk(IT technician)

- technik programista(programmer technician).

Students & Teacher email domain: zs1.bochnia.pl