### PR TITLE
Added studenti.gobettivolta.edu.it domain

### DIFF
--- a/lib/domains/it/edu/gobettivolta/studenti.txt
+++ b/lib/domains/it/edu/gobettivolta/studenti.txt
@@ -1,0 +1,1 @@
+I.S.I.S P.Gobetti-A.Volta


### PR DESCRIPTION
Added studenti.gobettivolta.edu.it.
Previously this school used .gov.it, but the address is now .edu.it.

School website: [www.gobettivolta.edu.it](http://www.gobettivolta.edu.it)