### PR TITLE
Add student subdomain for JCU

### DIFF
--- a/lib/domains/au/edu/jcu/my.txt
+++ b/lib/domains/au/edu/jcu/my.txt
@@ -1,0 +1,2 @@
+James Cook University
+


### PR DESCRIPTION
https://www.jcu.edu.au/
(the university official website URL, if it is different from the domain you are submitting)

https://www.jcu.edu.au/courses/study/information-technology
(a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university)

https://www.jcu.edu.au/information-and-communications-technology/help-and-support/email-and-office-365/student-email-@-jcu
see "Firstname.Surname@my.jcu.edu.au"
(a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students)

Thank you.