### PR TITLE
added Indian Institute Of Technology–Delhi to universities

### DIFF
--- a/lib/domains/org/dmsiitd.txt
+++ b/lib/domains/org/dmsiitd.txt
@@ -1,0 +1,1 @@
+Indian Institute Of Technology–Delhi


### PR DESCRIPTION
Adding Indian Institute Of Technology–Delhi to the list of universities
https://home.iitd.ac.in/