### PR TITLE
Adding Gymnázium, České Budějovice, Jírovcova 8

### DIFF
--- a/lib/domains/cz/jirovcovka.txt
+++ b/lib/domains/cz/jirovcovka.txt
@@ -1,0 +1,1 @@
+Gymnázium, České Budějovice, Jirovcova 8

--- a/lib/domains/net/jirovcovka.txt
+++ b/lib/domains/net/jirovcovka.txt
@@ -1,0 +1,1 @@
+Gymnázium, České Budějovice, Jírovcova 8, Czech Republic


### PR DESCRIPTION
Two domains:
jirovcovka.net 
 and  e-mail alias domain
jirovcovka.cz
Google hosted cloud - Google Workspace for Education. 

Our websites: https://www.gymji.cz/ and https://www.jirovcovka.net (new pages)