### PR TITLE
Create cshs.txt for Cedars Sinai graduate programs

### DIFF
--- a/lib/domains/org/cshs.txt
+++ b/lib/domains/org/cshs.txt
@@ -1,0 +1,1 @@
+Cedars Sinai


### PR DESCRIPTION
Cedars Sinai Health System offers multiple graduate degrees and uses the .org email address. 