### PR TITLE
Added huntington school york

### DIFF
--- a/lib/domains/uk/org/huntington-ed.txt
+++ b/lib/domains/uk/org/huntington-ed.txt
@@ -1,0 +1,1 @@
+Huntington School


### PR DESCRIPTION
Official Website: [School](https://huntingtonschool.co.uk/)
Email domain they use: huntington-ed.org.uk
Course: [Computer Science](https://huntingtonschool.co.uk/sixth-form/subjects/computer-scicence/)

Them recognising it as a school email: [YT Tutorial with timestamp](https://youtu.be/4nZro7tih3s?t=16) found on the school site listed as "How to access Microsoft Teams" [Student Learning](https://huntingtonschool.co.uk/students/student-online-learning/
) I can't really find any other mention of it online, Sorry.