### PR TITLE
renamed school to BBZBL IT

### DIFF
--- a/lib/domains/ch/bbzbl-it.txt
+++ b/lib/domains/ch/bbzbl-it.txt
@@ -1,0 +1,1 @@
+BBZBL IT Pratteln

--- a/lib/domains/ch/gibmit.txt
+++ b/lib/domains/ch/gibmit.txt
@@ -1,1 +1,0 @@
-GIBM IT Pratteln


### PR DESCRIPTION
The school was merged with an other school and the new name is now BBZBL, see this PDF in German: https://www.bbzbl.ch/wp-content/uploads/2019/12/GIBML-Jahresbericht-2018-Muttenz-Layout_fertig.pdf

The Domain for the students of the IT part of the school is bbzbl-it.ch