### PR TITLE
Panstwowa Uczelnia Zawodowa im. Ignacego Moscickiego w Ciechanowie

### DIFF
--- a/lib/domains/pl/edu/puzim/puzim.txt
+++ b/lib/domains/pl/edu/puzim/puzim.txt
@@ -1,0 +1,2 @@
+Państwowa Uczelnia Zawodowa im. Ignacego Mościckiego w Ciechanowie
+Ignacy Mościcki’s University of Applied Sciences in Ciechanów

--- a/lib/domains/pl/edu/puzim/student.txt
+++ b/lib/domains/pl/edu/puzim/student.txt
@@ -1,1 +1,0 @@
-Państwowa Uczelnia Zawodowa im. Ignacego Mościckiego w Ciechanowie


### PR DESCRIPTION
Add upper-level domain: Panstwowa Uczelnia Zawodowa im. Ignacego Moscickiego w Ciechanowie