### PR TITLE
Add stu.hytc.edu.cn(Huaiyin Normal University)

### DIFF
--- a/lib/domains/cn/edu/hytc.txt
+++ b/lib/domains/cn/edu/hytc.txt
@@ -1,0 +1,2 @@
+Huaiyin Normal University
+淮阴师范学院


### PR DESCRIPTION
Institution/School Name:
Huaiyin Normal University, Jiangsu, China
Official site:https://www.hytc.edu.cn/
Wiki:https://zh.wikipedia.org/wiki/%E6%B7%AE%E9%98%B4%E5%B8%88%E8%8C%83%E5%AD%A6%E9%99%A2
Student email example:example@stu.hytc.edu.cn
The School of Computer Science and Technology of Huaiyin Normal University:https://cs.hytc.edu.cn/
I think these information can help your checking more easily.