### PR TITLE
Add stu.fynu.edu.cn(Fuyang Normal University)

### DIFF
--- a/lib/domains/cn/edu/fynu.txt
+++ b/lib/domains/cn/edu/fynu.txt
@@ -1,0 +1,2 @@
+Fuyang Normal University
+阜阳师范大学


### PR DESCRIPTION
Institution/School Name:
Fuyang Normal University, Anhui, China
Official site:http://www.fynu.edu.cn/
Wiki:https://en.wikipedia.org/wiki/Fuyang_Normal_University
Student email example:example@stu.fynu.edu.cn
School of Computer and Information Engineering:http://www.fynu.edu.cn/xxgc/jxgz/jxdg.htm
I think these information can help your checking more easily.