### PR TITLE
Add Beijing Wuzi University

### DIFF
--- a/lib/domains/cn/edu/bwu.txt
+++ b/lib/domains/cn/edu/bwu.txt
@@ -1,0 +1,2 @@
+Beijing Wuzi University
+北京物资学院


### PR DESCRIPTION
Institution/School Name:
Beijing Wuzi University, Beijing, China
Official site:https://www.bwu.edu.cn/index.htm
Wiki:https://en.wikipedia.org/wiki/Beijing_Wuzi_University
Student email example:example@bwu.edu.cn
Notice on opening campus mailbox for all undergraduate and graduate students(If students graduate, their email will be cancelled):https://nic.bwu.edu.cn/info/9365/58733.htm
IT related major:https://yjsb.bwu.edu.cn/info/1017/4665.htm
I think these information can help your checking more easily.