### PR TITLE
Add Martin-Andersen-Nexö-Gymnasium Dresden

### DIFF
--- a/lib/domains/de/lernsax/manos-dresden.txt
+++ b/lib/domains/de/lernsax/manos-dresden.txt
@@ -1,0 +1,1 @@
+Martin-Andersen-Nexö-Gymnasium Dresden


### PR DESCRIPTION
Website: https://manos-dresden.de
IT-Course: https://manos-dresden.de/faecher/fk-informatik
Lernsax is linked on the homepage and all e-mail addresses related to the school end in manos-dresden.lernsax.de.