### PR TITLE
Add school in TW-CLHS

### DIFF
--- a/lib/domains/tw/edu/tyc/clhs/gm.txt
+++ b/lib/domains/tw/edu/tyc/clhs/gm.txt
@@ -1,0 +1,2 @@
+國立中央大學附屬中壢高級中學
+The Affiliated Zhongli Senior High School of National Central University


### PR DESCRIPTION
Add the school in Taiwan of The Affiliated Zhongli Senior High School of National Central University.
Official site: https://www.clhs.tyc.edu.tw/
Wiki: https://zh.wikipedia.org/wiki/%E5%9C%8B%E7%AB%8B%E4%B8%AD%E5%A4%AE%E5%A4%A7%E5%AD%B8%E9%99%84%E5%B1%AC%E4%B8%AD%E5%A3%A2%E9%AB%98%E7%B4%9A%E4%B8%AD%E5%AD%B8