### PR TITLE
Adding goe.go.kr

### DIFF
--- a/lib/domains/kr/go/goe/ggm.txt
+++ b/lib/domains/kr/go/goe/ggm.txt
@@ -1,0 +1,3 @@
+경기도교육청
+Gyeonggi Province Office of Education
+.group


### PR DESCRIPTION
https://goe.go.kr/ (Gyeonggi Province Office of Education)
