### PR TITLE
Added Jerusalem District educational domain - Gmail based.

### DIFF
--- a/lib/domains/il/org/jerschools.txt
+++ b/lib/domains/il/org/jerschools.txt
@@ -1,0 +1,3 @@
+משרד החינוך הישראלי - מחוז ירושלים
+Israeli Ministry of Education - Jerusalem District  
+.group


### PR DESCRIPTION
Hi, you recently merged a request I made, in which I added the Israeli Jerusalem District's educational domain which was created from the collaboration of our educational system and Microsoft 365. Now I would like to add a parallel domain that was created with a similar collaboration but with Google.
Here I will add the explanation from the last request with the relevant links:

Students who learn in the Israeli Jerusalem District get this domain from our educational system, and have it until they finish high school. I learn Computer science and Software engineering in high school.

Links:
This link is to the website of our educational system and is about its collaboration with Google, which among other things brought to the creation of the domain I request to add:
https://pop.education.gov.il/sherutey-tiksuv-bachinuch/anan-hinuch-google/

This website holds all the links to the educational environments of all the different districts that have their special domain, including the one I am talking about (jerschools.org.il - "jers" stands for Jerusalem).
https://sites.google.com/view/homel/%D7%93%D7%A3-%D7%94%D7%91%D7%99%D7%AA

Both of them are in Hebrew but can be easily translated with a right-click and a choice of the "Translate to" option (if you hopefully have the Google Translate extension)

Thanks in advance!