### PR TITLE
Add hillsideschool.txt

### DIFF
--- a/lib/domains/net/hillsideschool.txt
+++ b/lib/domains/net/hillsideschool.txt
@@ -1,0 +1,1 @@
+Hillside School


### PR DESCRIPTION
University official website: https://hillsideschool.net
URL of a page where a long-term (>1 year) IT related course is offered: https://www.hillsideschool.net/academics/innovation-center-at-hillside
URL of a page showing that the university recognizes the domain as an official email domain for the enrolled students: https://www.hillsideschool.net/about/directory. You can see the email addresses that correlate to the faculty. 