### PR TITLE
Add Domains

### DIFF
--- a/lib/domains/it/peano.txt
+++ b/lib/domains/it/peano.txt
@@ -1,0 +1,1 @@
+IIS Peano


### PR DESCRIPTION
Official school website: https://www.iispeano.edu.it, it can also be reached using https://www.peano.it
