### PR TITLE
Add Altes Gymnasium Oldenburg

### DIFF
--- a/lib/domains/eu/altesgymnasium.txt
+++ b/lib/domains/eu/altesgymnasium.txt
@@ -1,0 +1,1 @@
+Altes Gymnasium Oldenburg


### PR DESCRIPTION
- official website URL: https://altesgymnasium.de/
- adress: Theaterwall 11, 26122 Oldenburg, Germany
- proof of computer science courses: https://altesgymnasium.de/elementor-informatik/ (page for "Informatik" (Computer Science) as a subject at the school) - If you click on the "Wochenstunden" (weekly hours) button under "Sekundarstufe II" (upper secondary), you will see that there are hours for "Kurs auf erhöhtem Niveau" (advanced course). So it follows the German school system, in upper secondary (higher education) you always take advanced courses for two years.
- proof of the correctness of the email domain: https://altesgymnasium.de/wp-content/uploads/2020/03/IServ-_Einverst%C3%A4ndnis.pdf - This is a consent form for the use of "IServ", the communication platform used by the school. At point 6 the scheme of the corresponding email domain is shown: "vorname.nachname@altesgymnasium.eu" (forename.surname@altesgymnasium.eu)

I hope this is sufficient.