### PR TITLE
Add Faculdade Ideal Wyden

### DIFF
--- a/lib/domains/br/edu/faculdadeideal/alunos.txt
+++ b/lib/domains/br/edu/faculdadeideal/alunos.txt
@@ -1,0 +1,2 @@
+Faculdade Ideal Wyden
+Faci Wyden


### PR DESCRIPTION
- Official site URL: https://www.wyden.com.br/faci
- Address: Tv. Tupinambás, 461, Belém, Brazil
- Proof of long-term (>1 year) course: On the official site (https://www.wyden.com.br/faci), go to the section "Pesquisar Cursos" (Search Courses) and select "Pará" in the first box, "Faci" in the second box, then finally the courses list will load in the third box where you can see "Ciência da Computação" (Computer Science) among the first results. Also, there's another website with the courses list and you can go directly to Computer Science with this URL: https://inscricoes.facieducacional.com.br/curso/ciencias-da-computacao
- Proof of email domain: On this URL (https://blog.wyden.com.br/noticias/central-de-contatos-faci/) you can find a list of teacher's institucional emails with the domain. On the official site (https://www.wyden.com.br/faci), go to the top bar menu and select "Blog Universitário" to access this second blog/website.