### PR TITLE
Added the email domain of 'Evangelische Hochschule Nürnberg'.

### DIFF
--- a/lib/domains/de/evhn/stud.txt
+++ b/lib/domains/de/evhn/stud.txt
@@ -1,0 +1,2 @@
+Evangelische Hochschule Nürnberg
+Lutheran University of Applied Sciences


### PR DESCRIPTION
1. The official university website is https://www.evhn.de
2. The course "Quantitative Methoden der Wirtschaftswissenschaften"/"Quantitative Methods of Economics" is related to IT. The course covers the area of statistics. More details about the course can be found in this PDF file https://www.evhn.de/sites/default/files/media/downloads/modulhandbuch_m.ww_ab_sose_2022.pdf
3. The email domain for students is specified here https://www.evhn.de/studierende/service-fuer-studierende/it-referat/e-mail-fuer-studierende.