### PR TITLE
Add Escuela es[tech]

### DIFF
--- a/lib/domains/es/escuelaestech.txt
+++ b/lib/domains/es/escuelaestech.txt
@@ -1,0 +1,1 @@
+Escuela es[tech]


### PR DESCRIPTION
Adds Escuela es[tech] -- https://escuelaestech.es

> A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university

https://escuelaestech.es/tecnico-superior-en-desarrollo-de-aplicaciones-multiplataforma-presencial/