### PR TITLE
Add Global Institute of Software Technology

### DIFF
--- a/lib/domains/cn/edu/gist.txt
+++ b/lib/domains/cn/edu/gist.txt
@@ -1,0 +1,2 @@
+Global Institute of Software Technology
+苏州高博软件技术职业学院


### PR DESCRIPTION
The Global Institute of Software Technology (苏州高博软件技术职业学院, [official website](http://www.gist.edu.cn/)) is a full-time general institution of higher learning organized by Wuzhong Group and Gaobo Education Management (Suzhou) Co., Ltd. and approved by the Jiangsu Provincial People’s Government and filed by the Ministry of Education. It was founded in March 2007. There are [School of Information and Software](http://sis.gist.edu.cn/), School of Mechanical and Electrical Engineering, etc. There are currently nearly 6,000 students.