### PR TITLE
Add ncwu.edu.cn

### DIFF
--- a/lib/domains/cn/edu/ncwu.txt
+++ b/lib/domains/cn/edu/ncwu.txt
@@ -1,0 +1,2 @@
+North China University of Water Resources and Electric Power
+华北水利水电大学


### PR DESCRIPTION
domain contains ncwu.edu.cn and stu.ncwu.edu.cn.
I don't know why the domain ncwu.edu.cn is removed from the trusted domains list.
I'm sure, non-students can't register an address.
Please help me add to the list of trusted domains, thanks.
Otherwise, please provide some evidence that non-students can register for a ncwu.edu.au address.

Institution/School Name: North China University of Water Resources and Electric Power, Henan, China
Official site: https://www.ncwu.edu.cn/
Wiki: https://zh.wikipedia.org/wiki/%E5%8D%8E%E5%8C%97%E6%B0%B4%E5%88%A9%E6%B0%B4%E7%94%B5%E5%A4%A7%E5%AD%A6
Student email example: cexample@stu.ncwu.edu.cn
Email system picture: https://oss.rainsheep.cn/blog/20220320151340-1647760424-347.png
Email system url: http://webmail.stu.ncwu.edu.cn
School of Computer and Information Engineering: https://www2.ncwu.edu.cn/xingong/
I think these information can help your checking more easily.