### PR TITLE
Add github-action to build and release swot.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Compile and run Kotlin
+        run: |
+          kotlinc src/swot -include-runtime -d swot.jar
+          java -jar swot.jar
+
+      - name: Move the 'latest' tag to the head commit
+        run: |
+          git tag latest
+          git push origin latest -f
+
+      - name: Release swot.txt
+        uses: softprops/action-gh-release@v1
+        with:
+          files: out/artifacts/swot.txt
+          tag_name: latest
+          body: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Hi, thanks to this repo, it saved my time collecting educational emails.

It's a lightweight and convenient library for developers, but I found it non-user-friendly to read or get the list of educational emails.

In this PR, I create a Github Action to build and run `src/swot/Compiler.kt` for each commit, and then release the output `out/artifacts/swot.txt` on Github Release.

Base on it, the user can conveniently download (or write code to download) the `swot.txt` file from the page of Github Release. (an example is the [following](https://github.com/zhangt2333/swot/releases))

Note that I name the release `latest` (The new one will overwrite the old one), because I have observed that your repo has a lot of commits and it's not a good idea to create releases for every commit (unless the old release will be deleted).


You can give me any feedback.