### PR TITLE
add: University of Art and Design in Ha Noi, Viet Nam

### DIFF
--- a/lib/domains/vn/edu/uad/sv.txt
+++ b/lib/domains/vn/edu/uad/sv.txt
@@ -1,0 +1,2 @@
+Đại học Mỹ Thuật Công Nghiệp Hà Nội
+University of Industrial Fine Art


### PR DESCRIPTION
## What
Add `University of Art and Design`'s domain. Which is an University of Art and Design with many mixed program in Hanoi, Vietnam.

## Main domain
http://uad.edu.vn