### PR TITLE
Add Bryncelynnog Comprehensive School

### DIFF
--- a/lib/domains/uk/org/bryncelynnog.txt
+++ b/lib/domains/uk/org/bryncelynnog.txt
@@ -1,0 +1,1 @@
+Bryncelynnog Comprehensive School


### PR DESCRIPTION
Please Add
https://bryncelynnog.org.uk/
Bryn Celynnog Comprehensive School
Bryn Celynnog Bungalow, Penycoedcae Rd, Beddau, Pontypridd CF38 2AE
United Kingdom