### PR TITLE
Added Ranelagh School under ranelagh.bonitas.org

### DIFF
--- a/lib/domains/uk/org/bonitas/ranelagh.txt
+++ b/lib/domains/uk/org/bonitas/ranelagh.txt
@@ -1,0 +1,1 @@
+Ranelagh School


### PR DESCRIPTION
School website: https://ranelagh.bonitas.org.uk/
Courses: https://ranelagh.bonitas.org.uk/exam-boards/ - Computer Science offered at both GCSE and A Level - both 2 years.
Image showing that domain is accepted for emails: 
![image](https://user-images.githubusercontent.com/98121138/161392718-884de580-09a7-4682-a365-65a4a9be11a0.png)
(site here: https://ranelagh.bonitas.org.uk/guidance/)