### PR TITLE
adding student email domain for Center for Arts and Technology college

### DIFF
--- a/lib/domains/sh/school.txt
+++ b/lib/domains/sh/school.txt
@@ -1,1 +1,1 @@
-Center for Arts and Technology
+Centre for Arts and Technology

--- a/lib/domains/sh/school.txt
+++ b/lib/domains/sh/school.txt
@@ -1,0 +1,1 @@
+Center for Arts and Technology


### PR DESCRIPTION
Our school.sh domain email is the official student email for the Center for Arts and Technology college. Our staff domain email (which corresponds to our official marketing website) is digitalartschool.com. You can reach me personally at kcarisse@digitalartschool.com. We would like to get the school.sh domain email usable so that our students can also benefit from increased access to the JetBrains code editor suite.

Here is an example of one IT related course spanning a length of 1.5 years https://digitalartschool.com/programs/network-security

Here is an example of students with the school.sh domain email within our teams environment:
![image](https://user-images.githubusercontent.com/17826852/161903277-352afd79-7e42-468f-85be-ccb61da7a253.png)

