### PR TITLE
Add Technical High School of Lodz and ZSP nr 5 Lodz

### DIFF
--- a/lib/domains/pl/edu/elodz/zsp5.txt
+++ b/lib/domains/pl/edu/elodz/zsp5.txt
@@ -1,0 +1,1 @@
+Zespół Szkół Ponadpodstawowych Nr 5 im. Króla Bolesława Chrobrego

--- a/lib/domains/pl/lodz/p/liceum.txt
+++ b/lib/domains/pl/lodz/p/liceum.txt
@@ -1,0 +1,1 @@
+Technical High School of Lodz


### PR DESCRIPTION
Official websites:
https://zsp5lodz.pl/
https://liceum.p.lodz.pl/