### PR TITLE
Add Rosa-Luxemburg-Gymnasium (rlg.berlin)

### DIFF
--- a/lib/domains/berlin/rlg.txt
+++ b/lib/domains/berlin/rlg.txt
@@ -1,0 +1,1 @@
+Rosa-Luxemburg-Gymnasium


### PR DESCRIPTION
Rosa-Luxemburg-Gymnasium is a German gymnasium/academy/high school. The school's home page is https://www.rlo-berlin.de/cms3/, however, emails have the domain rlg.berlin.