### PR TITLE
Add IEP Group

### DIFF
--- a/lib/domains/es/iepgroup.txt
+++ b/lib/domains/es/iepgroup.txt
@@ -1,0 +1,1 @@
+IEP Group


### PR DESCRIPTION
For more information regarding it, see https://iepgroup.es.

Note it is not a single school, but a group of them.