### PR TITLE
Create ctide.txt

### DIFF
--- a/lib/domains/net/ctide.txt
+++ b/lib/domains/net/ctide.txt
@@ -1,0 +1,1 @@
+Pottsville Area High School


### PR DESCRIPTION
The school uses https://www.pottsville.k12.pa.us as it's primary domain, however student emails are under @ctide.net
Official pdf detailing this: https://www.pottsville.k12.pa.us/cms/lib/PA01916599/Centricity/Domain/170/PASD%20Google%20Apps%20Form%20Final.pdf
Page 2, Section III outlines @ctide.net are official student emails