### PR TITLE
Add Osnovna šola Trbovlje, Slovenia

### DIFF
--- a/lib/domains/si/ostrbovlje.txt
+++ b/lib/domains/si/ostrbovlje.txt
@@ -1,0 +1,1 @@
+Osnovna šola Trbovlje


### PR DESCRIPTION
This is a request to add the primary school (up to 15 years) from Trbovlje to the list.

About the school:
* https://ostrbovlje.si/index.php/o-soli/osnovni-podatki

Here's the official list of all primary schools from Slovenia, including their contacts:
* https://paka3.mss.edus.si/registriweb/Seznam1.aspx?Seznam=2010
* https://paka3.mss.edus.si/registriweb/ZavodPodatki.aspx?ZavodID=1216

The emails under this domain are granted to both teachers (https://ostrbovlje.si/index.php/o-soli/zaposleni) and students.

The school is organizing both advanced (optional) courses in programming and robotics for any interested students in the afternoons, as well as more basic topics from informatics during the regular schedule in the mornings.