### PR TITLE
Arden University

### DIFF
--- a/lib/domains/uk/ac/ardenuniversity.txt
+++ b/lib/domains/uk/ac/ardenuniversity.txt
@@ -1,0 +1,1 @@
+Arden University


### PR DESCRIPTION
The university official website URL:
https://arden.ac.uk

A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: 
https://arden.ac.uk/our-courses/undergraduate/computing-degrees/bsc-hons-computing?source=google&medium=cpc&campaign=arden-de-brand-worldwide-search

Screenshot proof that students use ardenuniversity.ac.uk domain for email access:
https://drive.google.com/file/d/16fXGiqF0cDRlj9ez03WII0BTLjp-JZOt/view?usp=sharing