### PR TITLE
Add ISTP domain

### DIFF
--- a/lib/domains/com/eleve-istp.txt
+++ b/lib/domains/com/eleve-istp.txt
@@ -1,0 +1,1 @@
+Institut Supérieur des Techniques de la Performance


### PR DESCRIPTION
1. Website URL : https://www.istp.fr/

3. IT related course (3 years) : https://www.istp.fr/etudiants/formations-dingenieur-en-apprentissage/formations/ingenieur-en-systemes-electroniques-embarques-isee/
Can be translated in english as a **Master’s Engineering Degree in Electrical Embedded Systems**

4. The whois data shows that the "eleve-istp.com" domain is owned by ISTP (field "Organization")
URL: https://www.whois.com/whois/eleve-istp.com