### PR TITLE
Create truro-penwith

### DIFF
--- a/lib/domains/uk/ac/truro-penwith
+++ b/lib/domains/uk/ac/truro-penwith
@@ -1,0 +1,1 @@
+Truro & Penwith College

--- a/lib/domains/uk/ac/truro-penwith
+++ b/lib/domains/uk/ac/truro-penwith
@@ -1,1 +1,0 @@
-Truro & Penwith College

--- a/lib/domains/uk/ac/truro-penwith.txt
+++ b/lib/domains/uk/ac/truro-penwith.txt
@@ -1,0 +1,1 @@
+Truro & Penwith College


### PR DESCRIPTION
Main site URL:
https://www.truro-penwith.ac.uk

Remote page where it is acknowledged that student logins use "@truro-penwith.ac.uk":
https://remote.truro-penwith.ac.uk
![image](https://user-images.githubusercontent.com/66559391/163840235-d7ff1c01-8465-4020-8572-96fe1122255c.png)


Computing related courses:
https://digital.ucas.com/coursedisplay/results/courses?destination=Undergraduate&distanceFromPostcode=&studyYear=2022&sort=MostRelevant&providers=Truro%20and%20Penwith%20College&pageNumber=1&searchTerm=Truro%20and%20Penwith%20College%20Comput