### PR TITLE
add Maasai Mara University

### DIFF
--- a/lib/domains/ke/ac/mmarau.txt
+++ b/lib/domains/ke/ac/mmarau.txt
@@ -1,0 +1,1 @@
+Maasai Mara University

--- a/lib/domains/ke/ac/mmarau/student.txt
+++ b/lib/domains/ke/ac/mmarau/student.txt
@@ -1,0 +1,1 @@
+Maasai Mara University

--- a/lib/domains/ke/ac/mmarau/student.txt
+++ b/lib/domains/ke/ac/mmarau/student.txt
@@ -1,1 +1,0 @@
-Maasai Mara University


### PR DESCRIPTION
- the school official website : https://mmarau.ac.ke
- the school address: Narok County, Nairobi, Kenya
- IT-related long-term course: https://www.mmarau.ac.ke/bachelor-of-science-in-information-science/
- our school emails end with mmarau.ac.ke, and students are assigned emails @student.mmarau.ac.ke

 