### PR TITLE
Added the domain for Lincoln student email

### DIFF
--- a/lib/domains/nz/ac/lincolnuni.txt
+++ b/lib/domains/nz/ac/lincolnuni.txt
@@ -1,0 +1,1 @@
+Lincoln University


### PR DESCRIPTION
The university official website URL: https://www.lincoln.ac.nz/

A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www.lincoln.ac.nz/study/study-programmes/programme-search/master-of-applied-computing/

A URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://www.ithelp.lincoln.ac.nz/how-to-guides/download-office365/ You can find _your lincolnuni.ac.nz email_ on the page regarding student email and MS Office package.