### PR TITLE
add Académie Militaire de Saint-Cyr Coëtquidan

### DIFF
--- a/lib/domains/fr/gouv/defense/terre-net/st-cyr.txt
+++ b/lib/domains/fr/gouv/defense/terre-net/st-cyr.txt
@@ -1,0 +1,1 @@
+Académie Militaire de Saint-Cyr Coëtquidan


### PR DESCRIPTION
The academy website is: https://www.st-cyr.terre.defense.gouv.fr/
The two concerned curriculums are described at https://www.st-cyr.terre.defense.gouv.fr/index.php/L-Academie/L-Ecole-militaire-Interarmes and https://www.st-cyr.terre.defense.gouv.fr/index.php/L-Academie/L-Ecole-Speciale-Militaire-de-Saint-Cyr (French  only, sorry).