### PR TITLE
Adding in edinburghcollege.ac.uk

### DIFF
--- a/lib/domains/uk/ac/edinburghcollege.txt
+++ b/lib/domains/uk/ac/edinburghcollege.txt
@@ -1,0 +1,2 @@
+Edinburgh College
+Edinburgh College


### PR DESCRIPTION
Adding Edinburgh College domain for computer science students and teachers - https://edinburghcollege.ac.uk