### PR TITLE
Added IDOL University

### DIFF
--- a/lib/domains/com/mumuniversity.txt
+++ b/lib/domains/com/mumuniversity.txt
@@ -1,0 +1,2 @@
+Institute of Distance and Open Learning, University of Mumbai
+Institute of Distance and Open Learning, University of Mumbai


### PR DESCRIPTION
Added IDOL - Institute of Distance and Open Learning, University of Mumbai
Sites:
[https://idoloa.digitaluniversity.ac/](https://idoloa.digitaluniversity.ac/)
[https://old.mu.ac.in/distance-open-learning/](https://old.mu.ac.in/distance-open-learning/)
[https://mu.ac.in/distance-open-learning](https://mu.ac.in/distance-open-learning)