### PR TITLE
add the tifr.res.in domain

### DIFF
--- a/lib/domains/in/res/tifr.txt
+++ b/lib/domains/in/res/tifr.txt
@@ -1,0 +1,1 @@
+Tata Institute of Fundamental Research


### PR DESCRIPTION
Official website: www.tifr.res.in
Official name: Tata Institute of Fundamental Research
Website of the Computer Science department at the institute: https://www.tcs.tifr.res.in/
