### PR TITLE
adding Misr higher institute of commerce and computers in Mansoura (MET Academy) domain

### DIFF
--- a/lib/domains/eg/edu/metmans.txt
+++ b/lib/domains/eg/edu/metmans.txt
@@ -1,0 +1,3 @@
+Misr higher institute of commerce and computers in Mansoura
+معهد مصر العالى للتجارة والحاسبات بالمنصورة
+MET Academey


### PR DESCRIPTION
official website
https://metmans.edu.eg/
official email
 info@metmans.edu.eg