### PR TITLE
Add Theresien-Gymnasium München

### DIFF
--- a/lib/domains/de/musin/muenchen/thg.txt
+++ b/lib/domains/de/musin/muenchen/thg.txt
@@ -1,0 +1,1 @@
+Theresien-Gymnasium München


### PR DESCRIPTION
See https://thg.musin.de,
other schools from Munich of the same type (called "Gymnasium" in Bavaria/Germany) are already present in this repository, for example

- https://github.com/JetBrains/swot/blob/master/lib/domains/de/musin/muenchen/gmm.txt
- https://github.com/JetBrains/swot/blob/master/lib/domains/de/musin/muenchen/lpg.txt
- ...
