### PR TITLE
Add Engelbert-von-Berg-Gymnasium additional domain

### DIFF
--- a/lib/domains/email/evb.txt
+++ b/lib/domains/email/evb.txt
@@ -1,0 +1,3 @@
+Städtisches Engelbert-von-Berg-Gymnasium
+Engelbert-von-Berg-Gymnasium
+EvB-Gymnasium


### PR DESCRIPTION
We would like to add a new additional domain _evb.email_ which is used by the students of our school.
See this pull request for my initial request to add the domain _evb-gymnasium.de_: [Add Engelbert-von-Berg-Gymnasium #14119](https://github.com/JetBrains/swot/pull/14119#issue-1227114561).

**Website of school:** 
https://evb-gymnasium.de/