### PR TITLE
Create u-paris.txt

### DIFF
--- a/lib/domains/fr/u-paris.txt
+++ b/lib/domains/fr/u-paris.txt
@@ -1,0 +1,1 @@
+Université Paris Cité


### PR DESCRIPTION
[Université Paris Cité](https://u-paris.fr) uses `u-paris.fr` as the domain name for staff email.