### PR TITLE
Adding Wellcome Sanger Insitute

### DIFF
--- a/lib/domains/uk/ac/sanger.txt
+++ b/lib/domains/uk/ac/sanger.txt
@@ -1,0 +1,1 @@
+Wellcome Sanger Institute


### PR DESCRIPTION
Wellcome Sanger Insitute is a research institute located in Cambridge, UK - world-leading in the use of large-scale genomic data to advance biology. The institute runs a PhD and Masters programmes (together with the University of Cambridge) and offers other training opportunities in computational biology and IT areas (apprenticeships, internships): https://www.sanger.ac.uk/about/study/