### PR TITLE
Adds Dekalb County School District

### DIFF
--- a/lib/domains/org/dekalbschoolsga.txt
+++ b/lib/domains/org/dekalbschoolsga.txt
@@ -1,0 +1,1 @@
+Dekalb County School District


### PR DESCRIPTION
Dekalb County Schools, K-12, in metro Atlanta, GA, US. - https://dekalbschoolsga.org

* In the [curriculum](https://www.dekalbschoolsga.org/curriculum/high-school/) under "Information Technology" there are Computer Science and Programming sections that describe the courses that could utilize JetBrains products.
* When showing [how students can email their teachers](https://www.dekalbschoolsga.org/wp-content/uploads/2020/08/Students-Sending-an-Email-through-O365.pdf), it shows this dekalbschoolsga.org domain is used for email communications (see page 2).