### PR TITLE
Add IMT Nord Europe to supported domains

### DIFF
--- a/lib/domains/fr/imt-nord-europe.txt
+++ b/lib/domains/fr/imt-nord-europe.txt
@@ -1,0 +1,2 @@
+IMT Nord Europe
+Institut Mines-Télécom Nord Europe


### PR DESCRIPTION
Hi JetBrains team!

Could you please add the IMT Nord Europe French high school to the educational institutions list?
Here are the useful information to help you validate this request:
* Domain being added: *imt-nord-europe.fr*
* Official website: https://imt-nord-europe.fr/en/
* URL to the IT-related courses offered:
  * General engineering: https://imt-nord-europe.fr/en/trainings-directory/general-engineering/
  * Telecom and IT Engineer: https://imt-nord-europe.fr/en/trainings-directory/telecommunications-and-it-engineer/
* Proof for the email domain name:
  * Attached: the Teacher's guide provided by the institution. Sorry, it's in French, it would need translating.
    [FOR_Guide-enseignant.pdf](https://github.com/JetBrains/swot/files/8717577/FOR_Guide-enseignant.pdf)
    
    The interesting part is in the middle of the second page:
    > In any case, as a teacher or speaker for the benefit of our training, you have an address such as @imt-nord-europe.fr or @ext.imt-nord-europe.fr. This address is your key that provides access to your My Services portal.

Thank you for all!

Have a nice day.

Eric.