### PR TITLE
Added Queen Margaret University, Edinburgh

### DIFF
--- a/lib/domains/uk/ac/qmu.txt
+++ b/lib/domains/uk/ac/qmu.txt
@@ -1,0 +1,1 @@
+Queen Margaret University


### PR DESCRIPTION
NB: E-mail is on the bare domain, but website only response on www.qmu.ac.uk