### PR TITLE
Added Kendriya vidyalaya domain for delhi region

### DIFF
--- a/lib/domains/in/kvsrodelhi.txt
+++ b/lib/domains/in/kvsrodelhi.txt
@@ -1,0 +1,1 @@
+Kendriya Vidyalaya


### PR DESCRIPTION

1. the school official website URL : https://rodelhi.kvs.gov.in/
2. the school street address, including city and country : Delhi Region, India
3. an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course : https://rodelhi.kvs.gov.in/en
4. a proof, which shows that the school recognizes the domain you are submitting as an official email domain for the students : N/A

