### PR TITLE
Add 'corsigaldus.org' domain

### DIFF
--- a/lib/domains/org/corsigaldus.txt
+++ b/lib/domains/org/corsigaldus.txt
@@ -1,0 +1,2 @@
+Galdus
+Galdus


### PR DESCRIPTION
Galdus offers a software developer course

Source: https://www.galdus.it/sviluppatori-informatica/