### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/uk/org/chauncy.txt
+++ b/lib/domains/uk/org/chauncy.txt
@@ -1,0 +1,1 @@
+Chauncy school


### PR DESCRIPTION
https://chauncyschool.com
https://chauncyopenevening.com
http://chauncyopenevening.com/computer-science (2 year A-Level Computer Science course)
I am not completely sure as to how I can prove that the chauncy.org.uk domain is used purely for student/teacher email accounts however I can assure you that every student and teacher alike has an email registered under this domain: port 80/443 under this domain however do redirect to chauncyschool.com to display the website