### PR TITLE
Adding gympb.txt

### DIFF
--- a/lib/domains/cz/gympb.txt
+++ b/lib/domains/cz/gympb.txt
@@ -1,0 +1,2 @@
+Gymnázium, Příbram, Legionářů 402
+Grammar School Příbram


### PR DESCRIPTION
Official website: https://gympb.cz/
IT courses: http://gympb.cz/wp-content/dokumenty/svp.pdf in sections 5.18 - 5.20 and apendix 40, 51, 52.
Proof that the school ownes the domain: https://www.nic.cz/whois/domain/gympb.cz/