### PR TITLE
http://www.schlaun-gymnasium.de/

### DIFF
--- a/lib/domains/com/onmicrosoft/schlaun.txt
+++ b/lib/domains/com/onmicrosoft/schlaun.txt
@@ -1,0 +1,2 @@
+Johann-Conrad-Schlaun-Gymnasium Münster
+Johann-Conrad-Schlaun-College Muenster


### PR DESCRIPTION
In Muenster we´re all using Iserv: `nameOfTheStudent@[college].ms.de` emails (pascal, stein, and many more, just look up the results: https://www.google.com/search?q=iserv+ms.de), but in my college we can´t use the email address to text with other email addressers than `@schlaun.ms.de`. Luckily we also have a `nameOfTheStudent.jcs@schlaun.onmicrosoft.com` email address we can use for all this kind of stuff.
The URL of my college is: http://www.schlaun-gymnasium.de/
IT-related long-term (>1 year) course: http://www.schlaun-gymnasium.de/fach/informatik/
Please feel free to contact me if you have any questions!