### PR TITLE
Add Ross Sheppard High School

### DIFF
--- a/lib/domains/ca/epsb/share.txt
+++ b/lib/domains/ca/epsb/share.txt
@@ -1,0 +1,1 @@
+Ross Sheppard High School


### PR DESCRIPTION
- School's official website URL is [https://rosssheppard.epsb.ca](https://rosssheppard.epsb.ca)
- 13546 111 Ave NW, Edmonton, AB T5M 2P2, Canada
- Offering CS and robotics course, see [https://rosssheppard.epsb.ca/academics/career-technology-studies/](https://rosssheppard.epsb.ca/academics/career-technology-studies/)
- Page that recognizes share.epsb.ca as an official student email [https://epsb.ca/news/students/howtoaccessonlinelearning.html](https://epsb.ca/news/students/howtoaccessonlinelearning.html)