### PR TITLE
Add psc.ac.uk

### DIFF
--- a/lib/domains/uk/ac/psc.txt
+++ b/lib/domains/uk/ac/psc.txt
@@ -1,0 +1,1 @@
+Peter Symonds College


### PR DESCRIPTION
Courses at: https://psc.ac.uk/courses/2023/compsci/


Proof domain is used by students:
![image](https://user-images.githubusercontent.com/72658447/175349707-9480fff6-b0a6-4648-83e9-c2a20a34ac0e.png)
