### PR TITLE
Add Lycee Saint Nicolas Paris

### DIFF
--- a/lib/domains/fr/lyceesaintnicolas.txt
+++ b/lib/domains/fr/lyceesaintnicolas.txt
@@ -1,0 +1,1 @@
+Lycée technique privé Saint Nicolas


### PR DESCRIPTION
Extensions differ between web site and e-mail domain :
* Web site : lyceesaintnicolas.com
* e-mail address domain name : lyceesaintnicolas.fr
