### PR TITLE
Add High School

### DIFF
--- a/lib/domains/bo/edu/ccc.txt
+++ b/lib/domains/bo/edu/ccc.txt
@@ -1,0 +1,2 @@
+Colegio Cristiano Colcapirhua
+C.C.C


### PR DESCRIPTION
Adds C.C.C. School, a HS located in Cochabamba, Bolivia