### PR TITLE
Adding oclock.school

### DIFF
--- a/lib/domains/school/oclock.txt
+++ b/lib/domains/school/oclock.txt
@@ -1,0 +1,1 @@
+Ecole O'clock


### PR DESCRIPTION
This is an equivalent to the oclock.io domain (already approved).
but we have made changes to our email strategy for some current and future students