### PR TITLE
Add Brighton Hove and Sussex Sixth Form College

### DIFF
--- a/lib/domains/uk/ac/bhasvic.txt
+++ b/lib/domains/uk/ac/bhasvic.txt
@@ -1,0 +1,1 @@
+Brighton Hove & Sussex Sixth Form College


### PR DESCRIPTION
Official Website URL:
bhasvic.ac.uk

URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
https://www.bhasvic.ac.uk/courses/computer-science-a-level