### PR TITLE
City of Glasgow College added to the list

### DIFF
--- a/lib/domains/uk/ac/cityofglacol.txt
+++ b/lib/domains/uk/ac/cityofglacol.txt
@@ -1,0 +1,1 @@
+City of Glasgow College


### PR DESCRIPTION
Domain for students' accounts for City of Glasgow College (cityofglacol.ac.uk). Main domain for college: cityofglasgowcollege.ac.uk