### PR TITLE
Add Truro & Penwith College Gmail (GHS) domain

### DIFF
--- a/lib/domains/uk/ac/truropenwith/ghs.txt
+++ b/lib/domains/uk/ac/truropenwith/ghs.txt
@@ -1,0 +1,1 @@
+Truro and Penwith College


### PR DESCRIPTION
Truro & Penwith College (UK), they use the domain @truro-penwith.ac.uk (already added) and @ghs.truropenwith.ac.uk - you can verify from the domain whois the college owns both domains. 

2 Year Computing BTEC: https://www.truro-penwith.ac.uk/courses/btec-level-3-national-extended-diploma-in-it-computing-games/

Extra info: A tweet to show they use email addresses from both domains - https://twitter.com/Truro_Penwith/status/1529112160537821185

Cheers