### PR TITLE
Add clsmss in HK

### DIFF
--- a/lib/domains/hk/edu/clsmss.txt
+++ b/lib/domains/hk/edu/clsmss.txt
@@ -1,0 +1,2 @@
+趙聿修紀念中學
+Chiu Lut Sau Memorial Secondary School


### PR DESCRIPTION
Add Chiu Lut Sau Memorial Secondary School in Hong Kong to the database.

[School Website](https://www.clsmss.edu.hk/)
Address: 7 Yuen Long Tai Yuk Rd, Yuen Long, Hong Kong