### PR TITLE
add Egyptian Ministry of Education: MOE

### DIFF
--- a/lib/domains/eg/edu/moe/behera4.txt
+++ b/lib/domains/eg/edu/moe/behera4.txt
@@ -1,0 +1,2 @@
+وزارة التربية والتعليم والتعليم الفني
+Egyptian Ministry of Education


### PR DESCRIPTION
The official website: [official site](https://moe.gov.eg/en)
The street: 12 El-falaki street, Cairo, Egypt
This is the official website of the Egyptian Ministry of Education: [An article](https://cpd.moe.gov.eg/) note:( this article is in the Arabic language)
The email address that is used by me is from the emails that the Ministry give for free, this is an article about this: [An article](https://office365.emis.gov.eg/) note: ( this article is in the Arabic language), this emails is for the students & teachers