### PR TITLE
add Institut polytechnique de Paris

### DIFF
--- a/lib/domains/fr/ip-paris.txt
+++ b/lib/domains/fr/ip-paris.txt
@@ -1,0 +1,2 @@
+Institut Polytechnique de Paris
+Institut Polytechnique de Paris


### PR DESCRIPTION
add IPP Paris:
Name: Institut polytechnique de Paris (IP Paris)
Web: https://www.ip-paris.fr/en
Address: 5 Av. Le Chatelier 2ème étage, 91764 Palaiseau, France
Phone: +33 1 69 33 33 33