### PR TITLE
Added jriit.ac.tz domain

### DIFF
--- a/lib/domains/tz/ac/jriit.txt
+++ b/lib/domains/tz/ac/jriit.txt
@@ -1,0 +1,1 @@
+Jr Institute Of Information Technology


### PR DESCRIPTION
The official Institute URL is https://jriit.ac.tz
