### PR TITLE
Add highschool Leman Manhattan Preparatory School domain

### DIFF
--- a/lib/domains/org/lemanmanhattan.txt
+++ b/lib/domains/org/lemanmanhattan.txt
@@ -1,0 +1,1 @@
+Leman Manhattan Preparatory School


### PR DESCRIPTION
School website: https://lemanmanhattan.org/

