### PR TITLE
Added new domain for Universidad Dominico-Americana

### DIFF
--- a/lib/domains/do/edu/unicda.txt
+++ b/lib/domains/do/edu/unicda.txt
@@ -1,0 +1,1 @@
+Universidad Dominico-Americana


### PR DESCRIPTION
Added new domain for Universidad Dominico Americana as it uses both icda.edu.do and unicda.edu.do