### PR TITLE
Add educator tenant for Rogaland Fylkeskommune

### DIFF
--- a/lib/domains/no/rogfk/elev.txt
+++ b/lib/domains/no/rogfk/elev.txt
@@ -1,1 +1,2 @@
-Rogaland fylkeskommune
+Rogaland Fylkeskommune
+Rogaland County Municipality

--- a/lib/domains/no/rogfk/skole.txt
+++ b/lib/domains/no/rogfk/skole.txt
@@ -1,0 +1,2 @@
+Rogaland Fylkeskommune
+Rogaland County Municipality


### PR DESCRIPTION
I also added an english name for `elev.rogfk.no` (our student tenant)

Edit, website of all 31 schools: https://www.rogfk.no/vare-tjenester/skole-og-utdanning/opplaring-i-skole/skoler-i-fylket/videregaende-skoler-og-fagskole/
`skole` (employees) = school
`elev` = pupil