### PR TITLE
Create bict-edu

### DIFF
--- a/lib/domains/ch/bict-edu.txt
+++ b/lib/domains/ch/bict-edu.txt
@@ -1,0 +1,1 @@
+BiCT AG, Die Berufsbildner


### PR DESCRIPTION
BiCT AG, Die Berufsbildner
New separate domain, especially for the apprentices