### PR TITLE
Changed name of EHL

### DIFF
--- a/lib/domains/ch/ehl.txt
+++ b/lib/domains/ch/ehl.txt
@@ -1,1 +1,1 @@
-Lausanne Hotel School (EHL)
+EHL Hospitality Business School


### PR DESCRIPTION
As mentioned in their press release:
https://news.ehlgroup.com/ehl-ecole-hoteliere-de-lausanne-becomes-ehl-hospitality-business-school