### PR TITLE
add Colegiul National Vasile Alecsandri

### DIFF
--- a/lib/domains/ro/cnvais.txt
+++ b/lib/domains/ro/cnvais.txt
@@ -1,0 +1,1 @@
+Colegiul National Vasile Alecsandri


### PR DESCRIPTION
Colegiul National Vasile Alecsandri is a national college in Iasi, Romania.

https://cnvais.ro