### PR TITLE
(+) added pmhs.de

### DIFF
--- a/lib/domains/de/pmhs.txt
+++ b/lib/domains/de/pmhs.txt
@@ -1,0 +1,1 @@
+Philipp-Matthäus-Hahn-Schule Nürtingen


### PR DESCRIPTION
added the Philipp-Matthäus-Hahn-Schule Nürtingen [(https://www.pmhs.de)](https://www.pmhs.de).

Link to page showing computer science related course: (e.g. https://www.pmhs.de/vollzeit/technisches-gymnasium/ - "Informatik" or https://www.pmhs.de/vollzeit/technisches-berufskolleg-1/ - "Informationstechnik") 

Link showing teacher e-mail addresses: https://www.pmhs.de/organisation-ablauf/schulleitung/
Student mails end on @pmhs.de too, but have more than three characters.