### PR TITLE
add domain fef

### DIFF
--- a/lib/domains/br/edu/fef.txt
+++ b/lib/domains/br/edu/fef.txt
@@ -1,0 +1,1 @@
+FEF - Fundação Educacional de Fernandópolis

--- a/lib/domains/br/fef.txt
+++ b/lib/domains/br/fef.txt
@@ -1,0 +1,1 @@
+FEF - Fundação Educacional de Fernandópolis


### PR DESCRIPTION
university official website URL:
https://fef.br

URL of a page on the official website where a long-term (>1 year) IT related course: 
https://fef.br/graduacao/1214-sistemas-de-informacao-bacharelado

The institutional email is under the domain **fef.edu.br** but website is under the domain **fef.br**