### PR TITLE
Add Gymnasium Eversten Oldenburg (GEO)

### DIFF
--- a/geo-iserv.txt
+++ b/geo-iserv.txt
@@ -1,0 +1,1 @@
+Gymnasium Eversten Oldenburg


### PR DESCRIPTION
Official Website (German): https://gymnasium-eversten.de/#
Link to Domain: https://geo-iserv.de/iserv/