### PR TITLE
Add CRAG from UAB

### DIFF
--- a/lib/domains/cat/autonoma.txt
+++ b/lib/domains/cat/autonoma.txt
@@ -1,0 +1,2 @@
+Universitat Autònoma de Barcelona
+Autonomous University of Barcelona

--- a/lib/domains/es/cragenomica.txt
+++ b/lib/domains/es/cragenomica.txt
@@ -1,0 +1,2 @@
+Centre de Recerca en Agrogènomica
+Centre for Research in Agrogenomics


### PR DESCRIPTION
Add cragenomica.es which is the domain for the reserachers of CRAG in UAB a leading in centre in agricultural genomics where lots of Phd, Master and undergraduate stundents use bioinformatics and would fancy the acces to JetBrains tools