### PR TITLE
Add Brisbane Boys' College

### DIFF
--- a/lib/domains/au/edu/qld/bbc.txt
+++ b/lib/domains/au/edu/qld/bbc.txt
@@ -1,0 +1,1 @@
+Brisbane Boys' College


### PR DESCRIPTION
Institution: Brisbane Boys' College
Location: Brisbane, Australia
Education: Primary and Secondary School (Elementary, Middle, and High School equivalent)
Email Users: Students, Academic Staff, Support Staff
Website: https://www.bbc.qld.edu.au
Proof of Email Domain: https://www.bbc.qld.edu.au/key-contacts
Proof of IT Courses: https://www.bbc.qld.edu.au/wp-content/uploads/2021/10/Curriculum-Handbook-2022_Senior-compressed.pdf#page=5