### PR TITLE
Rename gprc.ab.ca to nwpolytech.ca

### DIFF
--- a/lib/domains/ca/ab/gprc.txt
+++ b/lib/domains/ca/ab/gprc.txt
@@ -1,1 +1,0 @@
-Grande Prairie Regional College

--- a/lib/domains/ca/nwpolytech.txt
+++ b/lib/domains/ca/nwpolytech.txt
@@ -1,0 +1,1 @@
+Northwestern Polytechnic


### PR DESCRIPTION
Grande Prairie Regional College (GPRC) was renamed to Northwestern Polytechnic ([https://www.nwpolytech.ca/news/display.html?ID=2065](https://www.nwpolytech.ca/news/display.html?ID=2065)). AFAICT all email domains were changed to nwpolytech.ca

GPRC was originally added to this repository in #3612

Homepage: https://www.nwpolytech.ca/
Example program: https://www.nwpolytech.ca/programs/computer-systems-technology.html
Screenshot of the webmail login (can confirm if you click "Webmail" in the top-right corner of the homepage): 
![image](https://user-images.githubusercontent.com/4411333/186550292-bc746d21-58f4-431f-9c4d-c52c21c9aee5.png)
