### PR TITLE
Add University of Reading

### DIFF
--- a/lib/domains/uk/ac/reading/student.txt
+++ b/lib/domains/uk/ac/reading/student.txt
@@ -1,0 +1,1 @@
+University of Reading


### PR DESCRIPTION
official university website: https://www.reading.ac.uk/
long-term IT related course: https://www.reading.ac.uk/ready-to-study/study/2022/computer-science-ug/bsc-computer-science
university recognising the domain: https://www.reading.ac.uk/digital-technology-services/service-catalogue/office-365
