### PR TITLE
Please add Gateshead College to academic institutions

### DIFF
--- a/lib/domains/uk/ac/gateshead.txt
+++ b/lib/domains/uk/ac/gateshead.txt
@@ -1,0 +1,1 @@
+Gateshead College


### PR DESCRIPTION
College homepage:
https://www.gateshead.ac.uk/
Computing course:
https://www.gateshead.ac.uk/courses/higher-national-diploma-hnd-computing-and-devops
Page demonstrating that student email addresses have 123456@students.gateshead.ac.uk format:
https://www.gateshead.ac.uk/how-get-google-classroom