### PR TITLE
vss sckr UNI

### DIFF
--- a/lib/domains/si/sckr/vss.txt
+++ b/lib/domains/si/sckr/vss.txt
@@ -1,0 +1,1 @@
+Višja strokovna šola ŠC Kranj


### PR DESCRIPTION
name: Višja strokovna šola ŠC Kranj
website: https://sckr.si/vss/

same organization already has high school verified (sts.sckr.si)