### PR TITLE
Add CS Vincent van Gogh (NL)

### DIFF
--- a/lib/domains/eu/csvvg.txt
+++ b/lib/domains/eu/csvvg.txt
@@ -1,0 +1,1 @@
+CS Vincent van Gogh


### PR DESCRIPTION
This PR adds the "CS Vincent van Gogh" high school to the school names list.
- [Official website URL](https://www.csvincentvangogh.nl/) (this differs from the student email, which has the csvvg.eu domain)
- CS Vincent van Gogh offers two IT related courses
  - Informatics (no URL available, however, there are some references in downloadadle PDFs in https://www.csvincentvangogh.nl/downloads-en-protocollen)
  - Robotics (https://www.csvincentvangogh.nl/robotklas)
- Email proof: I currently do not have access to my school email address since I am switching schools. On the contact page, there are mentions of the email address (https://www.csvincentvangogh.nl/contact-1) as well as in the school informational document (page 30, [here](https://www.csvincentvangogh.nl/files/domains/www.csvincentvangogh.nl/file_system/file/file/766/Locatiegids%20Lariks%202022%20DEF.pdf) )

Context: I used to have a dr.nassaucollege.nl email address, so I could get access to professional Jetbrains tools, however I will lose this email address soon because I am switching schools. If neccesary, I can provide proof of a csvvg.eu email belonging to me later.