### PR TITLE
Added Accra Institute of Technology

### DIFF
--- a/lib/domains/gh/edu/ait.txt
+++ b/lib/domains/gh/edu/ait.txt
@@ -1,0 +1,3 @@
+Accra Institute of Technology
+AIT
+The university of the future


### PR DESCRIPTION
I added the Accra Institute of Technology domain name to JetBrain swot in order for students and lecturers with their school email to be granted free licenses for JetBrains tools.