### PR TITLE
Add Domain for CPCE-PolyU

### DIFF
--- a/lib/domains/hk/edu/cpce-polyu/common.txt
+++ b/lib/domains/hk/edu/cpce-polyu/common.txt
@@ -1,0 +1,2 @@
+香港理工大學專業及持續教育學院
+College of Professional and Continuing Education, PolyU


### PR DESCRIPTION
Official website: https://cpce-polyu.edu.hk

IT related programme:
[Associate in Information Technology](https://www.hkcc-polyu.edu.hk/en/programmes/associate-degree/programmeDetails.php?sid=17)
[Bsc (Hons) in Applied Sciences (Information Systems and Web Technologies)](https://www.speed-polyu.edu.hk/programme/applied-sciences-iswt)
Remark: HKCC and SPEED are operate by CPCE, PolyU

Proof:
<img src="https://user-images.githubusercontent.com/79555466/187980913-bd116c46-c408-492f-81e8-f9789e09804f.png" width="400">
