### PR TITLE
Add kgc.edu.vn to domain list

### DIFF
--- a/lib/domains/vn/edu/kgc.txt
+++ b/lib/domains/vn/edu/kgc.txt
@@ -1,0 +1,1 @@
+Kien Giang College


### PR DESCRIPTION
Belong to Kien Giang College (or Kien Giang Community College). Located in Kien Giang, Vietnam
![image](https://user-images.githubusercontent.com/29633492/188197249-c0fde7bf-0e6c-4c66-9dea-a914dfd11be8.png)