### PR TITLE
add stzn.katowice.pl

### DIFF
--- a/lib/domains/pl/katowice/sltzn.txt
+++ b/lib/domains/pl/katowice/sltzn.txt
@@ -1,0 +1,1 @@
+Śląskie Techniczne Zakłady Naukowe


### PR DESCRIPTION
Adding 
Śląskie Techniczne Zakłady Naukowe
ul. Sokolska 26
40-086 Katowice, Poland
http://www.sltzn.katowice.pl/