### PR TITLE
Create edu.txt

### DIFF
--- a/lib/domains/com/siemens-energy/edu.txt
+++ b/lib/domains/com/siemens-energy/edu.txt
@@ -1,0 +1,1 @@
+Siemens Energy Professional Education (SEPE)


### PR DESCRIPTION
https://www.siemens-energy.com/
https://www.education-siemens.com/ebis2/Portal/Default.aspx
First it was called SPE for Siemens Professional Education but now it changed to SEPE, Siemens Energy Professional Education.
There's no updated webpage just the Google search