### PR TITLE
Add Bridge Academy

### DIFF
--- a/lib/domains/org/bridgeacademy.txt
+++ b/lib/domains/org/bridgeacademy.txt
@@ -1,0 +1,1 @@
+Bridge Academy


### PR DESCRIPTION
Email domain can be seen in use behind the email button in the upper right hand corner of the home page:
https://bridgeacademy.org/.  Bridge Academy is a 6-12 (Middle School and High School) charter school.  