### PR TITLE
Add Windsor High School

### DIFF
--- a/lib/domains/org/weldre4.txt
+++ b/lib/domains/org/weldre4.txt
@@ -1,0 +1,1 @@
+Windsor High School


### PR DESCRIPTION
Add Windsor High School from Windsor Colorado.

https://whs.weldre4.org/