### PR TITLE
Add Liepājas Raiņa 6. vidusskola

### DIFF
--- a/lib/domains/lv/citadaskola.txt
+++ b/lib/domains/lv/citadaskola.txt
@@ -1,0 +1,2 @@
+Liepājas Raiņa 6. vidusskola
+Liepaja Rainis Secondary School No. 6

--- a/lib/domains/lv/edu/liepa6vsk.txt
+++ b/lib/domains/lv/edu/liepa6vsk.txt
@@ -1,0 +1,2 @@
+Liepājas Raiņa 6. vidusskola
+Liepāja Rainis Secondary School No. 6


### PR DESCRIPTION
We have two domains
* liepa6vsk.edu.lv is used for Gmail (redirects to main domain)
* citadaskola.lv is Office365 (as well as main domain for homepage)