### PR TITLE
Add FINra on the list of educational institutions

### DIFF
--- a/lib/domains/ba/edu/finra.txt
+++ b/lib/domains/ba/edu/finra.txt
@@ -1,0 +1,1 @@
+FINra Tuzla


### PR DESCRIPTION
University official website URL - https://finra.edu.ba/ 
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university - https://finra.edu.ba/programsko-inzenjerstvo/

Proof that they are now using info@finra.ba as an email address.
![proof](https://user-images.githubusercontent.com/81316440/193328450-f37419ab-cbc6-4fd4-b211-6b750d51ac69.jpg)
