### PR TITLE
Add I.E.S La Hontanilla

### DIFF
--- a/lib/domains/es/jccm/edu.txt
+++ b/lib/domains/es/jccm/edu.txt
@@ -1,0 +1,2 @@
+Instituto de Educación Secundaria La Hontanilla
+Institute of Secondary Education La Hontanilla


### PR DESCRIPTION
Official website:

http://ies-lahontanilla.centros.castillalamancha.es/
(caution, is http not https!)

Information about the 2-year Technology Science course. Where subjects such as Computer Science and Programming are taught:

https://www.educa.jccm.es/en/edubachiller

Location:

Street/ Antonio Machado, s/n. 16400, Tarancón (Cuenca-Spain)

Official domain evidence:

The official email portal is located directly above the school's homepage.
![IMG_20221001_205856.jpg](https://user-images.githubusercontent.com/61310905/193424255-c5c18971-48ea-40db-aaf8-5b6b741615a7.jpg)