### PR TITLE
Add South Thames Colleges Group domain

### DIFF
--- a/lib/domains/uk/ac/stcg.txt
+++ b/lib/domains/uk/ac/stcg.txt
@@ -1,0 +1,1 @@
+South Thames Colleges Group


### PR DESCRIPTION
Website: https://stcg.ac.uk

List of all IT courses at the college: https://stcg.ac.uk/courses?keywords=computing&t=1

Examples of longer term courses:
* https://stcg.ac.uk/kingston-college/computing-and-it/software-development-technician-apprenticeship-level-3 (2y)
* https://stcg.ac.uk/kingston-college/computing-and-it/software-developer-apprenticeship-level-4 (3y)
* https://stcg.ac.uk/merton-college/computing-and-it/level-2-certificate-understanding-coding (1y)

Screenshot of email message details showing the college domain:

<img width="736" alt="Screenshot 2022-10-02 at 08 14 17" src="https://user-images.githubusercontent.com/311736/193442743-ae056145-997c-4591-bae9-401c3d2fe238.png">
