### PR TITLE
Request to add the Gisela-Gymnasium München-Schwabing

### DIFF
--- a/lib/domains/de/musin/muenchen/gg.txt
+++ b/lib/domains/de/musin/muenchen/gg.txt
@@ -1,0 +1,1 @@
+Gisela-Gymnasium München-Schwabing


### PR DESCRIPTION
Request to add the Gisela-Gymnasium München-Schwabing to the list.
 - offical school website URL: http://www.giselagym.musin.de/
 - school address: Arcisstraße 65 80801 Munich
 - IT related course: http://www.giselagym.musin.de/index.php/faecher/faecher-nut-sport/informatik/46-faecher/informatik/142-informatik-am-gisela
 - school's wikipedia article: https://de.wikipedia.org/wiki/Gisela-Gymnasium