### PR TITLE
Create bfw-koblenz.txt

### DIFF
--- a/lib/domains/de/bfw-koblenz.txt
+++ b/lib/domains/de/bfw-koblenz.txt
@@ -1,0 +1,1 @@
+CJD Berufsförderungswerk Koblenz Gemeinnützige GmbH


### PR DESCRIPTION
Request to add the domain:  bfw-koblenz.de  to the list.

- the university official website URL: https://www.bfw-koblenz.de/
- a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
   https://www.bfw-koblenz.de/leistungstraeger/bildungsangebot/it