### PR TITLE
Add Shih Chien University gm1 domain

### DIFF
--- a/lib/domains/tw/edu/usc/gm1.txt
+++ b/lib/domains/tw/edu/usc/gm1.txt
@@ -1,0 +1,2 @@
+實踐大學
+Shih Chien University


### PR DESCRIPTION
An URL of a page at the official school website that says that students use this email domain

https://sites.google.com/a/g2.usc.edu.tw/g2/home