### PR TITLE
Mahad Aly Nurul Jadid

### DIFF
--- a/lib/domains/id/ac/mahadaly-nuruljadid.txt
+++ b/lib/domains/id/ac/mahadaly-nuruljadid.txt
@@ -1,0 +1,2 @@
+mahad aly nurul jadid
+mahad aly nurul jadid


### PR DESCRIPTION
Add Campus Mahad Aly Nurul Jadid , Paiton - Probolinggo - Jawa Timur - Indonesia
#### Institution/School Name 
Mahad Aly Nurul Jadid

#### Instiution/School Website
https://mahadaly-nuruljadid.ac.id/

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent