### PR TITLE
Add Hanoi University of Civil Engineering

### DIFF
--- a/lib/domains/vn/edu/huce.txt
+++ b/lib/domains/vn/edu/huce.txt
@@ -1,0 +1,1 @@
+Hanoi University of Civil Engineering


### PR DESCRIPTION
This one is the update to the **nuce.txt** file in the same folder. 
My university has changed the **official website** to: https://huce.edu.vn/. 
The old website which is: https://www.nuce.edu.vn/ has an announcement to redirect to the new website (since 15/11/2021).
New student's email will use **@huce.edu.vn** instead.
Please keep the old **nuce.txt** file since old students still using the old domain **@nuce.edu.vn**.

Thank you!


