### PR TITLE
Add King Edwards College, Nuneaton

### DIFF
--- a/lib/domains/uk/ac/ke6n.txt
+++ b/lib/domains/uk/ac/ke6n.txt
@@ -1,0 +1,1 @@
+King Edwards VI College Nuneaton


### PR DESCRIPTION
https://ke6n.ac.uk/

Offers A-level computer science (3rd level of education, years 12-13, 16+, UK)
https://ke6n.ac.uk/course/computer-science/

![image](https://user-images.githubusercontent.com/57567095/194754937-e1a14d26-e511-4777-82d5-49f2f3ae7da8.png)