### PR TITLE
Add Chitralada Vocational School

### DIFF
--- a/lib/domains/th/ac/cdti.txt
+++ b/lib/domains/th/ac/cdti.txt
@@ -1,0 +1,2 @@
+โรงเรียนจิตรลดาวิชาชีพ สถาบันเทคโนโลยีจิตรลดา
+Chitralada Vocational School


### PR DESCRIPTION
Just a sidenote, the vocational school is like a subset inside an Institute. So they use the same domain. The name for the institute is `Chitralada Technology Institute`.