### PR TITLE
Saint Paul Preparatory Seoul

### DIFF
--- a/lib/domains/org/stpaulseoul.txt
+++ b/lib/domains/org/stpaulseoul.txt
@@ -1,0 +1,1 @@
+Saint Paul Preparatory Seoul


### PR DESCRIPTION
Saint Paul Preparatory Seoul is an American international high and middle school based in Seoul, South Korea. It provides its high school students computing courses such as AP Computer Science and Intro to Computer Science. They are both full year courses.