### PR TITLE
Pope John Paul II Preparatory School

### DIFF
--- a/lib/domains/org/popeprep.txt
+++ b/lib/domains/org/popeprep.txt
@@ -1,0 +1,1 @@
+Pope John Paul II Preparatory School


### PR DESCRIPTION
Pope John Paul II Preparatory School Official Website: https://www.popeprep.org
Course offerings: https://www.popeprep.org/academics/curriculum - includes AP Computer Science and honors/intro to computer science for high school students.