### PR TITLE
Updating Andover Public Schools Email Domain

### DIFF
--- a/lib/domains/us/andoverma/k12.txt
+++ b/lib/domains/us/andoverma/k12.txt
@@ -1,1 +1,0 @@
-Andover Public Schools

--- a/lib/domains/us/andoverma/student.txt
+++ b/lib/domains/us/andoverma/student.txt
@@ -1,0 +1,1 @@
+Andover Public Schools


### PR DESCRIPTION
Our school system has updated email domains from k12.andoverma.us to student.andoverma.us and this pull request reflects that change.