### PR TITLE
Add domain hlg.hamburg.de

### DIFF
--- a/lib/domains/de/hamburg/hlg.txt
+++ b/lib/domains/de/hamburg/hlg.txt
@@ -1,0 +1,1 @@
+Helene-Lange-Gymnasium


### PR DESCRIPTION
Official website: https://www.hlg-hamburg.de
IT related course: https://www.hlg-hamburg.de/wp-content/uploads/2021/11/Profilangebot-2022.pdf
- see column 8 (Experimentieren, Simulieren, Interpretieren), row 2 (Profil begleitendes Fach 1)
- course is "Informatik", lasting 2 years (the entire "Oberstufe")

URL is recognized as official email domain: https://www.hlg-hamburg.de/kontakt/