### PR TITLE
Cambridge Academy for Science and Technology

### DIFF
--- a/lib/domains/uk/org/cambridgeast.txt
+++ b/lib/domains/uk/org/cambridgeast.txt
@@ -1,0 +1,2 @@
+Cambridge Academy for Science and Technology
+Cambridge Academy for Science and Technology


### PR DESCRIPTION
URL: cambridgeast.org.uk or cast.education

2-year Computer Science A-level course: https://www.cambridgeast.org.uk/sixth-form/curriculum/computer-science
also 3-year CompSci GCSE course: https://www.cambridgeast.org.uk/Years-9-11/Curriculum/Computer-Science