### PR TITLE
Added Padang State Polytechnic domain JetBrain whitelist

### DIFF
--- a/lib/domains/id/ac/pnp.txt
+++ b/lib/domains/id/ac/pnp.txt
@@ -1,0 +1,2 @@
+Politeknik Negeri Padang
+Padang State Polytechnic


### PR DESCRIPTION
add Padang State Polytechnic as a domain
you can check the official information here regarding Information Technology [https://ti.pnp.ac.id](https://ti.pnp.ac.id) 

one of the largest Information Technology academies in West Sumatera Indonesia