### PR TITLE
Add Arusha technical college

### DIFF
--- a/lib/domains/tz/ac/atc.txt
+++ b/lib/domains/tz/ac/atc.txt
@@ -1,0 +1,1 @@
+Arusha Technical College


### PR DESCRIPTION
The official College URL website is www.atc.ac.tz

The URL for IT course longer than one year is: https://atc.ac.tz/index.php/courses/diploma-in-information-technology
<img width="597" alt="Screenshot_20221102_094803" src="https://user-images.githubusercontent.com/38250641/199419828-cb9e5594-c0a8-44b3-ba0a-74bcab0efb1d.png">
