### PR TITLE
Add SAIS

### DIFF
--- a/lib/domains/sg/edu/sais.txt
+++ b/lib/domains/sg/edu/sais.txt
@@ -1,0 +1,1 @@
+Stamford American International School


### PR DESCRIPTION
- Add Stamford American International School as a school in Singapore