### PR TITLE
Add GCS

### DIFF
--- a/lib/domains/do/edu/genesis.txt
+++ b/lib/domains/do/edu/genesis.txt
@@ -1,0 +1,2 @@
+Genesis Christian School
+Genesis Christian School


### PR DESCRIPTION
Add Genesis Christian School as a school in the Dominican Republic