### PR TITLE
Add files via upload for QEGS Blackburn

### DIFF
--- a/lib/domains/com/qegsonline.txt
+++ b/lib/domains/com/qegsonline.txt
@@ -1,0 +1,1 @@
+Queen Elizabeth's Grammar School Blackburn


### PR DESCRIPTION
The official website URL for QEGS Blackburn is https://www.qegsblackburn.com/ The email domain is qegsonline.com
This is a link to their comp sci course: https://www.qegsblackburn.com/sixth/a-level-subjects/computer-science/