### PR TITLE
Add SIW Höhere Fachschule für Wirtschaft und Informatik

### DIFF
--- a/lib/domains/swiss/siw.txt
+++ b/lib/domains/swiss/siw.txt
@@ -1,0 +1,1 @@
+SIW Höhere Fachschule für Wirtschaft und Informatik


### PR DESCRIPTION
**Official website URL**
https://siw.swiss/

**URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university**
https://siw.swiss/lehrgaenge_category/wirtschaftsinformatik/
https://siw.swiss/lehrgaenge_category/technische-informatik/

**URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students**
https://siw.swiss/impressum/
![image](https://user-images.githubusercontent.com/11613026/200170084-fa836464-7fda-4cd4-b853-0165216e6239.png)
