### PR TITLE
Adding NCCL School - Newark Center for Creative Learning

### DIFF
--- a/lib/domains/org/ncclschool.txt
+++ b/lib/domains/org/ncclschool.txt
@@ -1,0 +1,2 @@
+Newark Center for Creative Learning
+NCCL School


### PR DESCRIPTION
Adding Newark Center for Creative Learning, it is a non-profit private K-8 school in Newark DE
More info at https://www.ncclschool.org/