### PR TITLE
Add another domain for FEU Institute of Technology

### DIFF
--- a/lib/domains/ph/edu/fit.txt
+++ b/lib/domains/ph/edu/fit.txt
@@ -1,0 +1,1 @@
+FEU Institute of Technology


### PR DESCRIPTION
Additional information for verification process:
* The university's official website URL: **https://fit.edu.ph/** domain redirects to **https://feutech.edu.ph/**
* A URL of a page on the official website where a long-term IT-related course is offered: **https://feutech.edu.ph/academics/ccsma**
* A URL of a page or some other proof showing that the university recognizes the domain: **https://students.feutech.edu.ph/_public/downloads/Google%20Account%20Recovery.pdf**
