### PR TITLE
Add University of Reading

### DIFF
--- a/lib/domains/uk/ac/reading.txt
+++ b/lib/domains/uk/ac/reading.txt
@@ -1,0 +1,1 @@
+University of Reading


### PR DESCRIPTION
Institution Website: https://www.reading.ac.uk/
Computer Science Course: https://www.reading.ac.uk/ready-to-study/study/2022/computer-science-ug/bsc-computer-science
Page specifying domain as official domain for staff: https://www.reading.ac.uk/imps/data-protection/data-protection-and-email

Already have the subdomain students.reading.ac.uk accepted #14892 - this PR adds the primary domain used by teaching staff.