### PR TITLE
Update Buhmann school domains

### DIFF
--- a/lib/domains/de/buhmann-hannover.txt
+++ b/lib/domains/de/buhmann-hannover.txt
@@ -1,2 +1,0 @@
-Dr. Buhmann Schule Hannover
-Dr. Buhmann Schule Hanover

--- a/lib/domains/de/buhmann.txt
+++ b/lib/domains/de/buhmann.txt
@@ -1,0 +1,2 @@
+Dr. Buhmann Schule & Akademie Hannover
+Dr. Buhmann School & Academy Hanover

--- a/lib/domains/schule/buhmann.txt
+++ b/lib/domains/schule/buhmann.txt
@@ -1,0 +1,2 @@
+Dr. Buhmann Schule & Akademie Hannover
+Dr. Buhmann School & Academy Hanover


### PR DESCRIPTION
buhmann-hannover.de doesnt exist (anymore?).
Main url is https://buhmann.de which is also used by most teachers for mails, and https://buhmann.schule which is used for emails by students and some teachers.

(Proof from #7922: https://buhmann.de/wp-content/uploads/sites/5/2019/09/Buhmann_Festschrift_2016.pdf)