### PR TITLE
Teacher/admin domain for Chapel hill-Carrboro city schools

### DIFF
--- a/lib/domains/us/nc/k12/chccs.txt
+++ b/lib/domains/us/nc/k12/chccs.txt
@@ -1,0 +1,1 @@
+Chapel-Hill Carrboro City Schools


### PR DESCRIPTION
just an extension of https://github.com/JetBrains/swot/pull/15555, which added the student domain. Teachers/Admins have a different address. (______@chccs.k12.nc.us)