### PR TITLE
Add Gower College Swansea

### DIFF
--- a/lib/domains/uk/ac/gcs.txt
+++ b/lib/domains/uk/ac/gcs.txt
@@ -1,0 +1,1 @@
+Gower College Swansea


### PR DESCRIPTION
Campus 1,
Tycoch Rd, Sketty, Swansea SA2 9EB
Campus 2,
Belgrave Rd, Gorseinon, Swansea SA4 6RD,
Campus 3,
Units 1&2, Jubilee Ct, Swansea SA5 4HB,
Campus 4,
77 Walter Rd, Uplands, Swansea SA1 4QA
Campus 5,
Sketty Ln, Sketty, Swansea SA2 8QF

https://www.gcs.ac.uk - College URL
https://www.gcs.ac.uk/full-time-course/information-technology-btec-extended-diploma - IT/CS course
https://www.gcs.ac.uk/staff-student-portal - Domain confirmation