### PR TITLE
Adding icemalta.com (ICE Malta) domain

### DIFF
--- a/lib/domains/com/icemalta.txt
+++ b/lib/domains/com/icemalta.txt
@@ -1,0 +1,2 @@
+Institute of Computer Education Ltd.
+ICE Malta


### PR DESCRIPTION
We are a computer/ICT training institute established in 2011, offering various programming, web design/development and related courses. 