### PR TITLE
Add student domain for Vellore Institute of Technology

### DIFF
--- a/lib/domains/in/ac/vitstudent.txt
+++ b/lib/domains/in/ac/vitstudent.txt
@@ -1,0 +1,1 @@
+Vellore Institute of Technology, Vellore


### PR DESCRIPTION
vit.ac.in is the domain for faculty email ids. This domain is already added. The domain for student email ids is vitstudent.ac.in