### PR TITLE
Add an entry of Kibabii university

### DIFF
--- a/lib/domains/ke/ac/kibu.txt
+++ b/lib/domains/ke/ac/kibu.txt
@@ -1,0 +1,1 @@
+Kibabii University


### PR DESCRIPTION
The university official website URL: https://kibu.ac.ke/
![Screenshot from 2022-11-19 19-31-51](https://user-images.githubusercontent.com/68158733/202861428-805feb30-8327-4342-8b12-4d77abe408b2.png)

A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://kibu.ac.ke/academic-programs/undergraduate-programmes/bachelor-of-science-in-information-technology/

