### PR TITLE
Cegep-lanaudiere

### DIFF
--- a/lib/domains/ca/qc/cegep-lanaudiere.txt
+++ b/lib/domains/ca/qc/cegep-lanaudiere.txt
@@ -1,0 +1,1 @@
+Cégep de Lanaudière à Joliette

--- a/lib/domains/ca/qc/cegep-lanaudiere/etu.txt
+++ b/lib/domains/ca/qc/cegep-lanaudiere/etu.txt
@@ -1,2 +1,2 @@
-Cégep régional de Lanaudière à Joliette
+Cégep de Lanaudière à Joliette
 Cegep of Lanaudière at Joliette


### PR DESCRIPTION
Add domain for cegep-lanaudiere.qc.ca for teachers and change school name for the "etu" subdomain (new school name)