### PR TITLE
Adding WQE as a school (Wyggeston & Queen Elizabeth I College) 

### DIFF
--- a/lib/domains/uk/ac/wqe.txt
+++ b/lib/domains/uk/ac/wqe.txt
@@ -1,0 +1,1 @@
+Wyggeston & Queen Elizabeth I College


### PR DESCRIPTION
**DOMAIN** 
https://wqe.ac.uk

**COURSES**
https://wqe.ac.uk/our-courses/a-levels/
Note: the website above has IT and computer science a levels, but there are also IT related Vocational courses (e.g. Level 3 diplomas)

**PROOF**
I don't have difinitive proof I can show that the school email is "person"@wqe.ac.uk, if I did it would have helped me quite a bit in the enrollment process. However, if you go anywhere on the wqe website, you'll find that they all have that sort of email 