### PR TITLE
Added Helsingborg middle school

### DIFF
--- a/lib/domains/se/helsingborg/utb.txt
+++ b/lib/domains/se/helsingborg/utb.txt
@@ -1,0 +1,1 @@
+Rydebäcksskolan


### PR DESCRIPTION
Rydebäcksskolan is one of several middle school (grundskola) in Helsingborg, Sweden https://rydebacksskolan.helsingborg.se/

List of all schools in Helsingborg on the City of Helsingborg website 
https://helsingborg.se/forskola-och-utbildning/grundskola/grundskolor-i-helsingborg-2/

Portal for schools of City of Helsingborg
https://skolportalen.helsingborg.se/