### PR TITLE
Adding new domain for IBA Erhvervsakademi Kolding

### DIFF
--- a/lib/domains/dk/iba.txt
+++ b/lib/domains/dk/iba.txt
@@ -1,0 +1,2 @@
+IBA Erhvervsakademi Kolding
+IBA International Business Academy


### PR DESCRIPTION
IBA Erhvervsakademi Kolding - IBA.DK