### PR TITLE
Added bttc.cn

### DIFF
--- a/lib/domains/cn/bttc.txt
+++ b/lib/domains/cn/bttc.txt
@@ -1,0 +1,2 @@
+包头师范学院
+Baotou Teachers College


### PR DESCRIPTION
Added Baotou Teachers College
Webpage [http:](https://www.bttc.edu.cn/)  or [http:](https://www.bttc.cn/)