### PR TITLE
Add Gymnasium Mellendorf to database

### DIFF
--- a/lib/domains/de/gym-mellendorf.txt
+++ b/lib/domains/de/gym-mellendorf.txt
@@ -1,0 +1,1 @@
+Gymnasium Mellendorf


### PR DESCRIPTION
Pull requests adds the Gymnasium Mellendorf, a gymnasium School in Germany to the lib.