### PR TITLE
Add domain for national college of science and technology

### DIFF
--- a/lib/domains/np/edu/nicolnist.txt
+++ b/lib/domains/np/edu/nicolnist.txt
@@ -1,0 +1,1 @@
+National College of Science and Technology


### PR DESCRIPTION
National College of Science and Technology - Kathmandu, Nepal  (Affiliated to Tribhuwan University) 