### PR TITLE
Add SMA Muhammadiyah 1 Jakarta to List

### DIFF
--- a/lib/domains/id/sch/smamuhammadiyah1jkt.txt
+++ b/lib/domains/id/sch/smamuhammadiyah1jkt.txt
@@ -1,0 +1,1 @@
+SMA Muhammadiyah 1 Jakarta

--- a/lib/domains/id/sch/smamuhammadiyah1jkt/student.txt
+++ b/lib/domains/id/sch/smamuhammadiyah1jkt/student.txt
@@ -1,0 +1,1 @@
+SMA Muhammadiyah 1 Jakarta


### PR DESCRIPTION
- the school official website URL: https://smamuhammadiyah1jkt.sch.id/
- the school street address, including city and country: Jalan Kramat Raya No.49 RT.03/RW.04 Kec. Kramat Kel. Senen - Central Jakarta - Indonesia
- an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course [Here](https://smamuhammadiyah1jkt.sch.id/ekstrakurikuler/)
- a proof, which shows that the school recognizes the domain you are submitting as an official email domain for the students. [Here](https://media.smamuhammadiyah1jkt.sch.id/wp-content/uploads/2022/12/06114728/Screenshot-from-2022-12-06-11-45-55.png)