### PR TITLE
Add VNU-HCM High School for the Gifted

### DIFF
--- a/lib/domains/vn/edu/ptnk.txt
+++ b/lib/domains/vn/edu/ptnk.txt
@@ -1,0 +1,1 @@
+VNU-HCM High School for the Gifted

--- a/lib/domains/vn/edu/ptnk.txt
+++ b/lib/domains/vn/edu/ptnk.txt
@@ -1,1 +1,2 @@
 VNU-HCM High School for the Gifted
+Trường Phổ Thông Năng Khiếu, ĐHQG-HCM


### PR DESCRIPTION
I would like to request to add my school, VNU-HCM High School for the Gifted, to the directory.

Here is some additional information:
- The school is designated as a "high school for gifted students", and as such has been admitting students into its Informatics class alongside other specialized classes. Admission information for school year 2022-2023 is provided [here](https://ptnk.edu.vn/thong-tin-tuyen-sinh-ptnk-nam-hoc-2022-2023/) (in Vietnamese).
- Contact information can be found on the official school website (same as domain).
- Students and teachers alike can access webmail via a button on the navigation bar of the school website.
- The school's parent institution, [Viet Nam National University HCMC](https://vnuhcm.edu.vn/), has already been added to this directory.