### PR TITLE
Add @alu.edu.gva.es

### DIFF
--- a/lib/domains/es/gva/edu/alu.txt
+++ b/lib/domains/es/gva/edu/alu.txt
@@ -1,0 +1,1 @@
+Students of Comunidad Valenciana, Spain


### PR DESCRIPTION
This domain is not specific to a school center, but to all the students of the centers of the new CDC (Digital Collaborative Center) project of the Valencian Community.

More information about CDC (Spanish): https://portal.edu.gva.es/cdc/es/inicio_cas/

Clarification: The emails ``@edu.gva.es`` are also used for university students but ``@alu.edu.gva.es`` is the new domain that is used for students of all levels of education.