### PR TITLE
Add Inria.fr

### DIFF
--- a/lib/domains/fr/inria.txt
+++ b/lib/domains/fr/inria.txt
@@ -1,0 +1,1 @@
+Institut national de recherche en sciences et technologies du numérique


### PR DESCRIPTION
This is a request to add the french National Institute for Research in Digital Science and Technology. Inria is public institute that provides free online course on the french public platform : France Université Numérique.

- Our free online courses : https://www.fun-mooc.fr/en/organizations/inria/
- Inria works closely with universities (most researchers are "teacher-researchers" in universities) : https://www.inria.fr/en/partnerships-universities-strategy-territorial-inria
- Our others paid online courses : https://www.inria.fr/en/inria-academy


