### PR TITLE
Add University of Eldoret

### DIFF
--- a/lib/domains/ke/ac/uoeld.txt
+++ b/lib/domains/ke/ac/uoeld.txt
@@ -1,0 +1,1 @@
+University of Eldoret


### PR DESCRIPTION
Website: www.uoeld.ac.ke

Verify our programmes here: https://uoeld.ac.ke/sites/default/files/academic_programmes/Final%20Inside%20UoE%20A5%202018%20Landscape%20Academic%20Programmes.pdf

University of Eldoret owns the domain: uoeld.ac.ke