### PR TITLE
Added Everest Engineering College name and domain urls

### DIFF
--- a/lib/domains/np/edu/eemc.txt
+++ b/lib/domains/np/edu/eemc.txt
@@ -1,0 +1,6 @@
+Everest Engineering College
+Everest Engineering College
+(formerly recognized as Everest Engineering and Management College, EEMC)
+(https://www.eemc.edu.np)
+(https://www.eemc.edu.np/be-it-information-technology)
+(contact url: https://www.eemc.edu.np/contact)


### PR DESCRIPTION
Everest Engineering College was formerly recognized as Everest Engineering College. This institution is providing  IT and Computer related  Bachelors of Engineering degrees since 2001 A.D. I am applying so that i can get my student license and use these awesome IDEs.
https://www.eemc.edu.np/contact