### PR TITLE
Create cambridge.txt

### DIFF
--- a/lib/domains/uz/cambridge.txt
+++ b/lib/domains/uz/cambridge.txt
@@ -1,0 +1,4 @@
+Cambridge International University in Tashkent
+Original website: cambridge.uz
+Main domain used by staff and teachers
+Subdomain student.cambridge.uz used by students and separate pull request has been created


### PR DESCRIPTION
Cambridge International University in Tashkent
Original website: cambridge.uz
Main domain used by staff and teachers
Subdomain student.cambridge.uz used by students and separate pull request has been created