### PR TITLE
Added IMT Atlantique, result of the merge of Télécom Bretagne and Éco…

### DIFF
--- a/lib/domains/org/imt-atlantique.txt
+++ b/lib/domains/org/imt-atlantique.txt
@@ -1,0 +1,1 @@
+IMT Atlantique Bretagne-Pays de la Loire École Mines-Télécom


### PR DESCRIPTION
IMT Atlantique comes from the merge of Télécom Bretagne and École des Mines de Nantes (France engineering universities).

See http://www.imt-atlantique.fr/en

Note that at some point in the future, the old names should be removed (eu/telecom-bretagne.txt and fr/mines-nantes.txt).

Thanks!