### PR TITLE
Add University Collège de Paris, 75001 Paris, FR

### DIFF
--- a/lib/domains/com/e-cdp.txt
+++ b/lib/domains/com/e-cdp.txt
@@ -1,0 +1,1 @@
+Collège de Paris


### PR DESCRIPTION
Hi, I added the College de Paris university group to the list of domains. Thank you in advance for your approval.

University website: https://www.collegedeparis.com
University official email domain for the students (@e-cdp.com): https://support.collegedeparis.com/hc/fr/articles/5310139595549-Initialiser-mon-e-CDP-ID