### PR TITLE
adding mesoamericana university

### DIFF
--- a/lib/domains/gt/edu/mesoamericana.txt
+++ b/lib/domains/gt/edu/mesoamericana.txt
@@ -1,0 +1,1 @@
+Universidad Mesoamericana Quetzaltenango


### PR DESCRIPTION
followed instructions in order to add Mesoamericana University located in Guatemala. 

Reference Link: http://mesoamericana.edu.gt/
