### PR TITLE
Adding IIS Jean Monnet

### DIFF
--- a/lib/domains/com/onmicrosoft/ismonnet.txt
+++ b/lib/domains/com/onmicrosoft/ismonnet.txt
@@ -1,0 +1,1 @@
+IIS Jean Monnet


### PR DESCRIPTION
I have added IIS Jean Monnet, like requested on JetBrains help page, the official website of school is ismonnet.edu.it, but the student mail are on @ismonnet.onmicrosoft.com
Please can you add these school?
Thx