### PR TITLE
Creating abs.txt to add Accra Business School

### DIFF
--- a/lib/domains/gh/edu/abs.txt
+++ b/lib/domains/gh/edu/abs.txt
@@ -1,0 +1,1 @@
+I added the Accra Business School domain name to JetBrain swot in order for students and lecturers with their school email to be granted free licenses for JetBrains tools.


### PR DESCRIPTION
I added the Accra Business School domain name to JetBrain swot in order for students and lecturers with their school email to be granted free licenses for JetBrains tools.