### PR TITLE
acme.edu.np domain for acme engineering college

### DIFF
--- a/lib/domains/np/edu/acme.txt
+++ b/lib/domains/np/edu/acme.txt
@@ -1,0 +1,1 @@
+Acme Engineering College


### PR DESCRIPTION
acme.edu.np domain added for [Acme Engineering College](https://www.acme.edu.np/)
Official website: https://www.acme.edu.np/
Programs offered: [Bachelors in Computer Engineering, 4 Years](https://www.acme.edu.np/p/bachelor-in-computer-engineering-4-years-63)
Programs offered: [M.Sc. in Information System Engineering, 2 Years](https://www.acme.edu.np/p/m-sc-in-information-system-engineering-2-years-65)