### PR TITLE
Add waldorf-augsburg.de

### DIFF
--- a/lib/domains/de/waldorf-augsburg.txt
+++ b/lib/domains/de/waldorf-augsburg.txt
@@ -1,0 +1,1 @@
+Freie Waldorfschule Augsburg


### PR DESCRIPTION
Add domain of the Freie Waldorfschule Augsburg (waldorf-augsburg.de)

https://github.com/FreieWaldorfschuleAugsburg
https://waldorf-augsburg.de/
https://www.waldorf-augsburg.de/schule/schulleben/digitalisierung/
(school provides a min. 1 max. 2 year long programming course, see "Schülerengagement")

https://elektronisch.dev/
(see blue box "Freie Waldorfschule Augsburg" for further details)