### PR TITLE
Support for @u.rochester.edu email domains

### DIFF
--- a/lib/domains/edu/rochester/u.txt
+++ b/lib/domains/edu/rochester/u.txt
@@ -1,0 +1,1 @@
+University of Rochester


### PR DESCRIPTION
```
[-] lib
      [-] domains
            [-] edu
                  [+] rochester
                        [+] u.txt
```
Adds support for @u.rochester.edu email domains at the University of Rochester.