### PR TITLE
Added a new university

### DIFF
--- a/lib/domains/ge/edu/ssu.txt
+++ b/lib/domains/ge/edu/ssu.txt
@@ -1,0 +1,1 @@
+Georgian Aviation University


### PR DESCRIPTION
Original name: საქართველოს საავიაციო უნივერსიტეტი
English name: Georgian Aviation University
Website: https://ssu.edu.ge/