### PR TITLE
Adding TorontoMetUniversity Domain

### DIFF
--- a/lib/domains/ca/torontomu.txt
+++ b/lib/domains/ca/torontomu.txt
@@ -1,0 +1,1 @@
+Toronto Metropolitan University


### PR DESCRIPTION
Ryerson University recently changed their name to Toronto Metropolitan University. Added the new domain of @torontomu.ca