### PR TITLE
Added Ministry of Public Education of Italy

### DIFF
--- a/lib/domains/it/istruzione/posta.txt
+++ b/lib/domains/it/istruzione/posta.txt
@@ -1,0 +1,2 @@
+Ministero dell'Istruzione e del Merito
+Ministry of Public Education


### PR DESCRIPTION
Teachers in italy have the following email given to them by the MIUR (Ministero dell'Istruzione e del Merito  / Ministry of Public Education) 

\<name\>.\<surname\>@posta.istruzione.it

Domain is https://istruzione.it which redirects to https://www.miur.gov.it/web/guest/home