### PR TITLE
added murang'a university to list

### DIFF
--- a/lib/domains/ke/ac/mut/student.txt
+++ b/lib/domains/ke/ac/mut/student.txt
@@ -1,0 +1,1 @@
+Murang'a University of Technology


### PR DESCRIPTION
The Murang'a university of technology is a public university in Murang'a, Kenya.
Checkout the university's [website](https://www.mut.ac.ke/)