### PR TITLE
fixed stoplist.txt because it's excluding University of Catania students

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -781,7 +781,6 @@ mail.apu.edu.my
 ucsy.edu.mm
 fpt.edu.vn
 wust.edu.cn
-studium.unict.it
 o365.unab.edu.co
 uoh.edu.pk
 ump.edu.my


### PR DESCRIPTION
Studium.unict.it is the official domain for the University of Catania students:
![image](https://user-images.githubusercontent.com/5181524/215093366-fe695118-26b7-49e9-ac49-1a76a7a54a96.png)
