### PR TITLE
Add Rondebosch Boys' Schools

### DIFF
--- a/lib/domains/com/rondebosch.txt
+++ b/lib/domains/com/rondebosch.txt
@@ -1,0 +1,1 @@
+Rondebosch Boys' Schools


### PR DESCRIPTION
Rondebosch Boys' Schools is a network of public boy's primary and secondary schools in Cape Town, South Africa registered with the [National Department of Basic Education](https://www.education.gov.za) in South Africa.

**Domain** - <https://rondebosch.com>
**High school** - _Web:_ <https://rondebosch.com/high/contact/> | _Telephone:_ +27 (21) 686 3987  
**Prep school** - _Web:_ <https://rondebosch.com/prep/contact/> | _Telephone:_ +27 (21) 686 4635

**Address:** Rondebosch Boys' High School  
Canigou Avenue, Rondebosch 7700, Cape Town, South Africa. 
**Email:** [infoline@rondebosch.com](mailto:infoline@rondebosch.com)  
**Office Hours:** 08:00 – 15:30 (GMT+2)

The school offers Information Technology subjects in both Preparatory and High School levels. Please find the academic pages related to this below:

- [Intermediate Phase Grades 4-6](https://rondebosch.com/prep/academics/intermediate-and-senior-phases-grades-4-7/) - scroll to bottom of page for IT overview.
- [Curriculum Grades 8 – 9](https://rondebosch.com/high/academics/curriculum-grades-8-9/) - click on the **Technology** box on the page for an overview of the programme as well as the [National Curriculum in PDF format here](https://rondebosch.com/high/wp-content/uploads/2019/07/caps-sp-technology-gr-7-9.pdf).
- [Curriculum Grades 10 – 12](https://rondebosch.com/high/academics/curriculum-grades-10-12/) - click on the **Information Technology (IT)** box on the page for an overview of the programme as well as the [National Curriculum in PDF format here](https://rondebosch.com/high/wp-content/uploads/2019/07/caps-fet-_-information-technology-_-gr-10-12-_-web_e677-1.pdf).