### PR TITLE
Add Brainster Next College

### DIFF
--- a/lib/domains/mk/edu/next.txt
+++ b/lib/domains/mk/edu/next.txt
@@ -1,0 +1,1 @@
+Brainster Next College


### PR DESCRIPTION
- The university official website URL, if it is different from the domain you are submitting: 
   https://next.edu.mk/
- A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
  https://next.edu.mk/softversko-inzenerstvo-i-inovacii/
