### PR TITLE
Added University Technical Collage Norfolk

### DIFF
--- a/lib/domains/org/utcncst.txt
+++ b/lib/domains/org/utcncst.txt
@@ -1,0 +1,1 @@
+University Technical Collage Norfolk


### PR DESCRIPTION
The school website is utcn.org.uk