### PR TITLE
Added UEM

### DIFF
--- a/lib/domains/mz/ac/uem.txt
+++ b/lib/domains/mz/ac/uem.txt
@@ -1,0 +1,1 @@
+Universidade Eduardo Mondlane


### PR DESCRIPTION
Adding Universidade Eduardo Mondlane // Eduardo Mondlane University (UEM) domain to Jetbrains domain list.
UEM Url: https://www.uem.mz/
Url of the page related to the Computer Engineering course that lasts 4 years: http://www.engenharia.uem.mz/index.php/licenciatura-em-engenharia-informatica

![image](https://user-images.githubusercontent.com/50259548/217751219-cdcbf3b6-75b1-4dde-8a8d-b1e119255f96.png)
