### PR TITLE
college domain added Kathmandu institute of science and technology

### DIFF
--- a/lib/domains/np/edu/kistcollege.txt
+++ b/lib/domains/np/edu/kistcollege.txt
@@ -1,0 +1,1 @@
+KIST college


### PR DESCRIPTION
https://kist.edu.np/
