### PR TITLE
Added kist college domain

### DIFF
--- a/lib/domains/np/edu/kist.txt
+++ b/lib/domains/np/edu/kist.txt
@@ -1,0 +1,1 @@
+KIST College & SS


### PR DESCRIPTION
Established in 1995, KIST is now a top +2 college in Nepal that offers high standard NEB + 2 Science & Management courses, a range of top quality Bachelor’s degrees – BBA, BIM, BIT, BBS & BSc Microbiology – followed by excellent Master’s degrees – MBS & MSc Microbiology.

Domain: https://kist.edu.np/introduction