### PR TITLE
Adding a new School for RO domain

### DIFF
--- a/lib/domains/ro/edu/nt/cni.txt
+++ b/lib/domains/ro/edu/nt/cni.txt
@@ -1,0 +1,2 @@
+Colegiul National de Informatica Piatra Neamt Romania
+National College of Computer Science Piatra Neamt Romania


### PR DESCRIPTION
\lib\domains\ro\edu\nt\cni.txt for @cni.nt.edu.ro

http://cni.nt.edu.ro/new/
IT course: http://cni.nt.edu.ro/new/index.php/profil/

RO: Colegiul National De Informatica Piatra Neamt, Romania 
EN: National College of Computer Science Piatra Neamt, Romania

Address: Romania, Piatra-Neamț, Str. Mihai Viteazu, Nr. 12, 610226