### PR TITLE
Added LaSalle College Institute Vancouver

### DIFF
--- a/lib/domains/net/lcieducation.txt
+++ b/lib/domains/net/lcieducation.txt
@@ -1,0 +1,1 @@
+LaSalle College Institute - Vancouver


### PR DESCRIPTION
Added "LaSalle College Institute - Vancouver" for "@lcieducation.net"