### PR TITLE
adding Delta University in Egypt to domains deltauniv.edu.eg

### DIFF
--- a/lib/domains/eg/edu/deltauniv.txt
+++ b/lib/domains/eg/edu/deltauniv.txt
@@ -1,0 +1,1 @@
+Delta University for Science & Technology (EG)


### PR DESCRIPTION
Name : Delta University for Science & Technology
Location : Egypt
Official Domain : deltauniv.edu.eg