### PR TITLE
The school's official domain name has been replaced

### DIFF
--- a/lib/domains/cn/net/shouhua.txt
+++ b/lib/domains/cn/net/shouhua.txt
@@ -1,1 +1,0 @@
-Shanghai Ouhua Vocational Technical College

--- a/lib/domains/com/shohzyxy.txt
+++ b/lib/domains/com/shohzyxy.txt
@@ -1,0 +1,2 @@
+上海欧华职业技术学院
+Shanghai Ouhua College


### PR DESCRIPTION
The school's official domain name has been changed from shouhua.net.cn to shohzyxy.com

official website:shohzyxy.com
it website:http://www.shohzyxy.com/index.php?c=article&a=type&tid=15