### PR TITLE
Adds Cranbrook school

### DIFF
--- a/lib/domains/au/edu/nsw/cranbrook.txt
+++ b/lib/domains/au/edu/nsw/cranbrook.txt
@@ -1,0 +1,1 @@
+Cranbrook School


### PR DESCRIPTION
website url: https://www.cranbrook.nsw.edu.au/

Proof IT course is offered: https://www.cranbrook.nsw.edu.au/wp-content/uploads/2022/09/Information-for-Overseas-Families-Brochure-March-2022.pdf 
 - p6 software design and development ( 2 year course year 11 and 12)
<img width="482" alt="Screen Shot 2023-02-25 at 7 07 23 pm" src="https://user-images.githubusercontent.com/123798534/221346350-d4f4d446-c994-47a4-be81-c8ddce8e57ce.png">

Proof of domain: 
At the bottom of 
https://www.cranbrook.nsw.edu.au/ 
there are emails with the @cranbrook.nsw.edu.au domain for each school that cranbrook has

<img width="437" alt="Screen Shot 2023-02-25 at 7 11 22 pm" src="https://user-images.githubusercontent.com/123798534/221346504-a39d131c-cbf8-45d3-b941-d8f90c202b4d.png">


