### PR TITLE
added Holy Cross of Davao College

### DIFF
--- a/lib/domains/ph/edu/hcdc.txt
+++ b/lib/domains/ph/edu/hcdc.txt
@@ -1,0 +1,1 @@
+Holy Cross of Davao College


### PR DESCRIPTION
School name: Holy Cross of Davao College
Address: Sta. Ana Avenue corner C. Guzman Street, Barangay 14-B, Davao City, Philippines
Website: https://www.hcdc.edu.ph/