### PR TITLE
Add Uganda Management Institute domain

### DIFF
--- a/lib/domains/ug/ac/umi/students.txt
+++ b/lib/domains/ug/ac/umi/students.txt
@@ -1,0 +1,2 @@
+Uganda Management Institute
+Uganda Management Institute


### PR DESCRIPTION
What is the university's official website URL?
====================================
https://umi.ac.ug/


A URL of a page on the official website where a long-term (>1 year) IT-related course is offered by the university
====================================

1. https://umi.ac.ug/index.php/courses
2. On the left side menu click PGD 
3. Click any of these courses (DITE, DISM)on the left side menu
