### PR TITLE
Domain name for Karatina university

### DIFF
--- a/lib/domains/ke/ac/karu/s.txt
+++ b/lib/domains/ke/ac/karu/s.txt
@@ -1,0 +1,1 @@
+Karatina University


### PR DESCRIPTION
University URL - https://karu.ac.ke/
IT-related course URL - https://karu.ac.ke/course/bachelor-of-science-in-computer-science/
