### PR TITLE
Add lumii.txt for an institute of University of Latvia

### DIFF
--- a/lib/domains/lv/lumii.txt
+++ b/lib/domains/lv/lumii.txt
@@ -1,0 +1,1 @@
+University of Latvia, Institute of Mathematics and Computer Science


### PR DESCRIPTION
Added Institute of Mathematics and Computer Science, which is part of University of Latvia and organises UL's CS master study programm.