### PR TITLE
Add UK Borden Grammar School

### DIFF
--- a/lib/domains/uk/sch/kent/bordengrammar.txt
+++ b/lib/domains/uk/sch/kent/bordengrammar.txt
@@ -1,0 +1,2 @@
+Borden Grammar School
+Borden Grammar School


### PR DESCRIPTION
Added file for Bordengrammar school @ kent.sch.uk
School is a mixed secondary AND higher education offering A-Level studies.
https://www.bordengrammar.kent.sch.uk/sixth-form/ks5 in which an OCR computer science A-Level is offered.