### PR TITLE
Added Korea Institute of Science and Technology Domain

### DIFF
--- a/lib/domains/kr/re/kist.txt
+++ b/lib/domains/kr/re/kist.txt
@@ -1,0 +1,1 @@
+Korea Institute of Science and Technology


### PR DESCRIPTION
Korea Institute of Science and Technology domain is "kist.re.kr"