### PR TITLE
Adding Barnsley College  Students & Staff

### DIFF
--- a/lib/domains/uk/ac/barnsley/live.txt
+++ b/lib/domains/uk/ac/barnsley/live.txt
@@ -1,1 +1,0 @@
-Barnsley College - Student Accounts


### PR DESCRIPTION
Adding Barnsley College so that both Staff and Students can have access. 
barnsley.ac.uk - For Staff
live.barnsley.ac.uk - For Students