### PR TITLE
Added new domain of MTG in Munich

### DIFF
--- a/lib/domains/de/musin/muenchen/mtg.txt
+++ b/lib/domains/de/musin/muenchen/mtg.txt
@@ -1,0 +1,1 @@
+Maria-Theresia-Gymnasium München


### PR DESCRIPTION
Hi there,

the Maria-Theresia-Gymnasium in Munich is already contained in swot (see de/musin/mtg.txt).
Time has passed and the email addresses they are now issuing to their students use @mtg.muenchen.musin.de

So this PR is about adding this new domain to swot

Best regards