### PR TITLE
Add Huazhong University of Science and Technology

### DIFF
--- a/lib/domains/cn/edu/hust.txt
+++ b/lib/domains/cn/edu/hust.txt
@@ -1,1 +1,2 @@
+华中科技大学
 Huazhong University of Science and Technology


### PR DESCRIPTION
About University official website URL in english:
 http://english.hust.edu.cn/
IT-related course is offered by the university. pdf which can be downloaded in this webpage can give detailed proof:  http://cs.hust.edu.cn/info/1076/1194.htm
Picture below can prove the committed email is belong to this school. The picture is a PrtSc from my laptop.
![proof](https://user-images.githubusercontent.com/107794700/222957636-f4684052-d1d5-4b4c-80c6-a2b47f9811e2.png)

