### PR TITLE
Adding colleges belonging to Colorado Community College System board

### DIFF
--- a/lib/domains/edu/cccs.txt
+++ b/lib/domains/edu/cccs.txt
@@ -1,3 +1,15 @@
 Colorado Community College System
 Arapahoe Community College
+Colorado Northwestern Community College
+Community College of Aurora
+Community College of Denver
+Front Range Community College
+Lamar Community College
+Morgan Community College
+Northeastern Junior College
+Otero College
+Pikes Peak State College
+Pueblo Community College
+Red Rocks Community College
+Trinidad State College
 .group


### PR DESCRIPTION
All colleges on this list use an email system provided by the Colorado Community College System board. All student emails from the colleges below use the cccs.edu domain (https://cccs.edu/ )

Added additional/remaining Colorado State/Community colleges that belong to the Colorado Community College System board

(Seen here for list: https://www.cccs.edu/college/ )

In the [initial commit](https://github.com/JetBrains/swot/commit/7ebe83688a62319d55061145636e553af8972a6b) to cccs.edu, looks like Arapahoe Community College was already added. It's the same case with the other colleges. That all of the colleges use the same domain for their email system.

Colorado Northwestern Community College:
https://www.cncc.edu/degrees/craig/cybersecurity

Community College of Aurora:
https://www.ccaurora.edu/programs-classes/departments/cis/cyber-security

Community College of Denver:
https://www.ccd.edu/program/cybersecurity-center

Front Range Community College:
https://www.frontrange.edu/programs-and-courses/a-z-program-list/computer-networking-virtualization-cybersecurity

Lamar Community College:
http://catalog.lamarcc.edu/preview_program.php?catoid=4&poid=195&returnto=117

Morgan Community College:
https://erpdnssb.cccs.edu/PRODMCC/bwckschd.p_disp_detail_sched?term_in=202330&crn_in=31184

Northeastern Junior College:
https://erpdnssb.cccs.edu/PRODNJC/bwckschd.p_disp_detail_sched?term_in=202330&crn_in=30182

Otero College:
https://www.ed2go.com/otero/online-courses/introduction-cybersecurity/

Pikes Peak State College:
https://www.pikespeak.edu/programs/cybersecurity/cybersecurity-program-options.php

Pueblo Community College:
https://pueblocc.edu/Programs/CSE

Red Rocks Community College:
https://www.rrcc.edu/cyber/program-info

Trinidad State College:
https://trinidadstate.edu/cis/index.html