### PR TITLE
Add Excel Institute Of Professionals

### DIFF
--- a/lib/domains/com/eipcollege.txt
+++ b/lib/domains/com/eipcollege.txt
@@ -1,0 +1,2 @@
+Excel Institute Of Professionals
+eipcollege.com/eipcollege.ac.ke

--- a/lib/domains/ke/ac/eipcollege.txt
+++ b/lib/domains/ke/ac/eipcollege.txt
@@ -1,0 +1,2 @@
+Excel Institute Of Professionals
+eipcollege.com/eipcollege.ac.ke


### PR DESCRIPTION
Name: Excel Institute Of Professionals
Domain Name: eipcollege.com/eipcollege.ac.ke
Type: Technical and Vocational Education and Training
Address: Murathe Plaza, Kisii St, Thika, Kiambu, Kenya
ICT Course Url: https://www.eipcollege.com/index.php/course/
Recognition: https://www.tveta.go.ke/institutions/(Line 420 has information about us)