### PR TITLE
Add Xihua University agin

### DIFF
--- a/lib/domains/cn/edu/xhu/stu.txt
+++ b/lib/domains/cn/edu/xhu/stu.txt
@@ -1,0 +1,2 @@
+Xihua University
+西华大学


### PR DESCRIPTION
The school has no open mailbox registration. Only students can log in with their student number, and they need to authenticate their identity cards before that. Notice link on the official website of the school: http://nmc.xhu.edu.cn/3d/3c/c3104a146748/page.htm
Please review again, thank you