### PR TITLE
Added Nepal Engineering College Domain

### DIFF
--- a/lib/domains/np/edu/nec.txt
+++ b/lib/domains/np/edu/nec.txt
@@ -1,0 +1,1 @@
+Nepal engineering college


### PR DESCRIPTION
The Nepal Engineering College was established in 1994 as the first privately led not-for-profit social organization providing engineering education in Nepal and is the largest engineering college in terms annual student intake as well as in terms of area. Its main campus is located at Changunarayan, Bhaktapur

Domain: https://nec.edu.np/