### PR TITLE
Adding Newark Charter School

### DIFF
--- a/lib/domains/us/de/k12/ncs.txt
+++ b/lib/domains/us/de/k12/ncs.txt
@@ -1,0 +1,1 @@
+Newark Charter School


### PR DESCRIPTION
School website: https://newarkcharterschool.org/
At the High School, we offer a CompSci STEM pathway.  
This page shows our email domain: https://newarkcharterschool.org/student-technology-support