### PR TITLE
Add European ICEA Catholic Institute

### DIFF
--- a/lib/domains/fr/icea-edu.txt
+++ b/lib/domains/fr/icea-edu.txt
@@ -1,0 +1,1 @@
+Institut Catholique Européen des Antilles


### PR DESCRIPTION
Institut Catholique Européen des Antilles (ICEA)
URL : https://icea-edu.fr/