### PR TITLE
Adding iu.edu for system-wide Indiana University domain

### DIFF
--- a/lib/domains/edu/iu.txt
+++ b/lib/domains/edu/iu.txt
@@ -1,0 +1,9 @@
+Indiana University - Bloomington
+Indiana University - Columbus
+Indiana University - East
+Indiana University - Indianapolis
+Indiana University - Kokomo
+Indiana University - Northwest
+Indiana University - Southeast
+Indiana University - South Bend
+Indiana University (System)


### PR DESCRIPTION
New students and faculty are encourage to use the iu.edu domain for new email address creation and in some cases those users will not have the campus specific ones already included in this project (Ex: iub.edu, iuk.edu, etc.). 

More can be found here: https://kb.iu.edu/d/aufj.