### PR TITLE
Add CKCM,Inc to PH .edu domain

### DIFF
--- a/lib/domains/ph/edu/ckcm.txt
+++ b/lib/domains/ph/edu/ckcm.txt
@@ -1,0 +1,1 @@
+Christ the King College de Maranding, Inc.


### PR DESCRIPTION
Register Christ the King College de Maranding, Inc.