### PR TITLE
Add student email domain for UPSA

### DIFF
--- a/lib/domains/bo/upsa.txt
+++ b/lib/domains/bo/upsa.txt
@@ -1,0 +1,1 @@
+Universidad Privada de Santa Cruz de la Sierra


### PR DESCRIPTION
Faculty email's domain is upsa.edu.bo, but student's email domain is upsa.bo