### PR TITLE
added Gesamtschule Porta Westfalica

### DIFF
--- a/lib/domains/de/geporta.txt
+++ b/lib/domains/de/geporta.txt
@@ -1,0 +1,1 @@
+Gesamtschule Porta Westfalica


### PR DESCRIPTION
added the german school named Gesamtschule Porta Westfalica
school: [url](https://www.gesamtschule-porta.de/)
maps: Bruchstraße 9, 32457 Porta Westfalica