### PR TITLE
add London Institute of Banking and Finance (LIBF)

### DIFF
--- a/lib/domains/uk/ac/libf.txt
+++ b/lib/domains/uk/ac/libf.txt
@@ -1,0 +1,1 @@
+London Institute of Banking and Finance


### PR DESCRIPTION
Website: https://www.libf.ac.uk
Course: https://www.libf.ac.uk/study/undergraduate/bsc-(hons)-in-finance-investment-and-risk
Staff domain: libf.ac.uk
student domain: edu.libf.ac.uk