### PR TITLE
add St Dominc Savio High School

### DIFF
--- a/lib/domains/org/saviochs.txt
+++ b/lib/domains/org/saviochs.txt
@@ -1,0 +1,1 @@
+St. Dominic Savio High School


### PR DESCRIPTION
adding St Dominic Savio High School located in Austin Texas
https://www.saviochs.org/
