### PR TITLE
add rmutr.ac.th

### DIFF
--- a/lib/domains/th/ac/rmutr.txt
+++ b/lib/domains/th/ac/rmutr.txt
@@ -1,0 +1,1 @@
+Rajamangala University of Technology Rattanakosin


### PR DESCRIPTION
The website is [https://www.rmutr.ac.th/ ](https://www.rmutr.ac.th/ ) (website is Thai language) or [https://www.rmutr.ac.th/en/](https://www.rmutr.ac.th/en/) (website is English language) ,The website mainly uses Thai language.