### PR TITLE
Add: WooSung High School

### DIFF
--- a/lib/domains/kr/go/goe/woosungh.txt
+++ b/lib/domains/kr/go/goe/woosungh.txt
@@ -1,0 +1,2 @@
+우성고등학교
+WooSung High School


### PR DESCRIPTION
I added an high school in the Republic of Korea.
official website URL: https://woosung.hs.kr
Street Address: `Gocheon-Dong 496, Uiwang-si, Gyeonggi-do `
