### PR TITLE
Adding 'New College Lanarkshire' 

### DIFF
--- a/lib/domains/uk/ac/nclan/my.txt
+++ b/lib/domains/uk/ac/nclan/my.txt
@@ -1,0 +1,1 @@
+New College Lanarkshire (Motherwell Campus)


### PR DESCRIPTION
Main website: [https://www.nclanarkshire.ac.uk/](https://www.nclanarkshire.ac.uk)
List of computing related courses available at this College: [https://www.nclanarkshire.ac.uk/courses/computing-and-digital-technologies](https://www.nclanarkshire.ac.uk/courses/computing-and-digital-technologies)

Email login recognising official domain for students:
![image](https://user-images.githubusercontent.com/108669549/227242007-efc85295-c2a9-461d-8e81-bf6eb39e43c4.png)
