### PR TITLE
added szlgbp to domain names

### DIFF
--- a/lib/domains/hu/szlgbp.txt
+++ b/lib/domains/hu/szlgbp.txt
@@ -1,0 +1,2 @@
+Kőbányai Szent László Gimnázium
+Kőbánya Szent László High School


### PR DESCRIPTION
Official name of school: Kőbányai Szent László Gimnázium
Location: Budapest, Kőrösi Csoma Sándor út 28-34, 1102
Website (sadly there is no english version): https://szlgbp.hu/
Url for the IT class (you have to scroll down a bit; it is a half class): https://szlgbp.hu/erdeklodoknek/