### PR TITLE
Addition of Wark C of E School

### DIFF
--- a/lib/domains/uk/sch/northumberland/wark.txt
+++ b/lib/domains/uk/sch/northumberland/wark.txt
@@ -1,0 +1,1 @@
+Wark C of E Primary School


### PR DESCRIPTION
Addition of a school (Wark C of E School): https://www.warkprimaryschool.co.uk/