### PR TITLE
adding Stepaside Educate Together National School

### DIFF
--- a/lib/domains/ie/stepasideetss.txt
+++ b/lib/domains/ie/stepasideetss.txt
@@ -1,0 +1,1 @@
+Stepaside Educate Together National School


### PR DESCRIPTION
Adding new secondary school to the list in Ireland: 
Stepaside Educate Together National School