### PR TITLE
added Second High School in Poznań

### DIFF
--- a/lib/domains/pl/2lopoznan.txt
+++ b/lib/domains/pl/2lopoznan.txt
@@ -1,0 +1,1 @@
+II Liceum Ogólnokształcące im. Generałowej Zamoyskiej i Heleny Modrzejewskiej w Poznaniu


### PR DESCRIPTION
### Some additional information to make verification easier for you
School website: http://2lo.poznan.pl/
School IB official page: https://www.ibo.org/school/001349/  (this one is in English)
School address: Matejki 8/10, Poznań, Poland
