### PR TITLE
Add etfbsb.edu.br

### DIFF
--- a/lib/domains/br/edu/etfbsb.txt
+++ b/lib/domains/br/edu/etfbsb.txt
@@ -1,0 +1,1 @@
+Instituto Federal de Educação, Ciência e Tecnologia de Brasília


### PR DESCRIPTION
WHOIS:
https://registro.br/tecnologia/ferramentas/whois/?search=etfbsb.edu.br

EXPLAIN:
This domain is used internally students to access tools, as Google for Education. The main site is https://www.ifb.edu.br