### PR TITLE
Add CBTis 71

### DIFF
--- a/lib/domains/mx/edu/cbtis71.txt
+++ b/lib/domains/mx/edu/cbtis71.txt
@@ -1,0 +1,2 @@
+Centro de Bachillerato Tecnológico, Industrial y de Servicios 71
+


### PR DESCRIPTION
Add `CBTis 71` or `Centro de Bachillerato Tecnológico, industrial y de servicios 71`.
It's a high school located in Veracruz, Mexico.
Website: https://cbtis71.edu.mx