### PR TITLE
add Francis Crick Institute domain

### DIFF
--- a/lib/domains/uk/ac/crick.txt
+++ b/lib/domains/uk/ac/crick.txt
@@ -1,0 +1,1 @@
+The Francis Crick Institute


### PR DESCRIPTION
https://www.crick.ac.uk/