### PR TITLE
Add alumno.uned.es domain

### DIFF
--- a/lib/domains/es/uned/alumno.txt
+++ b/lib/domains/es/uned/alumno.txt
@@ -1,0 +1,1 @@
+Universidad Nacional de Educación a Distancia


### PR DESCRIPTION
University official website: https://www.uned.es/universidad/inicio/en/
URL of a long-term (>1 year) IT related course offered by the university: http://portal.uned.es/portal/page?_pageid=93,71542233&_dad=portal&_schema=PORTAL
Proof showing that the university recognizes the domain for the enrolled students:
![image](https://user-images.githubusercontent.com/10176550/231156282-a28e6909-e15f-41c0-b103-ef623a907d4a.png)
