### PR TITLE
add student.pg.edu.pl

### DIFF
--- a/lib/domains/pl/edu/pg/student.txt
+++ b/lib/domains/pl/edu/pg/student.txt
@@ -1,0 +1,2 @@
+Politechnika Gdańska
+Gdańsk University of Technology


### PR DESCRIPTION
I believe it was mistakenly removed. The university website allows to create accounts BUT to get an email address at student.pg.edu.pl domain one needs to enter a student id number obtained from the dean's office (be a student). Without the code from the dean's offfice one can only create moodle account with external email address.