### PR TITLE
Add Cotham School

### DIFF
--- a/lib/domains/uk/sch/bristol/cotham.txt
+++ b/lib/domains/uk/sch/bristol/cotham.txt
@@ -1,0 +1,1 @@
+Cotham School


### PR DESCRIPTION
Add record for Cotham School.
cotham.bristol.sch.uk
(https://www.cotham.bristol.sch.uk)
JetBrains support ref 5057224