### PR TITLE
St. Louis Community College student domain

### DIFF
--- a/lib/domains/edu/stlcc/my.txt
+++ b/lib/domains/edu/stlcc/my.txt
@@ -1,0 +1,2 @@
+St. Louis Community College
+STLCC


### PR DESCRIPTION
The "my.stlcc.edu" email domain is for students.