### PR TITLE
Parmiters School

### DIFF
--- a/lib/domains/uk/sch/herts/parmiters.txt
+++ b/lib/domains/uk/sch/herts/parmiters.txt
@@ -1,0 +1,1 @@
+Parmiters School, High Elms Ln, Watford WD25 0UU


### PR DESCRIPTION
Added Parmiter's School, High Elms Ln, Watford WD25 0UU

parmiters.herts.sch.uk