### PR TITLE
Added Machakos University

### DIFF
--- a/lib/domains/ke/ac/mksu.txt
+++ b/lib/domains/ke/ac/mksu.txt
@@ -1,0 +1,1 @@
+Machakos University


### PR DESCRIPTION
The university's main webpage is at https://www.mksu.ac.ke/

Link to the about page: the department of Computing and IT
https://set.mksu.ac.ke/about-cit/

University's recognition of the domain:
Link to Machakos University's "contact us" page showing that the main email domain
https://www.mksu.ac.ke/contact-us/