### PR TITLE
Fixing misspelling and Additional information

### DIFF
--- a/lib/domains/tr/edu/itu.txt
+++ b/lib/domains/tr/edu/itu.txt
@@ -1,2 +1,2 @@
-İstanbul Teknik Üniversitesi
-İstanbul Technical University
+İstanbul Teknik Üniversitesi, İstanbul
+Istanbul Technical University, Istanbul


### PR DESCRIPTION
It is "İstanbul" but it must be "Istanbul" when written in English.

Looks like the university e-mail extension hasn't been approved by JetBrains yet, thinking of it may be because of the lack of adequate information. So additionally;

Offical website homepage: https://www.itu.edu.tr/en/homepage

Faculty of Computer and Informatics Enginnering: https://bbf.itu.edu.tr/en/home

A page I could find that shows the extension is official, another department of the same university but it shows that the e-mail extension is official: https://uubf.itu.edu.tr/en/students  Here is the highlighted screenshot of the page; https://snipboard.io/CEphlx.jpg

Many thanks!