### PR TITLE
Add extraterritorial Italian school of Cairo

### DIFF
--- a/lib/domains/org/donboscocairo.txt
+++ b/lib/domains/org/donboscocairo.txt
@@ -1,0 +1,1 @@
+Istituto Tecnico Industriale Salesiano - Don Bosco Cairo


### PR DESCRIPTION
Istituto Tecnico Industriale Salesiano (Salesian Industrial Technical Institute) - Don Bosco Cairo.
Official site: https://donboscocairo.org