### PR TITLE
Add Promeo  and ITII Picardie e-mail addresses. 

### DIFF
--- a/lib/domains/com/onmicrosoft/promeo365.txt
+++ b/lib/domains/com/onmicrosoft/promeo365.txt
@@ -1,0 +1,1 @@
+Institut des Techniques d'Ingénieur de l'Industrie Picardie

--- a/lib/domains/onmicrosoft/promeo365.txt
+++ b/lib/domains/onmicrosoft/promeo365.txt
@@ -1,0 +1,1 @@
+Institut des Techniques d'Ingénieur de l'Industrie Picardie

--- a/lib/domains/onmicrosoft/promeo365.txt
+++ b/lib/domains/onmicrosoft/promeo365.txt
@@ -1,1 +1,0 @@
-Institut des Techniques d'Ingénieur de l'Industrie Picardie


### PR DESCRIPTION
Hi, this is a pull resquest to add my school to the ones that you include to your student program.
Here is their website : https://www.itii-picardie.fr/
If you don't understand why does the domain is **Promeo** this is because ITII is undergoing PROMEO as you could see in the footer of their website. Here is the website of promeo. http://www.promeo-formation.fr/nos-centres/beauvais

Thank you for your reading.