### PR TITLE
add: Herald International Collage from Nepal

### DIFF
--- a/lib/domains/np/edu/heraldintlcollege.txt
+++ b/lib/domains/np/edu/heraldintlcollege.txt
@@ -1,0 +1,2 @@
+Herald International College
+contact@heraldintlcollege.edu.np


### PR DESCRIPTION
Founded in 2063 B.S. (2006 A.D.) under the umbrella of Herald Education Network, Herald International College has emerged as one of the best academic institutions in Nepal. It is run by a team of dedicated educationists, professionals and renowned academicians. Our students, faculties and staff share a commitment to work hard for the advancement of our society. 

Here is official site: [heraldintlcollege.edu.np](url)