### PR TITLE
Tomorrow education domain

### DIFF
--- a/lib/domains/education/tomorrows/campus.txt
+++ b/lib/domains/education/tomorrows/campus.txt
@@ -1,0 +1,1 @@
+Tomorrow university of applied sciences


### PR DESCRIPTION
Added domain tomorrows.education, the former domain of Tomorrow University of applied sciences, the emails still have the old domain

https://www.tomorrow.university/