### PR TITLE
Added the Newburyport Schools Domain (Newburyportschools.com)

### DIFF
--- a/lib/domains/com/newburyportschools.txt
+++ b/lib/domains/com/newburyportschools.txt
@@ -1,1 +1,2 @@
 Newburyport High School
+.group

--- a/lib/domains/com/newburyportschools.txt
+++ b/lib/domains/com/newburyportschools.txt
@@ -1,0 +1,1 @@
+Newburyport High School


### PR DESCRIPTION
This domain covers the entire Newburyport Public School District for students.