### PR TITLE
Add Brookfield Community School

### DIFF
--- a/lib/domains/uk/sch/hants/brookfield.txt
+++ b/lib/domains/uk/sch/hants/brookfield.txt
@@ -1,0 +1,1 @@
+Brookfield Community School


### PR DESCRIPTION
This domain belongs to Brookfield Community School, a secondary school based in Hampshire, UK. The school offers GCSE computing courses and has a physical site with over 1750 students in attendance. It is recognised by the UK government as an official state-run education establishment.

> Website: https://brookfield.hants.sch.uk
> Government confirmation: https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/116419