### PR TITLE
Add Padre Conceicao College of Engineering

### DIFF
--- a/lib/domains/com/onmicrosoft/pccegoa.txt
+++ b/lib/domains/com/onmicrosoft/pccegoa.txt
@@ -1,0 +1,1 @@
+Padre Conceicao College of Engineering, Verna


### PR DESCRIPTION
Padre Conceicao College of Engineering is an Engineering college affiliated with Goa University, India.
Website: https://pccegoa.edu.in/