### PR TITLE
Gdansk University of Technology student mail

### DIFF
--- a/lib/domains/pl/edu/pg/student.txt
+++ b/lib/domains/pl/edu/pg/student.txt
@@ -1,0 +1,1 @@
+Gdansk University of Technology


### PR DESCRIPTION
Currently the allowed domain for Gdansk University of Technology is pg.edu.pl. Students' mail addresses have a pattern of xxx@student.pg.edu.pl, so the license cannot be obtained automatically

University official URL : pg.edu.pl
URL where IT course is offered: https://pg.edu.pl/rekrutacja/studia-i-stopnia/wykaz-kierunkow/informatyka
URL when student.pg.edu.pl is whitelisted: https://cui.pg.edu.pl/katalog-uslug/poczta-elektroniczna