### PR TITLE
Adding ITICS Guatemala

### DIFF
--- a/lib/domains/gt/edu/itics.txt
+++ b/lib/domains/gt/edu/itics.txt
@@ -1,0 +1,1 @@
+ITICS Guatemala


### PR DESCRIPTION
Official site:
https://itics.edu.gt/
Another domain that proves .edu.gt domain it's working https://nube.itics.edu.gt