### PR TITLE
LVCSD Domain changed

### DIFF
--- a/lib/domains/us/ny/k12/lvcsd.txt
+++ b/lib/domains/us/ny/k12/lvcsd.txt
@@ -1,2 +1,0 @@
-Locust Valley Middle School
-Locust Valley Middle School


### PR DESCRIPTION
lvcsd.k12.ny.us Domain changed to locustvalleyschools.org