### PR TITLE
delete zjweu

### DIFF
--- a/lib/domains/cn/zjweu/stu.txt
+++ b/lib/domains/cn/zjweu/stu.txt
@@ -1,2 +1,0 @@
-Zhejiang University of Water Resources and Electric Power
-浙江水利水电学院


### PR DESCRIPTION
The domain name [zjweu.cn](http://zjweu.cn/) school has been discontinued and is now privately registered. As a result, it must be removed from the trusted list. If any instances of abuse or misuse of educational licenses are discovered on this domain name, it is recommended that all such licenses be revoked.