### PR TITLE
Adding Gabor Denes University

### DIFF
--- a/lib/domains/hu/gde/neptun.txt
+++ b/lib/domains/hu/gde/neptun.txt
@@ -1,0 +1,2 @@
+Gábor Dénes Egyetem
+Dennis Gabor University


### PR DESCRIPTION
Gabor Denes Collage became a University this year (2023-jan-01). The old neptun.gdf.hu domain only works for past students. In this pr there is the neptun.gde.hu variant of the domain.
The University Page: https://gde.hu/
The student emails are generated for m365 usage as well.
<img width="585" alt="Screenshot 2023-05-31 at 12 26 50" src="https://github.com/JetBrains/swot/assets/61193123/bb6a33a0-444a-473c-9815-bcd024d6ad49">
