### PR TITLE
Add Kantonsschule Zug

### DIFF
--- a/lib/domains/ch/edu-zg/ksz.txt
+++ b/lib/domains/ch/edu-zg/ksz.txt
@@ -1,0 +1,1 @@
+Kantonschule Zug (Gymnasium)


### PR DESCRIPTION
Name: Kantonsschule Zug
A public high school of the canton Zug, Switzerland
Website: [www.ksz.ch](https://www.ksz.ch/)
E-Mail-Domain: @ksz.edu-zg.ch

More Information: https://de.wikipedia.org/wiki/Kantonsschule_Zug

I hope I did everything right :-)