### PR TITLE
Add aiict.edu.au

### DIFF
--- a/lib/domains/au/edu/aiict.txt
+++ b/lib/domains/au/edu/aiict.txt
@@ -1,0 +1,1 @@
+Australian Institute of ICT


### PR DESCRIPTION
URL: https://aiict.edu.au/.
URL for courses: https://aiict.edu.au/courses/ (specific course: https://aiict.edu.au/courses/certificate-iv-in-information-technology-networking/).