### PR TITLE
Add new domain for existing uni

### DIFF
--- a/lib/domains/at/kunstuni-linz.txt
+++ b/lib/domains/at/kunstuni-linz.txt
@@ -1,0 +1,1 @@
+University of Art and Design Linz


### PR DESCRIPTION
The [University of Art and Design Linz](https://kunstuni-linz.at/) (a.k.a. University of Arts Linz) switched to a new official domain name sometime last year.

The old domain, [for which there already exists a file](https://github.com/JetBrains/swot/blob/master/lib/domains/at/ufg.txt), redirects to the new domain but continues to be in active (and exclusive, AFAIA) use for some services.

Students can also essentially still use the old domain for email, see [the IT dept's homepage](https://kunstuni-linz.at/IT-Services.1298+M52087573ab0.0.html) (scroll past the images for the text update), which is why I'm adding a new file rather than renaming the old one.