### PR TITLE
add student.42lehavre.fr domain

### DIFF
--- a/lib/domains/fr/42lehavre/student.txt
+++ b/lib/domains/fr/42lehavre/student.txt
@@ -1,0 +1,1 @@
+42 Le Havre


### PR DESCRIPTION
- official website url:
https://www.42lehavre.fr/

- a page on the official website where a long-term (>1 year) IT related course is offered:
https://www.42lehavre.fr/le-contenu/

Please find attached a screenshot showing the university's recognition of the domain as an official email domain for enrolled students.
![proof](https://github.com/JetBrains/swot/assets/126589687/11bc25b1-b38c-4f6e-869d-7317b7268517)
