### PR TITLE
Add XXVI LO High School in Łódź, Poland

### DIFF
--- a/lib/domains/pl/edu/elodz/lo26.txt
+++ b/lib/domains/pl/edu/elodz/lo26.txt
@@ -1,0 +1,2 @@
+XXVI Liceum Ogólnokształcące im. Krzysztofa Kamila Baczyńskiego w Łodzi
+Krzysztof Kamil Baczynski 26th High School in Lodz


### PR DESCRIPTION
Official website URL: https://www.lo26.pl/

A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www.lo26.pl/a/oferta-edukacyjna-202324

A URL of a page  showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://www.lo26.pl/contact/ (official contact email addresses are under submitted domain)