### PR TITLE
Added ITI Galileo Ferraris School

### DIFF
--- a/lib/domains/org/ferraris.txt
+++ b/lib/domains/org/ferraris.txt
@@ -1,0 +1,1 @@
+ITI Galileo Ferraris


### PR DESCRIPTION
the university official website URL: https://www.itiferraris.edu.it/
a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
http://2.228.35.46/accessorapido/orario/sttIndex.htm
a URL of a page showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: 
https://www.itiferraris.edu.it/attachments/article/330/Ottenere%20e%20Installare%20Office%20365.pdf