### PR TITLE
Create tameside.txt in /uk/ac

### DIFF
--- a/lib/domains/uk/ac/tameside.txt
+++ b/lib/domains/uk/ac/tameside.txt
@@ -1,0 +1,1 @@
+Tameside College


### PR DESCRIPTION
Links to IT courses offered:

- [16-18 School Leavers](https://www.tameside.ac.uk/pages/courses_search.aspx?a=9&x=a) (e.g. [Level 3 Computing](https://www.tameside.ac.uk/pages/course_info.aspx?x=178284))
- [Adults](https://www.tameside.ac.uk/pages/courses_search.aspx?a=9&x=c) (e.g. [Higher National Diploma in Computing](https://www.tameside.ac.uk/pages/course_info.aspx?x=179501))

The college provides emails to students in the format: <STUDENT_NUMBER>@tameside.ac.uk e.g. `123456@tameside.ac.uk`

Unfortunately, I could not find a public link that proves this directly, however, you can see a reference to this fact in [the student portal](https://lbox.tameside.ac.uk/ProPortal/_CCC/Authentication/CCCLogin.aspx):

> Your username for Student Portal is simply your student number
(don't put @tameside.ac.uk on the end as used by other systems)

I can also provide proof of my personal account if needed (I'm just unsure of what exactly you would want to see)