### PR TITLE
delete and update

### DIFF
--- a/lib/domains/cn/as/ucas/mails.txt
+++ b/lib/domains/cn/as/ucas/mails.txt
@@ -1,2 +1,0 @@
-中国科学院大学
-University of Chinese Academy of Sciences

--- a/lib/domains/cn/edu/kmust.txt
+++ b/lib/domains/cn/edu/kmust.txt
@@ -1,1 +1,0 @@
-Kunmimg University of Science and Technology

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -162,7 +162,6 @@ kkk.ac.nz
 k.kkk.ac.nz
 kkk.school.nz
 kmismail.com
-kmust.edu.cn
 kst.edu.sg
 k.tut.edu.pl
 kust.edu.cn


### PR DESCRIPTION
1.The domain name of the University of Chinese Academy of Sciences is [ucas.ac.cn](https://www.ucas.ac.cn/) instead of [ucas.as.cn](http://ucas.as.cn/). Someone may use [ucas.as.cn](http://ucas.as.cn/) to fraudulently obtain licenses.
2.According to the official website documents, the old domain name @kmust.edu.cn has been discontinued（[https://metc.kust.edu.cn/info/1261/1775.htm](https://metc.kust.edu.cn/info/1261/1775.htm)）
![image](https://github.com/JetBrains/swot/assets/46444328/e3b561b7-3271-4cec-a2b4-14ddd1f9c93f)
