### PR TITLE
Delete scun.txt

### DIFF
--- a/lib/domains/cn/scun.txt
+++ b/lib/domains/cn/scun.txt
@@ -1,2 +1,0 @@
-Sichuan Minzu College
-四川民族学院


### PR DESCRIPTION
The domain name [scun.cn](http://scun.cn/) school has been discontinued and is now privately registered. As a result, It is recommended to remove it from the trusted list, At the same time, it was personally registered on June 4, 2023, and it is recommended to revoke the educational license applied after that because it seems to be suspected of fraud.
![image](https://github.com/JetBrains/swot/assets/46444328/4c8b5ff5-e3ee-48ec-9f19-9539f2d72c51)