### PR TITLE
Adding Syosset CSD, primarily for Syosset HS

### DIFF
--- a/lib/domains/org/syossetschools.txt
+++ b/lib/domains/org/syossetschools.txt
@@ -1,0 +1,2 @@
+Syosset Senior High School
+Syosset Central School District


### PR DESCRIPTION
Syosset Senior High School is part of the wider Syosset Central School District. Even though it is a high school, it does offer a lot of  Higher Level Education Courses, including but not limited to, A.P. courses, SUPA courses, and many more.

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the school:
https://www.syossetschools.org/Page/659
(Also here is the Curriculum guide website, where you can see all the different Courses Syosset Senior High School has to offer):
https://www.syossetschools.org/domain/283

(Found a better document that satisfies the requirement)
https://www.syossetschools.org/cms/lib/NY50000216/Centricity/Domain/291/SHS%20Online%20Learning%20Plan.pdf