### PR TITLE
delete

### DIFF
--- a/lib/domains/cn/as/ucas/mails.txt
+++ b/lib/domains/cn/as/ucas/mails.txt
@@ -1,2 +1,0 @@
-中国科学院大学
-University of Chinese Academy of Sciences

--- a/lib/domains/cn/scun.txt
+++ b/lib/domains/cn/scun.txt
@@ -1,2 +1,0 @@
-Sichuan Minzu College
-四川民族学院


### PR DESCRIPTION
1.The domain name [scun.cn](http://scun.cn/) school has been discontinued and is now privately registered. As a result, It is recommended to remove it from the trusted list, At the same time, it was personally registered on June 4, 2023, and it is recommended to revoke the educational license applied after that because it seems to be suspected of fraud.
![image](https://github.com/JetBrains/swot/assets/46444328/8857e721-b65f-44ec-8a82-01ad96125ee6)
2.The domain name of the University of Chinese Academy of Sciences is [ucas.ac.cn](https://www.ucas.ac.cn/) instead of [ucas.as.cn](http://ucas.as.cn/). Someone may use [ucas.as.cn](http://ucas.as.cn/) to fraudulently obtain licenses.