### PR TITLE
Noser Young offers vocational education in the IT industry

### DIFF
--- a/lib/domains/ch/noseryoung.txt
+++ b/lib/domains/ch/noseryoung.txt
@@ -1,0 +1,1 @@
+Noser Young


### PR DESCRIPTION
Noser Young offers vocational education in the IT industry at Bern and Zürich, Switzerland. noseryoung.ch is used as the Email domain for the students during the two years of training, as well as for the trainers.
Official website is https://noseryoung.ch/ (in German only)