### PR TITLE
Debhis School (debhiss.com) added

### DIFF
--- a/lib/domains/com/debhiss.txt
+++ b/lib/domains/com/debhiss.txt
@@ -1,0 +1,2 @@
+DEBHIS School
+Daunne English Boarding Secondary School, Bardaghat, Nawalparasi, Lumbini, Nepal


### PR DESCRIPTION
Debhiss School (debhiss.com)
Daunne English Boarding Secondary School, Bardaghat-4, Nawalparasi(BSW), Lumbini, Nepal