### PR TITLE
Added Davao Oriental State University

### DIFF
--- a/lib/domains/ph/edu/dorsu.txt
+++ b/lib/domains/ph/edu/dorsu.txt
@@ -1,0 +1,1 @@
+Davao Oriental State University


### PR DESCRIPTION
The Davao Oriental State University (DOrSU) is a state-funded research-based coeducational higher education institution in Mati City, Davao Oriental, Philippines. It was founded on December 13, 1989.

Official Facebook Page: https://www.facebook.com/dorsuofficial/
Official Site: https://dorsu.edu.ph/