### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/org/fhsdschools.txt
+++ b/lib/domains/org/fhsdschools.txt
@@ -1,0 +1,1 @@
+Francis Howell School District


### PR DESCRIPTION
Adding Francis Howell School District to jet brains list of educational organizations.  This is a school district in Saint Charles Misosuri.  Adding for teachers who teach computer science so they can use jet brasins IDE to learn and practice Java to provide better instruction to out students.  To be clear, this is not used by students, only teachers for learning and practicing themselves.