### PR TITLE
Create iepscf-uccle.txt

### DIFF
--- a/lib/domains/be/iepscf-uccle.txt
+++ b/lib/domains/be/iepscf-uccle.txt
@@ -1,0 +1,1 @@
+EAFC-Uccle


### PR DESCRIPTION
This domain is still used by students who got their emails last year and the year before. They will use this email domain until they're no longer registered in an active curriculum.