### PR TITLE
Update hnu.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -127,7 +127,6 @@ hhu.edu.cn
 hiast.edu.vn
 hndx.ac.cn
 hnit.ed.cn
-hnu.edu.cn
 hqu.edu.cn
 hrbeu.edu.cn
 huanghuai.edu.cn


### PR DESCRIPTION
I found that my school domain name was removed from the trust list, because I don’t know when it was removed, but according to the current policy, the school mailbox only allows students to self-register, it should not be abused, please conduct an internal investigation Assess whether recovery is possible.Below is the policy link:
http://its.hnu.edu.cn/fwzn/xsfwlink/hdyx.htm
