### PR TITLE
Add Xi'An University of Finance and Economics

### DIFF
--- a/lib/domains/cn/edu/xaufe.txt
+++ b/lib/domains/cn/edu/xaufe.txt
@@ -1,0 +1,2 @@
+西安财经大学
+Xi'An University of Finance and Economics


### PR DESCRIPTION
Official website(in chinese): [https://www.xaufe.edu.cn](https://www.xaufe.edu.cn)

We have a Information Institute provided CS and SE major, see the intro page(also in chinese): [https://www.xaufe.edu.cn/yxsz1/xxxy1.htm](https://www.xaufe.edu.cn/yxsz1/xxxy1.htm) for more details.

We use `@xaufe.edu.cn` as a school issued email suffix for students, you can view it at the [email login page(also, in chinese)](https://mail.xaufe.edu.cn/). The `@mail.xaufe.edu.cn` suffix is for faculty use.

Last, I use the school issued email as a git commit email to let you make sure it's vaild for use.