### PR TITLE
Update hunnu.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -514,7 +514,6 @@ stu.cdut.edu.cn
 hsc.pku.edu.cn
 e.gzhu.edu.cn
 ayit.edu.cn
-hunnu.edu.cn
 cque.edu.cn
 sust.edu.cn
 o365.msu.ac.th


### PR DESCRIPTION
I found that my school domain name was removed from the trusted domains list, but according to the current policy, The school mailbox only allows students to apply for a mailbox, and they need to bring their ID card + campus card to the Sunshine Service Center of the school to apply, it should not be abused, please conduct an internal investigation Assess whether recovery is possible. Below is the policy link: https://io.hunnu.edu.cn/info/1008/1092.htm