### PR TITLE
Update cqu.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -66,7 +66,6 @@ connect.hku.hk
 correo.icesi.edu.co
 cougarmail.collin.edu
 cpcc.edu
-cqu.edu.cn
 csu.ph
 ctgu.edu.cn
 cug.edu.cn


### PR DESCRIPTION
I found that my school domain name was removed from the trusted domains list, but according to the latest email policy of the school, the mailbox can only be registered by oneself, and the graduate mailbox will be automatically deleted when it expires. it should not be abused, please conduct an internal investigation and assess whether recovery is possible. Below is the policy link:
http://net.cqu.edu.cn/info/1007/2194.htm