### PR TITLE
Delete aedu.txt

### DIFF
--- a/lib/domains/com/aedu.txt
+++ b/lib/domains/com/aedu.txt
@@ -1,1 +1,0 @@
-Anhanguera University


### PR DESCRIPTION
The correct domain name of the school is aedu.com.br. According to the description of the original adder, he wrongly added aedu.com to the library, and aedu.com is a privately registered domain name, which may lead to license abuse. It is recommended to check and remove it from Removed from the list of trusted domain names.
![Uploading image.png…]()
