### PR TITLE
remove alu domain 

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1337,3 +1337,4 @@ est.unicaribe.edu.do
 stud.ur.edu.pl
 uit.edu.vn
 brandeis.edu
+alu.cqu.edu.cn


### PR DESCRIPTION
According to the introduction on the official website, the email domain of teachers is @cqu.edu.cn, the domain of students is @stu.cqu.edu.cn, and the domain of graduated alumni is @alu.cqu.edu.cn, so the domain of alu.cqu.edu.cn It should be removed from the list of trusted domain names. The following link is the introduction of the school’s official website: http://net.cqu.edu.cn/info/1007/2194.htm