### PR TITLE
adding uci.cu domain

### DIFF
--- a/lib/domains/cu/uci.txt
+++ b/lib/domains/cu/uci.txt
@@ -1,0 +1,1 @@
+Universidad de las Ciencias Informáticas


### PR DESCRIPTION
Adding domain for Universidad de las Ciencias Informáticas, Havana, Cuba.
The oficial site of the university is https://www.uci.cu