### PR TITLE
Add email.vccs.edu

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,1 @@
+Virginia's Community Colleges


### PR DESCRIPTION
The domain vccs.edu for Virginia's Community Colleges already exists, but the subdomain email.vccs.edu does not.