### PR TITLE
remove vnu.edu.vn by wrong fraud detection

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -943,7 +943,6 @@ mail.tdc.edu.vn
 huaf.edu.vn
 rmu.ac.th
 nttu.edu.vn
-vnu.edu.vn
 sv.ussh.edu.vn
 alumni.anu.edu.au
 student.mmarau.ac.ke


### PR DESCRIPTION
vnu.edu.vn:
website: https://vnu.edu.vn/eng/
Name: Vietnam National University, Hanoi
Webmaster: media@vnu.edu.vn; thinhtt@vnu.edu.vn


![image](https://github.com/JetBrains/swot/assets/2316698/d049828f-cb7c-4b59-ab92-394e2fa5dbaa)
