### PR TITLE
add the edu domain for the Universidad Autonoma de Nayarit

### DIFF
--- a/lib/domains/mx/edu/uan.txt
+++ b/lib/domains/mx/edu/uan.txt
@@ -1,0 +1,1 @@
+Universidad Autonoma de Nayarit


### PR DESCRIPTION
The email domain for the university is uan.edu.mx. My institution is added outside of the "edu" folder in the base MX, and I have already tried accessing the products with different domain endings like .com. However, it says that my email does not belong to any university. I hope that by adding it, it will work.

