### PR TITLE
Added Faculty of Sport & Psychology - Tims, Novi Sad, Serbia

### DIFF
--- a/lib/domains/rs/edu/tims.txt
+++ b/lib/domains/rs/edu/tims.txt
@@ -1,0 +1,2 @@
+Fakultet za Sport i Psihologiju - Tims
+Faculty of Sport & Psychology - Tims


### PR DESCRIPTION
Added my own faculty in here, it belongs to [Educons University](https://educons.edu.rs/), which I also haven't found on the list, however, [Tims](https://www.tims.edu.rs/) is a specialized faculty for sport & psychology so it is quite reasonable why I have not been able to find it.