### PR TITLE
add crru

### DIFF
--- a/lib/domains/th/ac/crru/365.txt
+++ b/lib/domains/th/ac/crru/365.txt
@@ -1,0 +1,2 @@
+มหาวิทยาลัยราชภัฏเชียงราย
+Chiang Rai Rajabhat University


### PR DESCRIPTION
## Pull Request Comment

Thank you for submitting this pull request!

To the maintainers: 

I propose adding the Chiang Rai Rajabhat University (CRRU) domain to the JetBrains schools list.

Domain: `example@365.crru.ac.th`

CRRU is a well-known educational institution, and their domain follows the format commonly used by other universities in Thailand. Their official website can be found at [https://www.crru.ac.th](https://www.crru.ac.th).

I have confirmed that this domain belongs to the Chiang Rai Rajabhat University and is actively used for their academic email addresses.

Please review and consider merging this pull request to update the JetBrains schools list accordingly.

Thank you!
