### PR TITLE
Update : Please remove utp.edu.pe from the stoplist.txt file.

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -600,7 +600,6 @@ uraccan.edu.ni
 unasam.edu.pe
 stu.ftccollege.edu
 gtc.edu
-utp.edu.pe
 ute.edu.mx
 pace.edu
 unadvirtual.edu.co


### PR DESCRIPTION
I think there was a mistake when adding to the UTP (Universidad Tecnológica del Perú) to the list. If the request is denied, I would appreciate the reason.