### PR TITLE
Re-open PR `Create vnuhn.txt #18005`

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1378,3 +1378,4 @@ duocuc.cl
 cotc.edu
 student.wallacestate.edu
 tecnocomfenalco.edu.co
+live.acibadem.edu.tr


### PR DESCRIPTION
We have recently updated our records with an additional school email domain, and we would like to include it in our JetBrains account for VNUHN. The email domain to be added is @vnuhn.edu.vn . By adding this domain, we aim to provide our VNUHN students with the ability to access JetBrains tools and licenses for educational purposes.

We kindly request your assistance in adding the @vnuhn.edu.vn to our JetBrains account for Vietnam National University, Hanoi (VNUHN). If there are any specific requirements or procedures that need to be followed, please provide us with the necessary instructions or documentation. We value the collaboration between our university and JetBrains, and we are confident that this addition will further enhance the educational experience for our students.