### PR TITLE
Add Sangdang High School

### DIFF
--- a/lib/domains/kr/go/cbe/sangdang-h.txt
+++ b/lib/domains/kr/go/cbe/sangdang-h.txt
@@ -1,0 +1,2 @@
+상당고등학교
+Sangdang High School


### PR DESCRIPTION
- name:
    - (KR) 상당고등학교
    - (EN) Sangdang High School

- official website URL: https://school.cbe.go.kr/sangdang-h