### PR TITLE
Added Vermont State University.

### DIFF
--- a/lib/domains/edu/vermontstate.txt
+++ b/lib/domains/edu/vermontstate.txt
@@ -1,0 +1,1 @@
+Vermont State University

--- a/lib/domains/edu/vsc.txt
+++ b/lib/domains/edu/vsc.txt
@@ -1,4 +1,1 @@
-Castleton State College
-Johnson State College
-Lyndon State College
-Vermont Technical College
+Vermont State Colleges


### PR DESCRIPTION
As of July 1, 2023 several state colleges in Vermont have merged.  Castleton State College, Johnson State College, Lyndon State College, and Vermont Technical College no longer exist. They have combined to form Vermont State University. However, the vsc.edu domain continues to exist as the "Vermont State Colleges" domain. The VSC is (and always has been) an umbrella organization containing the other colleges. In the past the VSC system contained CSC, JSC, LSC, VTC, and the Community College of Vermont. Today the VSC system contains VTSU and continues to contain CCV. For this reason I edited the vsc.txt file rather than outright removed it.

The current VTSU website is: https://vermontstate.edu/.  Unfortunately you might have some trouble finding the detailed evidence you need on that site. It is a "micro" site. The full website for the new university won't go online until October 2023.  However, I'm hoping my students will be able to apply for JetBrains student licenses this fall using their vermontstate.edu email addresses since that email domain is now official.

I teach software engineering at VTSU (formerly I taught for the now non-existent Vermont Technical College). My GitHub identity is using a personal email address that I use for my own software work. However, feel free to reach out to me at peter.chapin@vermontstate.edu if you have any questions or need more information.