### PR TITLE
Add Queen Elizabeth's Grammar School, Derbyshire, UK

### DIFF
--- a/lib/domains/uk/sch/derbyshire/queenelizabeths.txt
+++ b/lib/domains/uk/sch/derbyshire/queenelizabeths.txt
@@ -1,0 +1,1 @@
+Queen Elizabeths Grammar School Ashbourne Academy


### PR DESCRIPTION
School website URL (matches email domain requested): https://www.queenelizabeths.derbyshire.sch.uk/

Computer Science A-Level course (2 years) described on p16 of the sixth-form prospectus available on the school URL: https://www.queenelizabeths.derbyshire.sch.uk/wp-content/uploads/sites/5/2022/10/Sixth-Form-Prospectus-2023-24-web.pdf