### PR TITLE
Added 'The Sheffield College' as a valid domain.

### DIFF
--- a/lib/domains/uk/ac/sheffcol.txt
+++ b/lib/domains/uk/ac/sheffcol.txt
@@ -1,0 +1,1 @@
+The Sheffield College


### PR DESCRIPTION
Institution:
The Sheffield College is a UK based college level institution that offers a variety of qualification levels, among them are university equivalent IT related qualifications (such as ones mentioned below).

Website:
https://www.sheffcol.ac.uk/

Official Email Domain:
@sheffcol.ac.uk

Email Users:
[X] Students
[X] Teachers
[  ] Alumni

Examples of longer term (>1yr) University level IT related courses available:
HNC Computing (2yrs):
https://www.sheffcol.ac.uk/courses/page/8F245574-F215-495C-B58F-C33E0A957907
BA Hons Game Design (3yrs):
https://www.sheffcol.ac.uk/courses/page/FD211490-A2FC-43E0-AC5E-A52F1D7C5D32

Address:
There are many campus' but the main 2 are as follows:
The Sheffield College, City Campus, Granville Road, Sheffield, S2 2RL, UK
Hillsborough Campus, Livesey Street, Sheffield, South Yorkshire, S6 2ET, UK