### PR TITLE
Dennis Gabor University, Budapest

### DIFF
--- a/lib/domains/hu/gde.txt
+++ b/lib/domains/hu/gde.txt
@@ -1,0 +1,1 @@
+Dennis Gabor University, Budapest


### PR DESCRIPTION
Previously added as gdf.hu, became University instead of College this year GDF->GDE

Offical website:
https://gde.hu
Courses (long term, BSc):
https://gde.hu/computer-science-engineering
Teachers with email domain:
https://gde.hu/oktatok