### PR TITLE
Add the Friedrich-Ebert-Gymnasium Bonn

### DIFF
--- a/lib/domains/de/schulen-bn/166364.txt
+++ b/lib/domains/de/schulen-bn/166364.txt
@@ -1,0 +1,1 @@
+Friedrich-Ebert-Gymnasium Bonn


### PR DESCRIPTION
Adds the [Friedrich-Ebert-Gymnasium Bonn](https://feg-bonn.de/b/informatik/). They are a public german learning institution that offer an informatics class over their 8-year curriculum.

Since they are a public institution, the school email system offered to students and teachers alike is offered by the city's (Bonn) IT department, hence why the domain `schulen-bn` and odd subdomain with the school's identifier.

You can confirm the student/teacher email address domain with the IT-responsible teacher michael.barth@feg-bonn.de or the Headteacher at schulleitung@friedrich-ebert-gymnasium.de

Teachers primarily use feg-bonn.de email addresses, but students do not have these, thus I submitted 166364.schulen-bn.de, which is available to both students and teachers.