### PR TITLE
Add TUS - Technical University of the Shannon, Ireland

### DIFF
--- a/lib/domains/ie/tus.txt
+++ b/lib/domains/ie/tus.txt
@@ -1,0 +1,1 @@
+Technological University of the Shannon


### PR DESCRIPTION
Add the Technical University of the Shannon. Ireland