### PR TITLE
add .siswa subdomain of uthm

### DIFF
--- a/lib/domains/my/edu/siswa/uthm.txt
+++ b/lib/domains/my/edu/siswa/uthm.txt
@@ -1,0 +1,1 @@
+Universiti Tun Hussein Onn Malaysia


### PR DESCRIPTION
There is different subdomian for Universiti Tun Hussein Onn Malaysia. There no official documents, the prove i found is from journal publication that having this email format:
https://books.google.com.my/books?id=YxgfEAAAQBAJ&pg=PA379&lpg=PA379&dq=siswa.uthm&source=bl&ots=Xpk7JN7Mvd&sig=ACfU3U2Mq0toKk_7rRFxDQOaQECgmQX06g&hl=en&sa=X&ved=2ahUKEwianLjJv7qAAxUOR2wGHdMhD4IQ6AF6BAgiEAM#v=onepage&q=siswa.uthm&f=false


![siswa uthm prove](https://github.com/JetBrains/swot/assets/53827778/e308d85f-7379-4096-84d7-945ead89f9a8)
