### PR TITLE
Added Kings Tirana faculty and student emails.

### DIFF
--- a/lib/domains/com/kingstirana.txt
+++ b/lib/domains/com/kingstirana.txt
@@ -1,0 +1,1 @@
+Kings Tirana

--- a/lib/domains/net/kingstirana.txt
+++ b/lib/domains/net/kingstirana.txt
@@ -1,0 +1,1 @@
+Kings Tirana


### PR DESCRIPTION
Official website URL, as the .net is used for Google emails (students) while .com is used for Zoho emails (staff): https://kingstirana.com