### PR TITLE
Institut Montana Zugerberg would like a free license 

### DIFF
--- a/lib/domains/lib/domains/ch/montana-zug.txt
+++ b/lib/domains/lib/domains/ch/montana-zug.txt
@@ -1,0 +1,1 @@
+Institut Montana Zugerberg


### PR DESCRIPTION
School website: https://www.montana-zug.ch/en
Document (Curriculum plan) proving my school offers IT courses (sadly, the document is only available in German): [https://montanaschule-my.sharepoint.com/personal/montana_admin_montana-zug_ch/_layouts/15/onedrive.aspx?ga=1&id=%2Fpersonal%2Fmontana%5Fadmin%5Fmontana%2Dzug%5Fch%2FDocuments%2F3%5FSG%5FSchweizersGymnasium%5FSwissSeniorHighSchool%2F21%2D22%5FLehrpläne%2F2021%5F22%5FLehrplan%5FInformatik%2Epdf&parent=%2Fpersonal%2Fmontana%5Fadmin%5Fmontana%2Dzug%5Fch%2FDocuments%2F3%5FSG%5FSchweizersGymnasium%5FSwissSeniorHighSchool%2F21%2D22%5FLehrpläne](https://montanaschule-my.sharepoint.com/personal/montana_admin_montana-zug_ch/_layouts/15/onedrive.aspx?ga=1&id=%2Fpersonal%2Fmontana%5Fadmin%5Fmontana%2Dzug%5Fch%2FDocuments%2F3%5FSG%5FSchweizersGymnasium%5FSwissSeniorHighSchool%2F21%2D22%5FLehrpl%C3%A4ne%2F2021%5F22%5FLehrplan%5FInformatik%2Epdf&parent=%2Fpersonal%2Fmontana%5Fadmin%5Fmontana%2Dzug%5Fch%2FDocuments%2F3%5FSG%5FSchweizersGymnasium%5FSwissSeniorHighSchool%2F21%2D22%5FLehrpl%C3%A4ne)
a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: Do not have such a document at my disposal. The best document I can provide is a picture of a student ID showing the school's domain on it. (As you can see, the school's official info email address is under the same domain)However, as you can see, the school itself is registered under the same domain as the email provided. 
![dc094828-f6e5-46c7-ac03-9d8ce5ea3160 2](https://github.com/JetBrains/swot/assets/97363645/ea6edda4-0432-4c9b-b301-103c426be9fd)
