### PR TITLE
Add Tibshelf Community School

### DIFF
--- a/lib/domains/uk/sch/derbyshire/tibshelfcommunity.txt
+++ b/lib/domains/uk/sch/derbyshire/tibshelfcommunity.txt
@@ -1,0 +1,1 @@
+Tibshelf Community School


### PR DESCRIPTION
Official domain:
https://www.tibshelf.derbyshire.sch.uk/

Relevant IT course lasting longer than 1 year:
https://www.tibshelf.derbyshire.sch.uk/page/?title=Computer+Science&pid=78

Page with recognition of .sch.uk domain name in email addresses:
https://www.tibshelf.derbyshire.sch.uk/page/?title=How+to+get+in+touch&pid=99

Student email login portal:
https://outlook.com/students.tibshelf.derbyshire.sch.uk