### PR TITLE
Add Kaplan Business School

### DIFF
--- a/lib/domains/au/edu/kbs.txt
+++ b/lib/domains/au/edu/kbs.txt
@@ -1,0 +1,1 @@
+Kaplan Business School


### PR DESCRIPTION
Add the latest domain name for Kaplan Business school - kbs.edu.au  Existing one is kaplanstudent.edu.au.