### PR TITLE
Add zstu and zjgsu

### DIFF
--- a/lib/domains/cn/edu/zjgsu/mail.txt
+++ b/lib/domains/cn/edu/zjgsu/mail.txt
@@ -1,0 +1,2 @@
+Zhejiang Gongshang University
+浙江工商大学

--- a/lib/domains/cn/edu/zstu.txt
+++ b/lib/domains/cn/edu/zstu.txt
@@ -1,0 +1,2 @@
+Zhejiang Sci-Tech University
+浙江理工大学

--- a/lib/domains/cn/edu/zstu/mails.txt
+++ b/lib/domains/cn/edu/zstu/mails.txt
@@ -1,0 +1,2 @@
+Zhejiang Sci-Tech University
+浙江理工大学


### PR DESCRIPTION
[zstu](https://www.zstu.edu.cn/): A university in Zhejiang province that provides programs in the fields of engineering, sciences, humanities (arts), economics, management and law with engineering being its main focus. It is run jointly by [Ministry of Education](https://en.wikipedia.org/wiki/Ministry_of_Education_of_the_People%27s_Republic_of_China) and the Zhejiang provincial government, the latter being the main administrative body.
Note: The English site is temporarily down but can be visited through [Wayback Machine](https://web.archive.org/web/english.zstu.edu.cn)
[zjgsu](http://www.zjgsu.edu.cn/): A public higher educational institution that focuses on the fields of social science.The university is administrated by Zhejiang Province. "Zhejiang" is the province where the university is and "Gongshang" is the Chinese pronunciation of two words meaning "Industry and Business".
