### PR TITLE
Add the "Friedrich-List-Schule"

### DIFF
--- a/lib/domains/de/fls-hi.txt
+++ b/lib/domains/de/fls-hi.txt
@@ -1,0 +1,2 @@
+Friedrich-List-Schule Hildesheim
+Friedrich-List-School Hildesheim


### PR DESCRIPTION
[Website](https://www.fls-hi.de/vollzeitschulen/sie-haben-bereits-erworben/realschulabschluss.html?view=article&id=1241:einj%C3%A4hrigebfsrealschulabsolventen&catid=10:vollzeitschulen)

[(Google-Translate)](https://www-fls--hi-de.translate.goog/vollzeitschulen/sie-haben-bereits-erworben/realschulabschluss.html?view=article&id=1241:einj%C3%A4hrigebfsrealschulabsolventen&catid=10:vollzeitschulen&_x_tr_sl=de&_x_tr_tl=ru&_x_tr_hl=de&_x_tr_pto=wapp)