### PR TITLE
add zstu

### DIFF
--- a/lib/domains/cn/edu/zstu.txt
+++ b/lib/domains/cn/edu/zstu.txt
@@ -1,0 +1,2 @@
+Zhejiang Sci-Tech University
+浙江理工大学

--- a/lib/domains/cn/edu/zstu/mails.txt
+++ b/lib/domains/cn/edu/zstu/mails.txt
@@ -1,2 +1,0 @@
-Zhejiang Sci-Tech University
-浙江理工大学

--- a/lib/domains/cn/edu/zstu/mails.txt
+++ b/lib/domains/cn/edu/zstu/mails.txt
@@ -1,0 +1,2 @@
+Zhejiang Sci-Tech University
+浙江理工大学


### PR DESCRIPTION
[zstu](https://www.zstu.edu.cn/): A university in Zhejiang province that provides programs in the fields of engineering, sciences, humanities (arts), economics, management and law with engineering being its main focus. It is run jointly by Ministry of Education and the Zhejiang provincial government, the latter being the main administrative body.
Note the English site is temporarily down but can be visited through [Wayback Machine](https://web.archive.org/web/english.zstu.edu.cn)