### PR TITLE
Add Institut Teknologi Bandung

### DIFF
--- a/lib/domains/id/ac/itb/mahasiswa.txt
+++ b/lib/domains/id/ac/itb/mahasiswa.txt
@@ -1,0 +1,1 @@
+Institut Teknologi Bandung

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -696,7 +696,6 @@ hbtcm.edu.cn
 campusucc.edu.co
 student.utem.edu.my
 pucgo.edu.br
-mahasiswa.itb.ac.id
 case.edu
 uncp.edu.pe
 edu.azores.gov.pt
@@ -747,7 +746,6 @@ xy.hbuas.edu.cn
 colegio-venecia.edu.mx
 hust.edu.vn
 o6u.edu.eg
-mahasiswa.itb.ac.id
 s.unikl.edu.my
 oshs.edu.ba
 email.zzuli.edu.cn


### PR DESCRIPTION
Good day, JetBrains Team!

I was trying to renew my Jetbrains student licence today when I noticed that I could no longer do so using my university email. After investigating, I figured out that the domain `mahasiswa.itb.ac.id` has been added to the stoplist quite recently. Considering the institution related to this domain has never been added to this repository, I thought I'd open a PR for consideration.

Institut Teknologi Bandung (Bandung Institute of Technology, will be referred to as ITB for the rest of this PR) is the oldest technology-focused education institution in Indonesia. Per ITB's Directorate of Information Technology, the ownership of an email with `mahasiswa.itb.ac.id` as its domain is a proof of identity that the owner is a student in ITB [1]. The email will be active as long as the owner is studying at ITB and will be revoked upon graduation [2].

For ease of review, the institute's official website can be accessed via https://www.itb.ac.id/. The institute integrates information technology education into all of the undergraduate, graduate, and doctorate program that it offers. One of the study program in which this is cannot be more true is Sekolah Teknik Elektro dan Informatika (School of Electrical Engineering and Informatics), more information about it can be accessed via https://stei.itb.ac.id/.

Obviously, the domain has been added to the stoplist for a reason. Hopefully even if this PR is rejected, a more detailed explanation for the stoplist addition can be presented. Thank you for your time.

[1] https://dti.itb.ac.id/email-mahasiswa/
[2] https://dti.itb.ac.id/en/microsoft-office-365/, point 3.A