### PR TITLE
Adding GRETB

### DIFF
--- a/lib/domains/ie/gretb.txt
+++ b/lib/domains/ie/gretb.txt
@@ -1,0 +1,2 @@
+Galway & Roscommon Educational Training Board
+GRETB


### PR DESCRIPTION
Adding GRETB as a vocational school (regional Irish college that provides further education): https://gretb.ie & https://gretb.ie/further-education-training/course-finder/?search=1&view=0