### PR TITLE
Add zst Radom (Zespół Szkół Technicznych im. Tadeusza Kościuszki w Radomiu) from Poland

### DIFF
--- a/lib/domains/pl/edu/zst-radom.txt
+++ b/lib/domains/pl/edu/zst-radom.txt
@@ -1,0 +1,1 @@
+Zespół Szkół Technicznych im. Tadeusza Kościuszki w Radomiu


### PR DESCRIPTION
Please add Zespół Szkół Technicznych
im. Tadeusza Kościuszki w Radomiu to school list
School Official Website: https://zst-radom.edu.pl/
School Location: City: Radom, Street: Bolesława Limanowskiego 26/30, Country: Poland
School offers long-term course (5 years): https://zst-radom.edu.pl/index.php/kierunki-ksztalcenia-2/

Major courses offered at the school associated with computer science are:

technik informatyk(IT technician)

technik programista(programmer technician).

Students & Teacher email domain: zst.radom.pl