### PR TITLE
Quy Nhon University - (Viet Nam)

### DIFF
--- a/lib/domains/vn/edu/qnu/st.txt
+++ b/lib/domains/vn/edu/qnu/st.txt
@@ -1,0 +1,1 @@
+Quy Nhon University


### PR DESCRIPTION
Please add Quy Nhon University to the school list
School Official Website: https://qnu.edu.vn/
School Location: 170 An Duong Vuong street, Quy Nhon City, Viet Nam Country