### PR TITLE
Added Tangen domain and updated Agderskolen description.

### DIFF
--- a/lib/domains/no/agderskolen.txt
+++ b/lib/domains/no/agderskolen.txt
@@ -1,0 +1,1 @@
+Agder Fylkeskommune

--- a/lib/domains/no/agderskolen/elev.txt
+++ b/lib/domains/no/agderskolen/elev.txt
@@ -1,1 +1,1 @@
-Agder Fylkeskommune
+Aust Agder Fylkeskommune

--- a/lib/domains/no/agderskolen/elev.txt
+++ b/lib/domains/no/agderskolen/elev.txt
@@ -1,1 +1,1 @@
-Aust Agder Fylkeskommune
+Agder Fylkeskommune

--- a/lib/domains/no/vgs/tangen.txt
+++ b/lib/domains/no/vgs/tangen.txt
@@ -1,0 +1,1 @@
+Tangen Vidregående skoles

--- a/lib/domains/no/vgs/tangen.txt
+++ b/lib/domains/no/vgs/tangen.txt
@@ -1,1 +1,1 @@
-Tangen Vidregående skoles
+Tangen Vidregående Skole


### PR DESCRIPTION
The Aust Agder and Vest Agder county in Norway has been combined and is now called Agder. All highschool studens in this new county are now included in this domain.

Tangen is located in Agder. The tangen domain is exclusivly for the employees of Tangen highschool. Our students is part of hte Agderskolen domain.