### PR TITLE
change Centro Universitário 7 de Setembro (University Center September 7)

### DIFF
--- a/lib/domains/br/com/sempreuni7.txt
+++ b/lib/domains/br/com/sempreuni7.txt
@@ -1,0 +1,2 @@
+Centro Universitário 7 de Setembro
+University Center September 7

--- a/lib/domains/br/edu/uni7.txt
+++ b/lib/domains/br/edu/uni7.txt
@@ -1,2 +1,0 @@
-Centro Universitário 7 de Setembro
-University Center September 7


### PR DESCRIPTION
Modified from "uni7.edu.br" to "sempreuni7.com.br".