### PR TITLE
Add more info about mymdc.net

### DIFF
--- a/lib/domains/net/mymdc.txt
+++ b/lib/domains/net/mymdc.txt
@@ -1,1 +1,6 @@
 Miami Dade College
+
+http://email.mymdc.net
+
+https://www.mdc.edu/
+


### PR DESCRIPTION
I hope that this information will whitelist the domain mymdc.net since it's different from the college portal domain. 
The domain http://email.mymdc.net is hosted in the https://www.mdc.edu/.