### PR TITLE
Manado Eben Haezar School of Economics

### DIFF
--- a/lib/domains/ng/edu/stiebenzar.txt
+++ b/lib/domains/ng/edu/stiebenzar.txt
@@ -1,0 +1,2 @@
+Sekolah Tinggi Ilmu Ekonomi Eben Haezar Manado
+Manado Eben Haezar School of Economics


### PR DESCRIPTION
Sekolah Tinggi Ilmu Ekonomi Eben Haezar Manado / Manado Eben Haezar School of Economics
Official Site: https://stiebenzar.ac.id/
Address: Jl. Diponegoro No.04, Mahakeret Bar., Kec. Wenang, Kota Manado, Sulawesi Utara PO BOX 95112