### PR TITLE
Add Shandong University

### DIFF
--- a/lib/domains/cn/edu/sdu/mail.txt
+++ b/lib/domains/cn/edu/sdu/mail.txt
@@ -1,0 +1,1 @@
+Shandong University


### PR DESCRIPTION
I've added Shandong University to the repository, whose email domain is email.sdu.edu.cn. The official website of Shandong University is https://www.sdu.edu.cn/. From the website https://www.bkjx.sdu.edu.cn/info/1070/34774.htm, it can be seen that the professional courses offered by Shandong University include Computer Science and Technology (计算机科学与技术 in Chinese) and other IT related courses, which last for four years. The method of applying for Shandong University email is specified in the document https://nc.sdu.edu.cn/pdf/xxhfwznxsb.pdf, in which the description that "The default email username is the student ID"(用户名：学生学号 in Chinese) and that "After graduation, the permission to use the student email will be automatically revoked"(学生毕业后，学生邮箱的使用权限将被自动收回 in Chinese) shows that Shandong University recognizes email.sdu.edu.cn as an official email domain for the enrolled students.