### PR TITLE
Create oregoncs.txt

### DIFF
--- a/lib/domains/org/oregoncs.txt
+++ b/lib/domains/org/oregoncs.txt
@@ -1,0 +1,2 @@
+Oregon City Schools
+  Located in Oregon, OH


### PR DESCRIPTION
The actual website is hosted at oregoncityschools.org, but GSuite and emails use the oregoncs.org domain.