### PR TITLE
Adding Tribhuvan University

### DIFF
--- a/lib/domains/tu/bkmc.txt
+++ b/lib/domains/tu/bkmc.txt
@@ -1,0 +1,1 @@
+Bhaktapur Multiple Campus -Tribhuvan University

--- a/lib/domains/tu/bkmc.txt
+++ b/lib/domains/tu/bkmc.txt
@@ -1,1 +1,0 @@
-Bhaktapur Multiple Campus -Tribhuvan University

--- a/lib/domains/tu/bkmc.txt
+++ b/lib/domains/tu/bkmc.txt
@@ -1,0 +1,2 @@
+Tribhuvan University
+Tribhuvan University


### PR DESCRIPTION
Domain: tu.edu.np
[Tribhuvan University](https://tu.edu.np/)
[Bhaktapur Multiple Campus](https://bmcbkt.edu.np/site/)
[Institute of science and technology of Tribhuvan University IOST](https://iost.tu.edu.np/)
The picture as a proof of bhaktapur multiple campus as a constituent collegees of TU-IOST where program such as CSIT (computer science and information technology) and BIT (bachelors in information technology) are included
![image](https://github.com/JetBrains/swot/assets/50907501/72f1b755-4c66-441a-821b-ea8612af848a)
