### PR TITLE
Add COBAEJ (Colegio de bachilleres del estado de Jalisco)

### DIFF
--- a/lib/domains/mx/edu/cobaej.txt
+++ b/lib/domains/mx/edu/cobaej.txt
@@ -1,0 +1,1 @@
+Colegio de Bachilleres del Estado de Jalisco Plantel 15


### PR DESCRIPTION
COBAEJ is a high school.
Our school offers training in computer science, where we teach our students about programming.
https://cobaej.edu.mx/directorio?type=academic-offer