### PR TITLE
Add BINUS University

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -887,7 +887,6 @@ dartmouth.edu
 uy.edu.mm
 est.umet.edu.ec
 fh.unair.ac.id
-binus.ac.id
 cit.edu
 dpu.ac.th
 puccampinas.edu.br


### PR DESCRIPTION
Good day,

Few months ago `binus.ac.id` domain got added to the stoplist.txt, and in
#18026 the request to add the domain back got rejected by @philipto due
to:
> the school allows to register an email address there even if you are
not a student of the school.

This is not true since people couldn't just randomly register to get this
email, and i hope that Jetbrain team could look into this. And if it said
so, please tell me IN which part the it allows someone to register, my email
is always open if you don't like to share it here. I asked this because i
don't understand on where you guys got that information from, since 
the email only is given when the person has been accepted as a student 
of the university.

It is also explained [here](https://support.binus.ac.id/article/bagaimana-cara-mendapatkan-username-atau-email-binus-ac-id/) (which you can translate) on how student could 
get their email. Where it's shown that they have to enter their `Student ID`
which is given by the university after they got accepted as a student, which
includes paying the tuition fee, pass the test, etc.

Thank You.