### PR TITLE
Reconsider adding student.chula.ac.th

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -859,7 +859,6 @@ bub.edu.bh
 correo.uis.edu.co
 etudiant.edcparis.edu
 archten.croydon.sch.uk
-student.chula.ac.th
 sharjah.ac.ae
 alumno.uaemex.mx
 mail.imu.edu.cn
@@ -1600,7 +1599,6 @@ post.bgu.ac.il
 unibge.hu
 moestudents.edu.kn
 nvsu.edu.ph
-chula.ac.th
 student.utcb.ro
 mhs.its.ac.id
 moe.edu.kn
@@ -1662,3 +1660,4 @@ alunos.ipb.pt
 fmed.uc.pt
 gregorianschool.edu.in
 rgi.edu.in
+alumni.chula.ac.th

--- a/lib/domains/th/ac/chula.txt
+++ b/lib/domains/th/ac/chula.txt
@@ -1,1 +1,0 @@
-Chulalongkorn University

--- a/lib/domains/th/ac/chula/student.txt
+++ b/lib/domains/th/ac/chula/student.txt
@@ -1,1 +1,2 @@
+จุฬาลงกรณ์มหาวิทยาลัย
 Chulalongkorn University


### PR DESCRIPTION
Chulalongkorn University offers wide-range of long term courses including courses related to IT and was approved in PR #14504. However, it was added to `lib/domains/stoplist.txt` in https://github.com/JetBrains/swot/commit/f640886a4cf42495ae62746f2f1c6c0be72352f3 and https://github.com/JetBrains/swot/commit/a6d7a02c8841a3a5f7c7682d00d2bc957783770e

Here are some reasons I think that it may cause confusions for frauds:

1.  `student.chula.ac.th` is the email provided for **current students** of Chulalongkorn University.[1] Upon their graduation, their email will be transferred to the domain `alumni.chula.ac.th`[2]
2.  `chula.ac.th` is the email provided for both teaching and non-teaching staff of the university.[3] The university does not allow just *anyone* to register their email on the domain. There was no ill-intentioned for the domain as this domain was added in the original upstream repo of this repository. (https://github.com/leereilly/swot/blob/master/lib/domains/th/ac/chula.txt)

Please let me know if there's any official document I can provide to prove the legitimacy of the email.

[1] https://www.it.chula.ac.th/en/service/en-email-nisit/
[2] https://www.it.chula.ac.th/new-account-domain-2564/ (2021 Announcement for email transfer in Thai.); https://www.it.chula.ac.th/en/service/en-office365/ (This article includes the usage of alumni email in English.)
[3] https://www.it.chula.ac.th/en/service/en-email-personal/