### PR TITLE
Add David-Roentgen-Schule Neuwied

### DIFF
--- a/lib/domains/de/drsneuwied.txt
+++ b/lib/domains/de/drsneuwied.txt
@@ -1,0 +1,1 @@
+David-Roentgen-Schule Neuwied

--- a/lib/domains/de/drsschueler.txt
+++ b/lib/domains/de/drsschueler.txt
@@ -1,0 +1,1 @@
+David-Roentgen-Schule Neuwied


### PR DESCRIPTION
Page of the school: https://www.drsneuwied.de/
Page of the long term it course: https://www.drsneuwied.de/index.php/bildungsangebote/berufsschule/it-berufe/fachinformatikerin (We have "Ausbildung" in germany, which is 3 years long by default.)
Proof that drsschueler.de is also part of the school: Is there a good way I can proof that without doxxing myself? 😅I have Outlook and MS Teams, which *could* be used as screenshots, but what part do you need as proof?

Background-Information about the 2 domains:
Teacher emails use drsneuwied.de and students use drsschueler.de. Sadly the website doesn't show any students mails, which is why I can't link the page to proof that.