### PR TITLE
Remove `chula.ac.th` from stroplist

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -859,7 +859,6 @@ bub.edu.bh
 correo.uis.edu.co
 etudiant.edcparis.edu
 archten.croydon.sch.uk
-student.chula.ac.th
 sharjah.ac.ae
 alumno.uaemex.mx
 mail.imu.edu.cn
@@ -1599,7 +1598,6 @@ post.bgu.ac.il
 unibge.hu
 moestudents.edu.kn
 nvsu.edu.ph
-chula.ac.th
 student.utcb.ro
 mhs.its.ac.id
 moe.edu.kn

--- a/lib/domains/th/ac/chula.txt
+++ b/lib/domains/th/ac/chula.txt
@@ -1,1 +1,2 @@
 Chulalongkorn University
+จุฬาลงกรณ์มหาวิทยาลัย

--- a/lib/domains/th/ac/chula/student.txt
+++ b/lib/domains/th/ac/chula/student.txt
@@ -1,1 +1,2 @@
 Chulalongkorn University
+จุฬาลงกรณ์มหาวิทยาลัย

--- a/lib/domains/tlds.txt
+++ b/lib/domains/tlds.txt
@@ -16,6 +16,7 @@ ac.pr
 ac.ru
 ac.rw
 ac.sz
+ac.th
 ac.yu
 ac.za
 ac.zm


### PR DESCRIPTION
Fixing PR #18482 for invalid `lib/domains/stoplist.txt` format