### PR TITLE
Register marsk12.org as school domain

### DIFF
--- a/lib/domains/org/marsk12.txt
+++ b/lib/domains/org/marsk12.txt
@@ -1,0 +1,1 @@
+Mars Area School District, Mars, PA, U.S.


### PR DESCRIPTION
It is the domain for the Mars Area School District (located in Mars, PA).