### PR TITLE
Karabuk University student subdomain added.

### DIFF
--- a/lib/domains/tr/edu/karabuk/ogrenci
+++ b/lib/domains/tr/edu/karabuk/ogrenci
@@ -1,2 +1,0 @@
-Karabük Üniversitesi
-Karabük University

--- a/lib/domains/tr/edu/karabuk/ogrenci
+++ b/lib/domains/tr/edu/karabuk/ogrenci
@@ -1,0 +1,2 @@
+Karabük Üniversitesi
+Karabük University

--- a/lib/domains/tr/edu/karabuk/ogrenci.txt
+++ b/lib/domains/tr/edu/karabuk/ogrenci.txt
@@ -1,0 +1,2 @@
+Karabük Üniversitesi
+Karabük University


### PR DESCRIPTION
ogrenci.karabuk.edu.tr added. ogrenci is equal to stud in Turkey Karabuk University.