### PR TITLE
Change domain of zst Radom (Zespół Szkół Technicznych im. Tadeusza Kościuszki w Radomiu) from Poland 

### DIFF
--- a/lib/domains/pl/edu/zst-radom.txt
+++ b/lib/domains/pl/edu/zst-radom.txt
@@ -1,1 +1,0 @@
-Zespół Szkół Technicznych im. Tadeusza Kościuszki w Radomiu

--- a/lib/domains/pl/radom/zst.txt
+++ b/lib/domains/pl/radom/zst.txt
@@ -1,0 +1,1 @@
+Zespół Szkół Technicznych im. Tadeusza Kościuszki w Radomiu


### PR DESCRIPTION
Please change domain of Zespół Szkół Technicznych
im. Tadeusza Kościuszki w Radomiu school
School Official Website: https://zst-radom.edu.pl/
School Location: City: Radom, Street: Bolesława Limanowskiego 26/30, Country: Poland
School offers long-term course (5 years): https://zst-radom.edu.pl/index.php/kierunki-ksztalcenia-2/

Major courses offered at the school associated with computer science are:

technik informatyk(IT technician)

technik programista(programmer technician).

Students & Teachers email domain: zst.radom.pl