### PR TITLE
Add students' mail domain .smail of Nanjing University.

### DIFF
--- a/lib/domains/cn/edu/nju/smail.txt
+++ b/lib/domains/cn/edu/nju/smail.txt
@@ -1,0 +1,2 @@
+南京大学
+Nanjing University 


### PR DESCRIPTION
The university official website URL: www.nju.edu.cn
A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://cs.nju.edu.cn/xyfeng/teaching/SICP/index.htm
A URL of a page showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://itsc.nju.edu.cn/1b/ce/c21586a334798/page.htm

P.S. the domain of our school (.nju.edu.cn) was banned for some reason. However, this subdomain (smail.nju.edu.cn) is the only domain used for students' mailbox now that can not be issued for any other individuals.