### PR TITLE
Add Saint Michel des Batignolles

### DIFF
--- a/lib/domains/fr/es-be.txt
+++ b/lib/domains/fr/es-be.txt
@@ -1,0 +1,1 @@
+Saint Michel des Batignolles

--- a/lib/domains/net/es-be.txt
+++ b/lib/domains/net/es-be.txt
@@ -1,0 +1,1 @@
+Saint Michel des Batignolles


### PR DESCRIPTION
My school uses `es-be.net` for my email but `es-be.fr` for their website.

Website : https://es-be.fr/lycee-saint-michel/

IT Course : https://es-be.fr/wp-content/uploads/2021/05/Combinaisons-des-sp%C3%A9cialit%C3%A9s-en-classe-de-1%C3%A8re-%C3%A0-SMDB.png
> "NSI" stands for _Numérique et sciences informatiques_ which means _Digital and computer sciences_

Email Domain Proof : 
![Couldn't find better...](https://github.com/JetBrains/swot/assets/77689281/3651c5aa-cdda-406c-ac5a-5be05068a356)
I couldn't find a better proof but I can attach other screenshots if needed.