### PR TITLE
Added Student Email for Sabahattin Zaim University

### DIFF
--- a/lib/domains/tr/edu/izu/std.txt
+++ b/lib/domains/tr/edu/izu/std.txt
@@ -1,0 +1,2 @@
+İstanbul Sabahattin Zaim Üniversitesi
+İstanbul Sabahattin Zaim University


### PR DESCRIPTION
Personal email already exist as ; /tr/edu/izu.txt
But student email domain is different from personal domain.
proofs;
https://izu.edu.tr/uluslararasi/erasmus/%C3%B6%C4%9Frenci-hareketlili%C4%9Fi/i-z%C3%BC-%C3%B6%C4%9Frencisi/staj-hareketliligi/nas%C4%B1l-ba%C5%9Fvurulur 
https://www.izu.edu.tr/en/international/erasmus/erasmus-coordinatorship/erasmus-student-club/contact https://www.izu.edu.tr/docs/default-source/international/outlooktum.pdf