### PR TITLE
Add St Swithun's

### DIFF
--- a/lib/domains/com/stswithuns.txt
+++ b/lib/domains/com/stswithuns.txt
@@ -1,0 +1,1 @@
+St Swithun's


### PR DESCRIPTION
This domain belongs to St Swithun's, a secondary school and sixth form college based in Winchester, UK. The school offers computing courses and has a physical site with over 700 students in attendance. It is recognised by the UK government as an official education establishment.

> Website: https://stswithuns.com/
> Government confirmation: https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/116534