### PR TITLE
Add Boiko School domain

### DIFF
--- a/lib/domains/ua/com/boiko.txt
+++ b/lib/domains/ua/com/boiko.txt
@@ -1,0 +1,2 @@
+Харківський приватний навчально-виховний комплекс "Авторська школа Бойка" Харківської області
+Kharkiv educational complex institution "Boiko English Private School"


### PR DESCRIPTION
https://boiko.top/ is the official website.
You can also check the information provided by https://kh.isuo.org/schools/view/id/11711.