### PR TITLE
Nord Anglia International School Dubai Addition

### DIFF
--- a/lib/domains/ae/nasdubai.txt
+++ b/lib/domains/ae/nasdubai.txt
@@ -1,0 +1,1 @@
+Nord Anglia International School Dubai


### PR DESCRIPTION
Added to .ae domains. https://nasdubai.ae for school website and more information.