### PR TITLE
- Added top level domain for must

### DIFF
--- a/lib/domains/ke/ac/must.txt
+++ b/lib/domains/ke/ac/must.txt
@@ -1,0 +1,1 @@
+Meru University of Science and Technology


### PR DESCRIPTION
University official website URL

> https://www.must.ac.ke/

URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university

> https://sci.must.ac.ke/bachelor-of-science-in-computer-science/

URL of a page showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.

> https://research.must.ac.ke/about-6/
The above url redirects to research page where the email is provided. The email has a domain for the university