### PR TITLE
Added  cogna.com.br domain

### DIFF
--- a/lib/domains/br/com/cogna.txt
+++ b/lib/domains/br/com/cogna.txt
@@ -1,0 +1,2 @@
+Cogna Educação
+Cogna Education


### PR DESCRIPTION
The cogna.com.br is a conglomeration of universities, and the teachers don't have more email for specific domain of universities.