### PR TITLE
Added cirencester

### DIFF
--- a/lib/domains/uk/ac/cirencester.txt
+++ b/lib/domains/uk/ac/cirencester.txt
@@ -1,0 +1,1 @@
+Cirencester College


### PR DESCRIPTION
Added cirencester.ac.uk domain. A college in South West England.