### PR TITLE
Update East Side Union High School District

### DIFF
--- a/lib/domains/org/esuhsd.txt
+++ b/lib/domains/org/esuhsd.txt
@@ -1,0 +1,2 @@
+East Side Union High School District
+.group

--- a/lib/domains/org/esuhsd/students.txt
+++ b/lib/domains/org/esuhsd/students.txt
@@ -1,2 +1,0 @@
-East Side Union High School District
-.group


### PR DESCRIPTION
Makes all subdomains available for East Side Union High School District. Previously, only the student subdomain was included, which left the educators out.

Domain: [esuhsd.org](https://www.esuhsd.org)