### PR TITLE
Add - Jubail Industrial College

### DIFF
--- a/lib/domains/sa/edu/rcjy.txt
+++ b/lib/domains/sa/edu/rcjy.txt
@@ -1,0 +1,2 @@
+كلية الجبيل الصناعية
+Jubail Industrial College


### PR DESCRIPTION
rcjy.edu.sa is associated with teachers and students of Jubail Industrial College
There are programs for a Bachelor's degree in Computer Science and a Diploma in Information Technology majors