### PR TITLE
Added latest University of Toronto domain

### DIFF
--- a/lib/domains/ca/utoronto/mail.txt
+++ b/lib/domains/ca/utoronto/mail.txt
@@ -1,0 +1,6 @@
+University of St. Michael's College
+University of Toronto
+University of Toronto, Mississauga
+University of Toronto, Scarborough
+University of Trinity College
+Victoria University Toronto, University of Toronto


### PR DESCRIPTION
Student email services were migrated to Office 365 in December 2017 and are since available at the domain @mail.utoronto.ca. I'm surprised this hasn't been updated earlier. See https://easi.its.utoronto.ca/shared-services/office365/utmail/utmail-for-students/ and https://help.learn.utoronto.ca/hc/en-us/articles/115004479953-Office-365-Accessing-your-UTORONTO-email-