### PR TITLE
Update Indian Institute of Chemical Biology (IICB), CSIR

### DIFF
--- a/lib/domains/in/csiriicb.txt
+++ b/lib/domains/in/csiriicb.txt
@@ -1,1 +1,1 @@
-CSIR-Indian Institute of Chemical Biology
+Indian Institute of Chemical Biology (IICB), CSIR


### PR DESCRIPTION
Makes all subdomains available for Indian Institute of Chemical Biology (IICB), CSIR.