### PR TITLE
Add osrw.de

### DIFF
--- a/lib/domains/de/osrw.txt
+++ b/lib/domains/de/osrw.txt
@@ -1,0 +1,1 @@
+Oberschule Rauschwalde Görlitz


### PR DESCRIPTION
School Name:
Oberschule Rauschwalde Görlitz

School Website:
[osrw.de](https://osrw.de)

Education Level: High School or equivalent