### PR TITLE
Adding Miva Open University latest domain.

### DIFF
--- a/lib/domains/university/miva.txt
+++ b/lib/domains/university/miva.txt
@@ -1,0 +1,1 @@
+Miva Open University


### PR DESCRIPTION
Official website: https://miva.university/
Page for a 4-year programme: https://miva.university/bsc-in-computer-science/
