### PR TITLE
Adds Harvard Westlake School

### DIFF
--- a/lib/domains/com/hw.txt
+++ b/lib/domains/com/hw.txt
@@ -1,0 +1,1 @@
+Harvard Westlake

--- a/lib/domains/com/hwemail.txt
+++ b/lib/domains/com/hwemail.txt
@@ -1,0 +1,1 @@
+Harvard Westlake


### PR DESCRIPTION
@hw.com is used for teachers and @hwemail.com is used for students. There is no site hosted at hwemail.com, but there are detailed whois records: https://www.whois.com/whois/hwemail.com