### PR TITLE
Requested Fakultas Teknik UMT domain

### DIFF
--- a/lib/domains/id/ac/ft-umt.txt
+++ b/lib/domains/id/ac/ft-umt.txt
@@ -1,0 +1,2 @@
+Universitas Muhammadiyah Tangerang
+Muhammadiyah University of Tangerang


### PR DESCRIPTION
Requested to add new Education Institution domain called "@ft-umt.ac.id"

UMT stands for Universitas Muhammadiyah Tangerang or Muhammadiyah University of Tangerang in english, UMT is a university located in Tangerang City, Banten, Indonesia.

FT stands for Fakultas Teknik or Engineering Faculty in english.

UMT is registered under the Ministry of Education, Culture, Research, and Technology of Indonesia.

Official site : https://umt.ac.id/ft/