### PR TITLE
Added Centro de Enseñanza Tecnica Industrial

### DIFF
--- a/lib/domains/mx/com/ceti.txt
+++ b/lib/domains/mx/com/ceti.txt
@@ -1,0 +1,2 @@
+Centro de Enseñanza Tecnica Industrial
+Centro de Enseñanza Tecnica Industrial


### PR DESCRIPTION
In this commit, we have incorporated Centro de Enseñanza Tecnica Industrial into the existing list of schools. This update enhances the comprehensiveness of our educational institution data, ensuring that our users have access to a more comprehensive and accurate resource.