### PR TITLE
Create ndlp.txt

### DIFF
--- a/lib/domains/fr/ndlp.txt
+++ b/lib/domains/fr/ndlp.txt
@@ -1,0 +1,1 @@
+Lycée Notre-Dame de La Paix


### PR DESCRIPTION
Added Lycée Notre Dame de La Paix (France)
[Official website ](https://saintlouis-lapaix.com/lycee-la-paix/)
[Link to the the high education IT program](https://saintlouis-lapaix.com/lycee-la-paix/enseignement-superieur/bts-sio-services-informatiques-aux-organisations/)
It's [a French official 2-years diploma](https://en.wikipedia.org/wiki/Brevet_de_technicien_sup%C3%A9rieur) (BTS SIO).
domain is ndlp.fr