### PR TITLE
Add ESAD to fr domains

### DIFF
--- a/lib/domains/fr/esad-pyrenees.txt
+++ b/lib/domains/fr/esad-pyrenees.txt
@@ -1,0 +1,2 @@
+École supérieure d'art et de design des Pyrénées
+Pyrenees College of Art and Design


### PR DESCRIPTION
Add ESAD to the french domains

ESAD (Ecole supérieur d'art et de design des Pyrénées => Pyrenees College of Art and Design) is a public institution of higher artistic education whose studies lead to national diplomas.

The school's curriculum includes courses in design and web-design in particular, with students developing web and programming projects.

Here is the school's [website](https://esad-pyrenees.fr/) and the [Wikipedia page](https://fr.wikipedia.org/wiki/%C3%89cole_sup%C3%A9rieure_d'art_et_de_design_des_Pyr%C3%A9n%C3%A9es), both in French