### PR TITLE
Add Gymnasium Lerbermatt and Neufeld

### DIFF
--- a/lib/domains/ch/gymneufeld.txt
+++ b/lib/domains/ch/gymneufeld.txt
@@ -1,0 +1,1 @@
+Gymnasium Neufeld, Switzerland

--- a/lib/domains/ch/lerbermatt.txt
+++ b/lib/domains/ch/lerbermatt.txt
@@ -1,0 +1,1 @@
+Gymnasium Lerbermatt, Switzerland


### PR DESCRIPTION
Hi

While I don't have professional affiliations with both institutions these days I used to work for both and thus know them. They are (with minor differences) following the same curriculum in the canton of Bern, Switzerland as institutions already registered using the following domains:

* gymkirchenfeld.ch
* mygymer.ch
* gymburgdorf.ch
* stud.gymthun.ch

| Institution | Official websites | Computer Science Courses |
| ---------- | ---------- | ---------- |
| Gymnasium Neufeld | https://www.gymneufeld.ch/ | https://gymneufeld.ch/gymnasium/bildungsangebot/ |
| Gymnasium Lerbermatt | https://www.lerbermatt.ch/ | https://informatik.lerbermatt.ch/ |

I hope I got everything right