### PR TITLE
Add King's School Grantham

### DIFF
--- a/lib/domains/uk/sch/lincs/kings.txt
+++ b/lib/domains/uk/sch/lincs/kings.txt
@@ -1,0 +1,2 @@
+The King's School Grantham
+The King's School Grantham


### PR DESCRIPTION
Main website: https://kings.lincs.sch.uk/

TKSG is not only a secondary school, higher courses in Computer Science are provided: https://kings.lincs.sch.uk/computingalevel