### PR TITLE
Bushey Meads Secondary School, UK

### DIFF
--- a/lib/domains/uk/org/busheymeads.txt
+++ b/lib/domains/uk/org/busheymeads.txt
@@ -1,0 +1,1 @@
+Bushey Meads School


### PR DESCRIPTION
Add Bushey Meads Secondary School which is based in Bushey, Hertfordshire

https://busheymeads.org.uk/