### PR TITLE
Add gghi.de

### DIFF
--- a/lib/domains/de/gghi.txt
+++ b/lib/domains/de/gghi.txt
@@ -1,0 +1,1 @@
+Goethegymnasium Hildesheim


### PR DESCRIPTION
* official website: https://www.goethegymnasium-hildesheim.de/
* offers computer science classes up until graduation: https://www.goethegymnasium-hildesheim.de/index.php/component/k2/item/278-informatikunterricht
* uses ISERV platform with gghi.de as a domain: https://www.goethegymnasium-hildesheim.de/index.php/component/k2/item/115-iserv

![image](https://github.com/JetBrains/swot/assets/16470072/c0c65bf6-4889-4d53-a2e4-514db296e944)
