### PR TITLE
Added NPS International Singapore to sg/edu domain list

### DIFF
--- a/lib/domains/NPS/lib/domains/sg/edu/npsinternational.txt
+++ b/lib/domains/NPS/lib/domains/sg/edu/npsinternational.txt
@@ -1,0 +1,1 @@
+NPS International Singapore


### PR DESCRIPTION
Hello,

I've added NPS International Singapore to the `sg/edu` domain list to ensure it's recognized as an educational institution. This addition will help in automating the process for academic discounts and other related verifications.

Thank you for considering this inclusion!