### PR TITLE
Add New Bogazici University Domain

### DIFF
--- a/lib/domains/tr/edu/bogazici.txt
+++ b/lib/domains/tr/edu/bogazici.txt
@@ -1,0 +1,2 @@
+Boğaziçi Üniversitesi
+Boğaziçi University


### PR DESCRIPTION
Bogazici University is in the process of converting its domain from `boun.edu.tr` to `bogazici.edu.tr`. So I'm adding the new domain to accommodate this change. 

#### Changes: 

- add `lib/domains/tr/edu/bogazici.txt`
  - the file contents are the same as `lib/domains/tr/edu/boun.txt` 
  - `boun.txt` [permalink](https://github.com/JetBrains/swot/blob/1730645625e2efea27c6aaa35e88ffd579128c0c/lib/domains/tr/edu/boun.txt) and `bogazici.txt` [commit link](https://github.com/JetBrains/swot/commit/43822e6742f858fe04bfdc782ee08095c20bccbe). 


#### About the Domain Change
Check out the new [bogazici.edu.tr](https://bogazici.edu.tr) page, it is the same as [boun.edu.tr](https://boun.edu.tr) currently both are available and `boun.edu.tr` redirects to the new page. 