### PR TITLE
Add Worcester Sixth Form college

### DIFF
--- a/lib/domains/uk/ac/wsfc.txt
+++ b/lib/domains/uk/ac/wsfc.txt
@@ -1,0 +1,1 @@
+Worcester Sixth Form College


### PR DESCRIPTION
Official website URL: https://www.wsfc.ac.uk/
Proof of Computer Science A Level on website: https://www.wsfc.ac.uk/courses/a-levels/computer-science-a-level/