### PR TITLE
remove alunos.estacio.br from block list

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1262,7 +1262,6 @@ uta.edu.ec
 students.uettaxila.edu.pk
 must.edu.mn
 itca.edu.sv
-alunos.estacio.br
 utmachala.edu.ec
 academico.ifg.edu.br
 sempreuninorte.com.br


### PR DESCRIPTION
PLEASE remove alunos.estacio.br from the stoplist.txt

This is a valid student email managed by Universidade Estácio de Sá, provided by Microsoft and made available to students to access their virtual classrooms and their respective campuses. Student email is an important tool for academic and professional communication, in addition to offering benefits such as unlimited storage, security and integration with other Microsoft services.

![image](https://github.com/JetBrains/swot/assets/25422117/e008fadc-2a8f-49b4-8022-2934535a4f06)

The official site of the university is https://estacio.br/

The official portal dor students is https://estudante.estacio.br/

Any questions, please contact me.
