### PR TITLE
Add new mozambican universities originated from the former Pedagogica…

### DIFF
--- a/lib/domains/mz/ac/unilicungo.txt
+++ b/lib/domains/mz/ac/unilicungo.txt
@@ -1,0 +1,2 @@
+Universidade Licungo
+Licungo University

--- a/lib/domains/mz/ac/unipungue.txt
+++ b/lib/domains/mz/ac/unipungue.txt
@@ -1,0 +1,2 @@
+Universidade Púnguè
+Pungue University

--- a/lib/domains/mz/ac/unirovuma.txt
+++ b/lib/domains/mz/ac/unirovuma.txt
@@ -1,0 +1,2 @@
+Universidade Rovuma
+Rovuma University

--- a/lib/domains/mz/ac/unisave.txt
+++ b/lib/domains/mz/ac/unisave.txt
@@ -1,0 +1,2 @@
+Universidade Save
+Save University

--- a/lib/domains/mz/ac/up.txt
+++ b/lib/domains/mz/ac/up.txt
@@ -1,0 +1,2 @@
+Universidade Pedagógica de Maputo
+Maputo Pedagogical University


### PR DESCRIPTION
This PR submits 5 mozambican universities to the list of educational institutions:

1. Universidade Pedagógica de Maputo - [up.ac.mz](https://up.ac.mz)
2. Universidade Licungo - [unilicungo.ac.mz](https://unilicungo.ac.mz)
3. Universidade Púnguè - [unipungue.ac.mz](https://unipungue.ac.mz)
4. Universidade Rovuma - [unirovuma.ac.mz](https://unirovuma.ac.mz)
5. Universidade Save - [unisave.ac.mz](https://unisave.ac.mz)