### PR TITLE
Add Maputo Pedagogical University to the list - Mozambique

### DIFF
--- a/lib/domains/mz/ac/up.txt
+++ b/lib/domains/mz/ac/up.txt
@@ -1,0 +1,2 @@
+Universidade Pedagógica de Maputo
+Maputo Pedagogical University


### PR DESCRIPTION
This PR submits 1 mozambican university to the list of educational institutions:

Universidade Pedagógica de Maputo - [up.ac.mz](https://up.ac.mz/)