### PR TITLE
add Dongeui University Student mail account

### DIFF
--- a/lib/domains/kr/ac/deu/office.txt
+++ b/lib/domains/kr/ac/deu/office.txt
@@ -1,0 +1,2 @@
+DONG-EUI University
+동의대학교


### PR DESCRIPTION
add Dongeui University Student mail account
Due to school policy, Undergraduate students at Dongui University can only use ms accounts