### PR TITLE
Merge remote-tracking branch 'origin/master'

### DIFF
--- a/lib/domains/fr/imj-prg.txt
+++ b/lib/domains/fr/imj-prg.txt
@@ -1,0 +1,1 @@
+Institut de Mathématiques de Jussieu-Paris Rive Gauche


### PR DESCRIPTION
https://www.imj-prg.fr

https://master-math-fonda.imj-prg.fr

The imj-prg.fr domain is used by all faculty member of the Jussieu mathematical institute. See :

https://www.imj-prg.fr/enseignants-chercheur/