### PR TITLE
Add ual.ac.uk domain

### DIFF
--- a/lib/domains/uk/ac/ual.txt
+++ b/lib/domains/uk/ac/ual.txt
@@ -1,0 +1,1 @@
+University of the Arts London


### PR DESCRIPTION
Add ual.ac.uk as an approved domain. This is the email domain of University of arts London.

They offer a range of computing related courses as part of their creative computing institute, including BSc Computer Science: https://www.arts.ac.uk/subjects/creative-computing/undergraduate/bsc-hons-computer-science

The universities website can be found here: https://www.arts.ac.uk/