### PR TITLE
Added Stephen Perse Foundation file

### DIFF
--- a/lib/domains/com/stephenperse.txt
+++ b/lib/domains/com/stephenperse.txt
@@ -1,0 +1,1 @@
+stephen perse foundation


### PR DESCRIPTION
Adding Stephen Perse Foundation, based in Cambridge, UK, to the list of schools.