### PR TITLE
Adding Kingsdale Foundation School

### DIFF
--- a/lib/domains/uk/sch/southwark/kingsdale.txt
+++ b/lib/domains/uk/sch/southwark/kingsdale.txt
@@ -1,0 +1,1 @@
+Kingsdale Foundation School

--- a/lib/domains/uk/sch/southwark/students.txt
+++ b/lib/domains/uk/sch/southwark/students.txt
@@ -1,0 +1,1 @@
+Kingsdale Foundation School

--- a/lib/domains/uk/sch/southwark/students.txt
+++ b/lib/domains/uk/sch/southwark/students.txt
@@ -1,1 +1,0 @@
-Kingsdale Foundation School


### PR DESCRIPTION
This school is a High School, but it offers a Sixth Form program. 

The real domain for the email is @students.kingsdale.southwark.sch.uk but I had trouble trying to add that.

School Website:
https://kingsdalefoundationschool.org.uk/


Sixth Form Program Info:
https://s3-eu-west-1.amazonaws.com/sh22-kingsdalefoundationschool-org-uk/media/downloads/kfssixthformstudyprogrammescoursesforseptember2024year12entry.pdf