### PR TITLE
add sandberg.nl domain

### DIFF
--- a/lib/domains/nl/sandberg.txt
+++ b/lib/domains/nl/sandberg.txt
@@ -1,0 +1,1 @@
+Sandberg Instituut


### PR DESCRIPTION
Adding https://sandberg.nl/

The Sandberg Institute is the postgraduate programme of the Gerrit Rietveld Academie Amsterdam.
Most departments engage in new media art / coding / IT but i especially wanna highlight the "Artificial Times" department (2 years) dealing with AI: https://sandberg.nl/temporary-program-artificial-times-course

Adress: Fred. Roeskestraat 96, 1076 ED Amsterdam, NL