### PR TITLE
Add Graduate School of CAAS

### DIFF
--- a/lib/domains/cn/GSCAAS.txt
+++ b/lib/domains/cn/GSCAAS.txt
@@ -1,0 +1,2 @@
+中国农业科学院研究生院
+Graduate School of Chinese Academy of Agricultural Sciences


### PR DESCRIPTION
Institution/School Name
Graduate School of Chinese Academy of Agricultural Sciences
中国农业科学院研究生院(Chinese)

Instiution/School Website
https://gs.caas.cn/en/

Email Users

 Students
 Academic/Teaching Staff

Education Levels
Post-graduate research