### PR TITLE
Add Pegaso University

### DIFF
--- a/lib/domains/it/unipegaso/studenti.txt
+++ b/lib/domains/it/unipegaso/studenti.txt
@@ -1,0 +1,2 @@
+Università Telematica "Pegaso"
+Pegaso University


### PR DESCRIPTION
University official website URL:
https://www.unipegaso.it/

URL of a page that has a long-term IT course:
https://www.unipegaso.it/lauree-triennali/informatica-per-le-aziende-digitali

URL of a screenshot that shows an email which states that Università Telematica Pegaso granted me an email with this domain to use as an institutional email https://gyazo.com/a74a61e09292ff4a4dd3df499efdab44