### PR TITLE
Remove mail2.gdut.edu.cn from stoplist

### DIFF
--- a/lib/domains/cn/edu/gdut/mail2.txt
+++ b/lib/domains/cn/edu/gdut/mail2.txt
@@ -1,0 +1,1 @@
+Guangdong University of Technology

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -176,7 +176,6 @@ lzpcc.edu.cn
 lzu.edu.cn
 madisoncollege.edu
 mail.0du.win
-mail2.gdut.edu.cn
 mail.ac.id
 mail.alumni.edu.vn
 mail.broward.edu


### PR DESCRIPTION
This email comes from 广东工业大学 (Guangdong University of Technology)
https://english.gdut.edu.cn/
https://en.wikipedia.org/wiki/Guangdong_University_of_Technology
It's our students' email