### PR TITLE
Add Baltic High School of Gastronomy

### DIFF
--- a/lib/domains/ru/bvshg.txt
+++ b/lib/domains/ru/bvshg.txt
@@ -1,0 +1,2 @@
+Балтийская высшая школа гастрономии
+Baltic High School of Gastronomy


### PR DESCRIPTION
Балтийская высшая школа гастрономии - это подразделение Калининградского государственного технического университета

Домены университета: klgtu.ru, i-klgtu.ru
Домен подразделения: bvshg.ru

Страницы, доказывающие причастность БВШГ к КГТУ:
https://gov39.ru/press/255729/
https://www.klgtu.ru/divisions/baltiyskaya_vysshaya_shkola_gastronomii/

Хоть наше подразделение и не относится напрямую к IT специальностям, но мы относимся к техническому университету , в котором достаточно IT направлений и разрабатываем собственное ПО для тестирования наших студентов