### PR TITLE
add hecm-afrique.net record

### DIFF
--- a/lib/domains/net/hecm-afrique.txt
+++ b/lib/domains/net/hecm-afrique.txt
@@ -1,0 +1,2 @@
+Haute Ecole de Commerce et de Management
+

--- a/lib/domains/net/hecm-afrique/student.txt
+++ b/lib/domains/net/hecm-afrique/student.txt
@@ -1,0 +1,1 @@
+Haute Ecole de Commerce et de Management


### PR DESCRIPTION
## Comments
This university started in 1999, but it still hasn't given its students official email addresses with the university's name. So, most students who graduate from there don't have official university email addresses.

Fixed applied after #19202 closed
