### PR TITLE
Add NAE Schools in Vietnam

### DIFF
--- a/lib/domains/com/bishanoi.txt
+++ b/lib/domains/com/bishanoi.txt
@@ -1,0 +1,1 @@
+British International School, Hanoi (Trường Quốc Tế Đa Cấp Anh - Hà Nội)

--- a/lib/domains/com/bisvietnam.txt
+++ b/lib/domains/com/bisvietnam.txt
@@ -1,0 +1,1 @@
+British International School, Ho Chi Minh City (Trường Quốc Tế Đa Cấp Anh - Thành phố Hồ Chí Minh)

--- a/lib/domains/com/bvishanoi.txt
+++ b/lib/domains/com/bvishanoi.txt
@@ -1,0 +1,1 @@
+British Vietnamese International School, Hanoi (Trường Quốc Tế Đa Cấp Anh Việt - Hà Nội)

--- a/lib/domains/com/bvisvietnam.txt
+++ b/lib/domains/com/bvisvietnam.txt
@@ -1,0 +1,1 @@
+British Vietnamese International School, Ho Chi Minh City (Trường Quốc Tế Đa Cấp Anh Việt - Thành phố Hồ Chí Minh)

--- a/lib/domains/net/bishanoi.txt
+++ b/lib/domains/net/bishanoi.txt
@@ -1,0 +1,1 @@
+British International School, Hanoi (Trường Quốc Tế Đa Cấp Anh - Hà Nội)

--- a/lib/domains/net/bisvietnam.txt
+++ b/lib/domains/net/bisvietnam.txt
@@ -1,0 +1,1 @@
+British International School, Ho Chi Minh City (Trường Quốc Tế Đa Cấp Anh - Thành phố Hồ Chí Minh)

--- a/lib/domains/net/bvishanoi.txt
+++ b/lib/domains/net/bvishanoi.txt
@@ -1,0 +1,1 @@
+British Vietnamese International School, Hanoi (Trường Quốc Tế Đa Cấp Anh Việt - Hà Nội)

--- a/lib/domains/net/bvisvietnam.txt
+++ b/lib/domains/net/bvisvietnam.txt
@@ -1,0 +1,1 @@
+British Vietnamese International School, Ho Chi Minh City (Trường Quốc Tế Đa Cấp Anh Việt - Thành phố Hồ Chí Minh)


### PR DESCRIPTION
British International School, Hanoi

School Official Website : https://www.nordangliaeducation.com/bis-hanoi
Address : Hoa Lan Road, Vinhomes Riverside, Long Bien District, Hanoi, Vietnam
Student email : @bishanoi.net or @bishanoi.com

British International School, Ho Chi Minh City

School Official Website : https://www.nordangliaeducation.com/bis-hcmc
Address : 246 Nguyen Van Huong Street, Thao Dien Ward, Thu Duc City, Ho Chi Minh City, Vietnam
Student email : @bisvietnam.com or @bisvietnam.net

British Vietnamese International School, Hanoi

School Official Website : https://www.nordangliaeducation.com/bvis-hanoi
Address : 72A Nguyen Trai Street, Thanh Xuan District, Hanoi, Vietnam
Student email : @bvishanoi.com or @bvishanoi.net

British Vietnamese International School, Ho Chi Minh City

School Official Website : https://www.nordangliaeducation.com/bvis-hcmc
Address : Street 1, Binh Hung, Binh Chanh, Ho Chi Minh City, Vietnam
Student email : @bvisvietnam.com or @bvisvietnam.net