### PR TITLE
add the currently used academic subdomain ac.eap.gr

### DIFF
--- a/lib/domains/gr/eap/ac.txt
+++ b/lib/domains/gr/eap/ac.txt
@@ -1,0 +1,1 @@
+Hellenic Open University


### PR DESCRIPTION
Hellenic Open University student and teacher emails are currently under the (academic) subdomain: ac.eap.gr