### PR TITLE
Add Domain for Staff Mail Addresses for Heinz-Nixdorf-Berufskolleg

### DIFF
--- a/lib/domains/de/hnbk.txt
+++ b/lib/domains/de/hnbk.txt
@@ -1,0 +1,1 @@
+Heinz-Nixdorf-Berufskolleg Essen


### PR DESCRIPTION
This is the domain for all staff of the Heinz-Nixdorf-Berufskolleg. The website is also on the same domain (https://hnbk.de/)