### PR TITLE
Update uni-muenster.txt

### DIFF
--- a/lib/domains/de/uni-muenster.txt
+++ b/lib/domains/de/uni-muenster.txt
@@ -1,1 +1,2 @@
-Westfälische Wilhelms-Universität Münster
+Universität Münster
+University of Münster


### PR DESCRIPTION
Former Westfälische Wilhelms-Universität-Münster got renamed to Universität Münster on 01.10.2023 ([more about this](https://www.uni-muenster.de/ZurSacheWWU/en/index.html)).
[Official Website](https://www.uni-muenster.de/en/), [Proof that this domain is used for student email](https://www.uni-muenster.de/IT/en/services/kommunikation/email/index.html)