### PR TITLE
Carcavelos High School

### DIFF
--- a/lib/domains/com/aecarcavelos.txt
+++ b/lib/domains/com/aecarcavelos.txt
@@ -1,0 +1,2 @@
+Escola Secundária de Carcavelos
+Carcavelos High School


### PR DESCRIPTION
Carcavelos High School or "Escola Secundária de Carcavelos"(in Portuguese) is a high school located in Carcavelos, Lisbon. It has around 2000 students and has 3 types of courses related to science, one being science and technologies(equivalent to computer science in english).