### PR TITLE
Add Foothill High School

### DIFF
--- a/lib/domains/org/mytusd.txt
+++ b/lib/domains/org/mytusd.txt
@@ -1,0 +1,1 @@
+Foothill High School


### PR DESCRIPTION
Foothill High in Santa Ana offers AP CSA and AP CSP classes to its students where JetBrains products would be helpful.