### PR TITLE
add ddecnc.org mail adress

### DIFF
--- a/lib/domains/org/ddecnc.txt
+++ b/lib/domains/org/ddecnc.txt
@@ -1,0 +1,1 @@
+Lycée Privé Générale et Technologique Blaise Pascal (DDEC)


### PR DESCRIPTION
Addition of the email address of the Blaise Pascal private high school (ddec).