### PR TITLE
Add BBS2Leer domain

### DIFF
--- a/lib/domains/net/bbs2leer.txt
+++ b/lib/domains/net/bbs2leer.txt
@@ -1,0 +1,1 @@
+Berufsbildende Schulen 2 Leer


### PR DESCRIPTION
Website is https://bbs2leer.de although https://bbs2leer.net also works. 

Example of a school email: exampl2023@bbs2leer.net