### PR TITLE
Free licenses to students from Nexus Singapore

### DIFF
--- a/lib/domains/sg/edu/nexus.txt
+++ b/lib/domains/sg/edu/nexus.txt
@@ -1,0 +1,10 @@
+Nexus International School (Singapore)
+Under Taylor's Schools Group
+
+https://www.nexus.edu.sg/
+https://www.nexus.edu.sg/secondary/
+- Scroll down and click "IGCSE" and "IB Diploma Programme"
+- Key word: "Computer Science"
+
+School email domain:
+[First name].[Last name].[Graduation year]@nexus.edu.sg


### PR DESCRIPTION
Nexus International School (Singapore)

https://www.nexus.edu.sg/
https://www.nexus.edu.sg/secondary/

- Scroll down and click "IGCSE" and "IB Diploma Programme"
- Key word: "Computer Science"

School email domain:
[First name].[Last name].[Graduation year]@nexus.edu.sg