### PR TITLE
Update tlds.txt

### DIFF
--- a/lib/domains/tlds.txt
+++ b/lib/domains/tlds.txt
@@ -36,6 +36,7 @@ edu.dz
 edu.ee
 edu.er
 edu.gh
+edu.gn
 edu.hn
 edu.in
 edu.kz


### PR DESCRIPTION
Adding a Guinean Domain name suffix can only be applied by real educational institutions in Guinea.