### PR TITLE
Add Crescent University, Abeokuta

### DIFF
--- a/lib/domains/ng/edu/cuab.txt
+++ b/lib/domains/ng/edu/cuab.txt
@@ -1,0 +1,1 @@
+Crescent University, Abeokuta


### PR DESCRIPTION
domain: cuab.edu.ng

https://cuab.edu.ng/college-of-information-and-communication-technology/