### PR TITLE
add gxaqzy.cn for guangxi vocational college of safety engineering

### DIFF
--- a/lib/domains/cn/gxaqzy.txt
+++ b/lib/domains/cn/gxaqzy.txt
@@ -1,0 +1,2 @@
+广西安全工程职业技术学院
+Guangxi Vocational College of Safety Engineering


### PR DESCRIPTION
A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
https://www.gxaqzy.cn/dzyxxaqx

A URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students:
![微信图片_20231125202234](https://github.com/JetBrains/swot/assets/18201606/20fceaaf-c7d3-46f3-b199-bb9b25a8c451)
