### PR TITLE
adding hudson high school of learning technologies

### DIFF
--- a/lib/domains/com/hudsonhs.txt
+++ b/lib/domains/com/hudsonhs.txt
@@ -1,0 +1,1 @@
+Hudson High School of Learning Technologies


### PR DESCRIPTION
Hudson High School of Learning Technologies in NYC 
[hudsonhs.com](https://hudsonhs.com/)