### PR TITLE
Include Kyunghee University global campus

### DIFF
--- a/lib/domains/ac/khu.txt
+++ b/lib/domains/ac/khu.txt
@@ -1,2 +1,0 @@
-Kyunghee University
-global campus

--- a/lib/domains/ac/khu.txt
+++ b/lib/domains/ac/khu.txt
@@ -1,0 +1,2 @@
+Kyunghee University
+global campus

--- a/lib/domains/kr/ac/khu.txt
+++ b/lib/domains/kr/ac/khu.txt
@@ -1,0 +1,2 @@
+Kyung Hee University
+Global campus


### PR DESCRIPTION
khu.ac.kr

Request a full request for use on Kyung Hee University's global campus.
The existing Kyung Hee University email is currently approved on swot and I don't know if that email domain is still used that was registered in the past, but the university is using khu.ac.kr domain.
So, I would like to request additional approval for that domain.