### PR TITLE
Add Centre Tecnologic de Telecomunicacions de Catalunya domain

### DIFF
--- a/lib/domains/cat/cttc.txt
+++ b/lib/domains/cat/cttc.txt
@@ -1,0 +1,1 @@
+Centre Tecnologic de Telecomunicacions de Catalunya


### PR DESCRIPTION
Request to add Centre Tecnologic de Telecomunicacions de Catalunya (CTTC) located in Castelldefels, Spain.