### PR TITLE
Add GRETA-CFA Aquitaine

### DIFF
--- a/lib/domains/academy/greta-cfa-aquitaine.txt
+++ b/lib/domains/academy/greta-cfa-aquitaine.txt
@@ -1,0 +1,2 @@
+GRETA-CFA Aquitaine
+GRETA-CFA Aquitaine


### PR DESCRIPTION
The GRETA-CFA Aquitaine is an educational institution based in the Aquitaine region of France. It operates as a Training Center for Apprenticeship (CFA) and is affiliated with the GRETA network, which focuses on providing vocational training and education. 

https://greta-cfa-aquitaine.fr/