### PR TITLE
Add ac.eap.gr domain file

### DIFF
--- a/lib/domains/gr/eap/ac.txt
+++ b/lib/domains/gr/eap/ac.txt
@@ -1,0 +1,2 @@
+Hellenic Open University
+Ελληνικό Ανοιχτό Πανεπιστήμιο


### PR DESCRIPTION
University Official Website: https://www.eap.gr

The URL of the long-term IT related course: Computer Science Undergraduate Program https://www.eap.gr/en/undergraduate/computer-science/

Proof of Domain Recognition: [Link to screenshot] https://www.dropbox.com/scl/fi/5obiix8mz12u3a8bfjykv/Screenshot_2023-12-05_at_19_20_18-2.png?rlkey=6f3oc6jxeyopqfwk1t18rnsdb&dl=0
