### PR TITLE
Add Nottingham Emmanuel School

### DIFF
--- a/lib/domains/uk/sch/nottingham/emmanuel.txt
+++ b/lib/domains/uk/sch/nottingham/emmanuel.txt
@@ -1,0 +1,1 @@
+Nottingham Emmanuel School


### PR DESCRIPTION
Adds the Nottingham Emmanuel School to SWOT

School website can be found here:
https://www.emmanuel.nottingham.sch.uk/

Curriculum here:
https://www.emmanuel.nottingham.sch.uk/learning/curriculum-overview/

Computer Science is an optional course available from Year 10