### PR TITLE
Adding Flint High School flint.flintshire.sch.uk & flinthighschool.wales

### DIFF
--- a/lib/domains/uk/sch/flintshire/flint.txt
+++ b/lib/domains/uk/sch/flintshire/flint.txt
@@ -1,0 +1,1 @@
+Flint High School

--- a/lib/domains/wales/flinthighschool.txt
+++ b/lib/domains/wales/flinthighschool.txt
@@ -1,0 +1,1 @@
+Flint High School


### PR DESCRIPTION
School Website: https://www.flinthighschool.wales/
School Curriculum: https://www.flinthighschool.wales/curriculum/curriculum-overview

School emails addresses are administered the **local council** and have a different domain from the school website, email address domains are: @flint.flintshire.sch.uk.

**Local council** is: https://www.flintshire.gov.uk
School List for Flintshire: https://www.flintshire.gov.uk/en/PDFFiles/Lifelong-Learning/Schools/School-Admissions/Schools-List-2023-2024.pdf 

Flint High School Page 17:
![image](https://github.com/JetBrains/swot/assets/10357512/ac3cce05-3413-455a-a54f-ef2120a9a13e)
