### PR TITLE
Added Mt. San Jacinto College

### DIFF
--- a/lib/domains/edu/msjc.txt
+++ b/lib/domains/edu/msjc.txt
@@ -1,0 +1,1 @@
+Mt. San Jacinto College


### PR DESCRIPTION
Adding "Mt. San Jacinto College"; Webpage https://www.msjc.edu/. Part of the California Community College system in southern California. Offers many programs and classes in computer science and programming: https://catalog.msjc.edu/instructional-programs/computer-information-systems/#degreescertificatestext