### PR TITLE
Adding KVS delhi | Kendriya Vidhyalya | Govt School (India)

### DIFF
--- a/lib/domains/in/kvsrodelhi.txt
+++ b/lib/domains/in/kvsrodelhi.txt
@@ -1,0 +1,1 @@
+KVS Delhi | Kendriya Vidyalaya Delhi


### PR DESCRIPTION
Scheme of Kendriya Vidyalayas (Central Schools) was approved in November 1962 by the Govt. of India on the recommendations of the Second Central Pay Commission. It recommended that the Government should develop a scheme to provide uninterrupted education to the wards of transferable Central Government employees. Consequently, Central School Organization was started as a unit of the Ministry of Education of the Govt. of India.

These are the school run by central govt of india.

Wikipedia - https://en.wikipedia.org/wiki/Kendriya_Vidyalaya_Sangathan
Website - https://dsel.education.gov.in/kvs,