### PR TITLE
Create opgs.txt

### DIFF
--- a/lib/domains/org/opgs.txt
+++ b/lib/domains/org/opgs.txt
@@ -1,0 +1,1 @@
+Oakwood Park Grammar School


### PR DESCRIPTION
Oakwood Park Grammar School offers a 2-year course in computer science for higher education which can be found at https://www.opgs.org/page/?title=Computing&pid=72