### PR TITLE
Add PHSZ - Schwyz University of Teacher Education

### DIFF
--- a/lib/domains/ch/phsz.txt
+++ b/lib/domains/ch/phsz.txt
@@ -1,0 +1,1 @@
+Pädagogische Hochschule Schwyz, Goldau

--- a/lib/domains/ch/phsz.txt
+++ b/lib/domains/ch/phsz.txt
@@ -1,1 +1,2 @@
 Pädagogische Hochschule Schwyz, Goldau
+Schwyz University of Teacher Education, Goldau


### PR DESCRIPTION
Please add Schwyz University of Teacher Education 
https://www.phsz.ch/

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
Bachelor: https://www.phsz.ch/ausbildung/bachelorstudium/studiengaenge-und-studienformate
Master: https://www.phsz.ch/ausbildung/masterstudium

a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students:
https://www.phsz.ch/person/raffael-meier

