### PR TITLE
Added clsg.org.uk for Students of City of London School for girls

### DIFF
--- a/lib/domains/uk/org/clsg.txt
+++ b/lib/domains/uk/org/clsg.txt
@@ -1,0 +1,1 @@
+City of London School for Girls


### PR DESCRIPTION
Please Merge to add City of London School for Girls , in London UK