### PR TITLE
Adding UnDF - Universidade do Distrito Federal

### DIFF
--- a/lib/domains/br/edu/undf.txt
+++ b/lib/domains/br/edu/undf.txt
@@ -1,0 +1,1 @@
+Universidade do Distrito Federal


### PR DESCRIPTION
It's a public University from Brazil's capital, Brasília - Distrito Federal since 2022

example e-mail: teacher@undf.edu.br

related links

[Web site - teacher's room](https://undf.edu.br/)
[Official web site](https://universidade.df.gov.br/a-undf/)
[Wikipedia - UnDF](https://pt.wikipedia.org/wiki/Universidade_do_Distrito_Federal_Jorge_Amaury)
[Linkedin - UnDF](https://br.linkedin.com/company/undf-universidade-do-distrito-federal)
[Press coverage about UnDF](https://g1.globo.com/df/distrito-federal/df2/video/undf-autoriza-a-criacao-de-seis-novos-cursos-de-graduacao-11471095.ghtml)
[Interview with Simone Benck: Creation of the University of the Federal District (UnDF)](https://www.praxia.ueg.br/index.php/atatot/article/download/13083/9217)
