### PR TITLE
Adding IES La Fuensanta

### DIFF
--- a/lib/domains/es/ieslafuensanta/ieslafuensanta.txt
+++ b/lib/domains/es/ieslafuensanta/ieslafuensanta.txt
@@ -1,0 +1,1 @@
+IES La Fuensanta


### PR DESCRIPTION
**IES LA FUENSANTA**

High school and professional certification center in Cordoba (Spain).

Url: https://www.ieslafuensanta.es/
Educative offer: https://www.ieslafuensanta.es/index.php/ejemplo/oferta-educativa

