### PR TITLE
Update Florida Virtual School

### DIFF
--- a/lib/domains/net/flvs/flvsft912.txt
+++ b/lib/domains/net/flvs/flvsft912.txt
@@ -1,0 +1,1 @@
+Florida Virtual School


### PR DESCRIPTION
The existing domain for Florida Virtual School does not cover most students attending FLVS. The domain `flvsft912.flvs.net` however, covers all students in FLVS' highschool segment.