### PR TITLE
Add CD Loga Highschool students email domain

### DIFF
--- a/lib/domains/ro/e-cdloga.txt
+++ b/lib/domains/ro/e-cdloga.txt
@@ -1,0 +1,2 @@
+Colegiul National "Constantin Diaconovici Loga" Timisoara
+National College "Constantin Diaconovici Loga" Timisoara


### PR DESCRIPTION
CD Loga Highschool is already included as "@cdloga.ro", but this is for the administrator and teachers emails.
Students emails received the @e-cdloga.ro domain, therefore we need to add this domain too, so that our students can access the students offers.

Highschool website: http://cdloga.ro
Highschool mathematics-informatics (4 years - highschool): http://cdloga.ro/specializarea-matematica-informatica/

Thank you!