### PR TITLE
Please add Sirindhorn School (Thailand).

### DIFF
--- a/lib/domains/th/ac/sirin.txt
+++ b/lib/domains/th/ac/sirin.txt
@@ -1,0 +1,2 @@
+โรงเรียนสิรินธร
+Sirindhorn School


### PR DESCRIPTION
Please ass Sirindhorn School.

Official web site: https://sirin.ac.th/
Personnel of science and technology subjects: https://sirin.ac.th/science-department/

Our school currently uses Google's email service and many other services, so school staff's email addresses end in @sirin.ac.th which must be approved by our school's appointed email administrator only.