### PR TITLE
Add Schillerschule Hannover

### DIFF
--- a/lib/domains/de/iserv-schillerschule.txt
+++ b/lib/domains/de/iserv-schillerschule.txt
@@ -1,0 +1,1 @@
+Schillerschule Hannover


### PR DESCRIPTION
- Official school homepage: https://www.schillerschule-hannover.de/
- Student E-Mails are registered on the `iserv-schillerschule.de` domain, a link to it is present on the right sidebar ("Iserv")
- Proof of long-term cs-courses: https://www.schillerschule-hannover.de/informatik/