### PR TITLE
Create scarletmail.rutgers.txt

### DIFF
--- a/lib/domains/edu/scarletmail.rutgers.txt
+++ b/lib/domains/edu/scarletmail.rutgers.txt
@@ -1,0 +1,1 @@
+Rutgers University, Rutgers University - The State University of New Jersey


### PR DESCRIPTION
Added Rutgers University's email extension. Example email: aaa111@scarletmail.rutgers.edu. Thank you!