### PR TITLE
add loyola-icam (licet) - india

### DIFF
--- a/lib/domains/in/ac/licet.txt
+++ b/lib/domains/in/ac/licet.txt
@@ -1,0 +1,1 @@
+Loyola-ICAM College of Engineering and Technology, Chennai


### PR DESCRIPTION
Added Loyola-ICAM College of Engineering & Technology, Chennai, Tamil Nadu, India.

**Official Website**: https://licet.ac.in/
**Wikipedia**: [Link](https://en.wikipedia.org/wiki/Loyola-ICAM_College_of_Engineering_and_Technology)
**Map**: [Link](https://maps.app.goo.gl/bMjkjFYoS82b53eG8)