### PR TITLE
edu.wroclaw.pl domain added

### DIFF
--- a/lib/domains/pl/wroclaw/edu.txt
+++ b/lib/domains/pl/wroclaw/edu.txt
@@ -1,0 +1,3 @@
+XIV Liceum Ogólnokształcące im. Polonii Belgijskiej we Wrocławiu
+14th High School of Polonia Belgijska in Wroclaw
+.group


### PR DESCRIPTION
High School website
https://lo14.wroc.pl/

Here it is offering a computer science class for 4 years (last year recruitment page)
https://lo14.wroc.pl/rekrutacja-do-liceum-ogolnoksztalcacego-nr-xiv-na-rok-szkolny-20232024,123,pl

edu.wroclaw.pl is a domain shared by High Schools and Universities in Wroclaw
Here is the page where is says, that every educational institution managed by Gmina Wroclaw (local goverment) is allowed to use this platform (includes e-mailing service).
https://pe.edu.wroclaw.pl/kontakt

Since PyCharm is basically the only choice of a code Editor/IDE for the python language on the graduation exam, and is used for universities, student/educational license might help students.