### PR TITLE
Add University of Perpetual Help System DALTA

### DIFF
--- a/lib/domains/ph/edu/perpetual.txt
+++ b/lib/domains/ph/edu/perpetual.txt
@@ -1,0 +1,1 @@
+University of Perpetual Help System DALTA


### PR DESCRIPTION
Microsoft domain for the University of Perpetual Help System DALTA, used by 3 campuses in the same school system (perpetual.edu.ph)

This email domain is strictly for student use (not accessible publicly), and is compliant of the requirements needed for school/university registration for JetBrains products.