### PR TITLE
Add Limerick college of further education (LCFE)

### DIFF
--- a/lib/domains/ie/lcetb/learner.txt
+++ b/lib/domains/ie/lcetb/learner.txt
@@ -1,0 +1,1 @@
+Limerick college of further education


### PR DESCRIPTION
Added the official domain of Limerick college of further education (LCFE).
official domain: https://www.lcfe.ie/ & https://lcetb.ie/
apart of other FET colleges verified under the IE section 