### PR TITLE
Adding record for student mail domain at WVNCC (@mail.wvncc.edu)

### DIFF
--- a/lib/domains/edu/wvncc/mail.txt
+++ b/lib/domains/edu/wvncc/mail.txt
@@ -1,0 +1,1 @@
+West Virginia Northern Community College


### PR DESCRIPTION
Added new directory for student mail domain, @mail.wvncc.edue, for student emails at West Virginia Northern Community College.