### PR TITLE
Add Heinrich Schliemann Gymnasium

### DIFF
--- a/lib/domains/eu/hsg-berlin.txt
+++ b/lib/domains/eu/hsg-berlin.txt
@@ -1,0 +1,1 @@
+Heinrich-Schliemann-Gymnasium


### PR DESCRIPTION
School website: https://hsg-berlin.de/

The eu-domain is for student and teacher mails only (and the internal learn management system).

The school offers computer science courses for high school age students (~ 14-18 years old). Teaching content includes - for example - Kotlin, databases, data protection and social effects of IT.