### PR TITLE
Add Faculty of Computers and Information Helwan University

### DIFF
--- a/lib/domains/eg/edu/helwan/fci.txt
+++ b/lib/domains/eg/edu/helwan/fci.txt
@@ -1,0 +1,1 @@
+Faculty of Computers and Information Helwan University


### PR DESCRIPTION
The faculty official website URL : 
[http://fcih.helwan.edu.eg/](url)


Faculty Contact Email:
info@fci.helwan.edu.eg
