### PR TITLE
Nist College

### DIFF
--- a/lib/domains/np/edu/nistbanepa.txt
+++ b/lib/domains/np/edu/nistbanepa.txt
@@ -1,0 +1,2 @@
+Nist Banepa Secondary School
+https://nistbanepa.edu.np/

--- a/lib/domains/np/edu/nistcollege.txt
+++ b/lib/domains/np/edu/nistcollege.txt
@@ -1,0 +1,2 @@
+Nist College, Tribhuban University
+https://nistcollege.edu.np/


### PR DESCRIPTION
Nist College,
Nayabasti Nala Road, Banepa 45210

There are two domains of this college, 
1.nistbanepa.edu.np
2.nistcollege.edu.np

both of them are workable, and I have updated both in this pull request. I hope this PR will be merged
