### PR TITLE
Domain file for Jēkabpils Tehnoloģiju Tehnikums

### DIFF
--- a/lib/domains/lv/jak.txt
+++ b/lib/domains/lv/jak.txt
@@ -1,0 +1,1 @@
+Jēkabpils Tehnoloģiju Tehnikums


### PR DESCRIPTION
Added domain file for the Jēkabpils Tehnoloģiju Tehnikums

Official websites URL: https://jekabpils.jttehnikums.lv/
URL For IT related course (Programming 4 years): https://jekabpils.jttehnikums.lv/lv/programmas/programmesana/
URL for @ jak domain confirmation (Teachers page with their email (including mine), that contains @ jak domain): https://jekabpils.jttehnikums.lv/lv/skola/skolotaji/
