### PR TITLE
The mailbox was sold publicly.

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1973,3 +1973,5 @@ dmu.ac.kr
 suwon.ac.kr
 s.konan-u.ac.jp
 student.tp.edu.sg
+mail.utoronto.ca
+my.cityu.edu.hk


### PR DESCRIPTION
Alumni mailboxes are not recalled, and mailbox aliases can be set multiple times.
mail.utoronto.ca: aliases can be set once per day.
my.cityu.edu.hk: aliases can be set 20 times per mailbox.