### PR TITLE
Add Physics subdomain for University of Crete

### DIFF
--- a/lib/domains/gr/uoc/physics/edu.txt
+++ b/lib/domains/gr/uoc/physics/edu.txt
@@ -1,0 +1,1 @@
+University of Crete Department of Physics


### PR DESCRIPTION
Official website: https://www.physics.uoc.gr/

Websites of courses related to IT:
- https://elearning.physics.uoc.gr/?lang=en
- https://www.physics.uoc.gr/en/courses/65
- https://www.physics.uoc.gr/en/courses/157

Webmail website: https://webmail.physics.uoc.gr/
The edu prefix is for students only