### PR TITLE
Anne Arundel Community College student email.

### DIFF
--- a/lib/domains/edu/aacc/mymail.txt
+++ b/lib/domains/edu/aacc/mymail.txt
@@ -1,0 +1,1 @@
+Anne Arundel Community College


### PR DESCRIPTION
Students now have @mymail.aacc.edu addresses. The former @aacc.edu (already in the repo) is now used for staff emails.

University website: https://www.aacc.edu/
CS/IT programs: https://www.aacc.edu/programs-and-courses/credit-and-degree-seekers/computer-science-and-software-development/
Proof of this being official: https://portal.aacc.edu/
("MyAACC" login screen: https://i.imgur.com/7E8iVuu.png)