### PR TITLE
ITIS De Petto Schio

### DIFF
--- a/lib/domains/it/edu/depretto.txt
+++ b/lib/domains/it/edu/depretto.txt
@@ -1,0 +1,1 @@
+ITIS De Pretto Schio


### PR DESCRIPTION
IT High School in Schio (province of Vicenza), Italy
site: https://www.depretto.edu.it/
domain @depretto.edu.it