### PR TITLE
Nukus branch of Tashkent University of Information Technologies 

### DIFF
--- a/lib/domains/uz/tatunf.txt
+++ b/lib/domains/uz/tatunf.txt
@@ -1,0 +1,2 @@
+Muhammed Al-Xorezmiy atındaǵı Tashkent Informaciyalıq Texnologiyaları Universiteti Nókis filialı
+Nukus branch of Tashkent University of Information technologies named after Muhammad al-Khwarizmi


### PR DESCRIPTION
**Nukus branch of Tashkent University of Information Technologies named after Muhammad al-Khwarizmi**

**Website:** https://tatunf.uz/
**Location:** https://maps.app.goo.gl/Ymh7T1VNA1719NVR8