### PR TITLE
Adding De Montfort University

### DIFF
--- a/lib/domains/uk/ac/dmu/my.txt
+++ b/lib/domains/uk/ac/dmu/my.txt
@@ -1,0 +1,1 @@
+De Montfort University


### PR DESCRIPTION
Adding De Montfort University
Site: https://www.dmu.ac.uk/
CS Course: https://www.dmu.ac.uk/study/courses/undergraduate-courses/computer-science-bsc-degree/computer-science-bsc-degree.aspx
Proof of email addresses: https://www.dmu.ac.uk/current-students/student-resources/it-media-support.aspx