### PR TITLE
Add I.T.I.S. P.L. Nervi

### DIFF
--- a/lib/domains/it/edu/istitutonervialaimo
+++ b/lib/domains/it/edu/istitutonervialaimo
@@ -1,0 +1,1 @@
+I.T.I.S. P.L. Nervi


### PR DESCRIPTION
The official domain of the school is: istitutonervialaimo.edu.it
(It is a school that includes various fields in addition to informatic)