### PR TITLE
Add domain itsdigitalacademy.com

### DIFF
--- a/lib/domains/com/itsdigitalacademy.txt
+++ b/lib/domains/com/itsdigitalacademy.txt
@@ -1,0 +1,1 @@
+ITS Digital Academy Mario Volpato, Italy


### PR DESCRIPTION
Add ITS digital academy Mario Volpato to the recognized domains.

The institution website: https://itsdigitalacademy.com/

An example of a 2 year course: https://itsdigitalacademy.com/corsi/web-developer-full-stack/

an email is given to students ending with @itsdigitalacademy.com