### PR TITLE
Add Maaslandcollege Domain

### DIFF
--- a/lib/domains/nl/maaslandcollege.txt
+++ b/lib/domains/nl/maaslandcollege.txt
@@ -1,0 +1,1 @@
+Maaslandcollege


### PR DESCRIPTION
I've added the Maaslandcollege domain to be able to use the Educational License of the JetBrains IDE's.