### PR TITLE
Create uni-mannheim/students.txt

### DIFF
--- a/lib/domains/de/uni-mannheim/students.txt
+++ b/lib/domains/de/uni-mannheim/students.txt
@@ -1,0 +1,1 @@
+Universität Mannheim


### PR DESCRIPTION
This change adds the domain "@students.uni-mannheim.de" to the repository.  The University of Mannheim uses this domain for the email addresses of its students.  The official website of the University of Mannheim is: https://www.uni-mannheim.de/.