### PR TITLE
Lycee Coetlogon add

### DIFF
--- a/lib/domains/fr/lyceecoetlogon.txt
+++ b/lib/domains/fr/lyceecoetlogon.txt
@@ -1,0 +1,2 @@
+Lycee Coetlogon 
+Académie de Renne


### PR DESCRIPTION
Official Website: https://lyceecoetlogon.fr/
Or rather: https://lycee-coetlogon.ac-rennes.fr/ since it redirects us
Student email : @lyceecoetlogon.fr