### PR TITLE
Re: Register a domain that can receive emails to University Of Ulsan stud…

### DIFF
--- a/lib/domains/kr/ac/ulsan/mail.txt
+++ b/lib/domains/kr/ac/ulsan/mail.txt
@@ -1,0 +1,2 @@
+울산대학교
+UNIVERSITY OF ULSAN


### PR DESCRIPTION
Please check again. [Previous issue #20005]
must register Office 365 mail after receiving a member account at the university, so non-member are not allowed to do so.

> Ref. Services provided > Email Provided

<img width="1310" alt="image" src="https://github.com/JetBrains/swot/assets/35905295/70283a32-2d8d-43a3-bcf9-4241b95c14e0">
