### PR TITLE
add Immanuel Kant Gymnasium Hiltrup (kant.ms.de)

### DIFF
--- a/lib/domains/de/ms/kant.txt
+++ b/lib/domains/de/ms/kant.txt
@@ -1,0 +1,1 @@
+Immanuel Kant Gymnasium Hiltrup


### PR DESCRIPTION
The immanuel Kant Gymnasium is a public school in 48165 Münster, Germany. The public school website is kant-hiltrup.de.