### PR TITLE
Add domain isae-supmeca.fr.

### DIFF
--- a/lib/domains/fr/isae-supmeca.txt
+++ b/lib/domains/fr/isae-supmeca.txt
@@ -1,0 +1,1 @@
+ISAE-Supméca — Institut supérieur de mécanique de Paris


### PR DESCRIPTION
ISAE-Supméca is a French engineering school (master's degree).

From [English version of engineering program](https://en.isae-supmeca.fr/training/training/):
> Structure of the core teachings:
> Scientific education covering: applied mathematics, IT, industrial automation and IT, mechanical and structural engineering, materials, fluids and energy engineering.

Support page of IT service from school intranet with mention of “first_name.name@isae-supmeca.fr”:
[isae-supmeca.fr_email-domain.pdf](https://github.com/JetBrains/swot/files/14343205/isae-supmeca.fr_email-domain.pdf)
