### PR TITLE
Please add domain loreto.ac.uk

### DIFF
--- a/lib/domains/uk/ac/loreto.txt
+++ b/lib/domains/uk/ac/loreto.txt
@@ -1,0 +1,1 @@
+Loreto Sixth Form College


### PR DESCRIPTION
Please add domain `loreto.ac.uk`, a 16-19 Sixth Form College in Manchester, UK.

- [Computer Science Course Page](https://www.loreto.ac.uk/courses/computer-science/)
- [Computing Level 3 Course Page](https://www.loreto.ac.uk/courses/computing-level-3/)
- [IT Course Page](https://www.loreto.ac.uk/courses/it/)

Thank you.