### PR TITLE
Add student.guc.edu.eg

### DIFF
--- a/lib/domains/eg/edu/guc/student.txt
+++ b/lib/domains/eg/edu/guc/student.txt
@@ -1,0 +1,1 @@
+German University in Cairo


### PR DESCRIPTION
Please add the domain student.guc.edu.eg to your accepted domains as this is the domain for students at the German University in Cairo. The domain you already have is guc.edu.eg is for teachers. 