### PR TITLE
Add uniroma1's students email domain

### DIFF
--- a/lib/domains/it/uniroma1/studenti.txt
+++ b/lib/domains/it/uniroma1/studenti.txt
@@ -1,0 +1,1 @@
+University of Roma La Sapienza


### PR DESCRIPTION
The main domain (`uniroma1.it`) was already included in the repo, but seems like the checker isn't okay with the usage of students' email domain (`@studenti.uniroma1.it`) in the addresses.

University's official website: https://www.uniroma1.it/en
Computer Science course page: https://corsidilaurea.uniroma1.it/en/corso/2023/29923/home
Domain usage proof: https://www.uniroma1.it/en/pagina/email-google-apps