### PR TITLE
Add a new Fourth-level domain of Ibaraki University

### DIFF
--- a/lib/domains/jp/ac/ibaraki/vc.txt
+++ b/lib/domains/jp/ac/ibaraki/vc.txt
@@ -1,0 +1,2 @@
+IBARAKI UNIVERSITY
+茨城大学


### PR DESCRIPTION
Our university changed the university member's personal email domain from '@ibaraki.ac.jp' to '@vc.ibaraki.ac.jp' 7 or 8 years back. However there has been no application to JetBrain on this matter.
Ibaraki University is a national educational institution recognized by the Japanese government, and it offers a full four-year undergraduate education, as well as a two-year master's program and a three-year doctoral program.
Ibaraki University is a comprehensive university with professors in the fields of literature, science, agriculture, and engineering, including research and development related to the computer field.
It is hoped that this request will be approved by the JetBrain reviewers.
Thank you.

PS:A screenshot of an email "related to an induction session hosted by the school" has been submitted as an attachment to the evidence. The e-mail address is partially yellowed.
![ScreenShot 2024-02-28 120404](https://github.com/JetBrains/swot/assets/110218874/50546e8e-0f25-4168-a794-7925f5c7aefd)
This is the official homepage of Ibaraki University：https://www.ibaraki.ac.jp/en/