### PR TITLE
feature: Added Egglescliffe School & Sixth Form to uk org domains

### DIFF
--- a/lib/domains/uk/org/egglescliffe.txt
+++ b/lib/domains/uk/org/egglescliffe.txt
@@ -1,0 +1,1 @@
+Egglescliffe School & Sixth Form College


### PR DESCRIPTION
Adding Egglecliffe School & Sixth Form College

https://egglescliffe.org.uk/

https://egglescliffe.org.uk/sixth-form/choosing-a-course/

Students are issued an email in format SurnameXYY@egglescliffe.org.uk Where X = a first name initial and XX are two numeric digits.  e.g. DoeJ99@egglescliffe.org.uk
