### PR TITLE
Add Staatliche Berufsschule 1 Landshut mit Berufsfachschule für Informatik

### DIFF
--- a/lib/domains/de/bs1-landshut.txt
+++ b/lib/domains/de/bs1-landshut.txt
@@ -1,0 +1,2 @@
+Staatliche Berufsschule 1 Landshut mit Berufsfachschule für Informatik
+Public Vocational School 1 Landshut with Vocational School for Informatics


### PR DESCRIPTION
If the title is too long it can be shortened to "Add Staatl. BS1 Landshut/BFI" or "Add Staatl. Berufsschule 1 mit BFI"

The Vocational School for Informatics (Berufsfachschule für Informatik) is a sub-school located physically and administratively within the Public Vocational School 1 Landshut. Both offer a long-term IT-related course and use the same domain for students and teachers.

[IT course at the Public Vocational School 1 Landshut](https://bs1-landshut.de/abteilungen/informationstechnik/ueberblick)
[Vocational School for Informatics](https://bfi-landshut.de)

[Proof that the domain is in use as an official email domain](https://bs1-landshut.de/abteilungen/informationstechnik/team) (only contains teacher's email addresses, but students use the same upper-level domain, I just couldn't find any proof (`@sus.bs1-landshut.de` for students, just `@bs1-landshut.de` for teachers and administration))