### PR TITLE
add afpa pompey domain

### DIFF
--- a/lib/domains/fr/afpa-dev-pompey.txt
+++ b/lib/domains/fr/afpa-dev-pompey.txt
@@ -1,0 +1,1 @@
+Agence nationale pour la Formation Professionnelle des Adultes


### PR DESCRIPTION
afpa-dev-pompey.fr is a specific domain for developpers at AFPA Pompey France.
The main URL of our nationnal school : https://www.afpa.fr/
Our course of CDA, is at least 15 years old : https://www.afpa.fr/formation-qualifiante/concepteur-developpeur-d-applications a bachelor equivalent in software development.