### PR TITLE
Added NCC (Niigata Computer College)

### DIFF
--- a/lib/domains/jp/nsgcl.txt
+++ b/lib/domains/jp/nsgcl.txt
@@ -1,0 +1,2 @@
+新潟コンピュータ専門学校
+Niigata Computer College


### PR DESCRIPTION
Optional Info:
     Official Webpage : [https://www.ncc-net.ac.jp/](url)