### PR TITLE
Request to remove o.cnu.ac.kr from stoplist

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1980,6 +1980,5 @@ stu.jhun.edu.cn
 upm.edu.sa
 wzut.edu.cn
 ogr.akdeniz.edu.tr
-o.cnu.ac.kr
 ydu.edu.tw
 setsuna.eu.org


### PR DESCRIPTION
I checked why the domain in the stoplist is suspended through the previous pull request.

It was confirmed that our university is removing accounts for unused accounts in a policy.
https://cic.cnu.ac.kr/cic/resources/notice.do?mode=view&articleNo=444132&article.offset=0&articleLimit=10

I would like to request that the domain be removed from the stoplist.

Thank you.