### PR TITLE
add ip.mpg.de - Planck Institute for Innovation and Competition

### DIFF
--- a/lib/domains/de/mpg/ip.txt
+++ b/lib/domains/de/mpg/ip.txt
@@ -1,0 +1,2 @@
+Max-Planck-Institut für Innovation und Wettbewerb
+Max Planck Institute for Innovation and Competition


### PR DESCRIPTION
The Max Planck Institute for Innovation and Competition (ip.mpg.de) is a member of the Max Planck Society.

Website: https://www.ip.mpg.de/en/