### PR TITLE
Medical University of Innsbruck (Austria), Institute of Legal Medicine

### DIFF
--- a/lib/domains/at/ac/gmi-tirol.txt
+++ b/lib/domains/at/ac/gmi-tirol.txt
@@ -1,0 +1,2 @@
+Medizinische Universität Innsbruck, Institut für Gerichtliche Medizin
+Medical University of Innsbruck, Institute of Legal Medicine


### PR DESCRIPTION
Medical University of Innsbruck (Austria), Institute of Legal Medicine

```bash
whois gmi-tirol.ac.at

domain:         gmi-tirol.ac.at
registrar:      
registrant:     MUI1323603-NICAT
admin-c:        <data not disclosed>
tech-c:         <data not disclosed>
tech-c:         <data not disclosed>
nserver:        ns1.i-med.ac.at
nserver:        ns2.i-med.ac.at
changed:        20140418 10:08:43
source:         AT-DOM

personname:     
organization:   Medizinische Universitaet Innsbruck
street address: Christoph-Probst-Platz 1
postal code:    A-6020
city:           Insbruck
country:        Austria
phone:          +435129003
e-mail:         it-services@i-med.ac.at
nic-hdl:        MUI1323603-NICAT
changed:        20140415 11:30:00
source:         AT-DOM
```