### PR TITLE
Modified domain for Shenley Brook End School, Milton Keynes, UK

### DIFF
--- a/lib/domains/com/sbe5d.txt
+++ b/lib/domains/com/sbe5d.txt
@@ -1,0 +1,1 @@
+Shenley Brook End School, Milton Keynes


### PR DESCRIPTION
Domain for emails has changed for Shenley Brook End School, Milton Keynes, UK from .org.uk to .com one.
It doesn't appear to be possible to automatically verify emails with .com domain.
@philipto Can you review and approve, please?