### PR TITLE
Add EST

### DIFF
--- a/lib/domains/ne/edu/est.txt
+++ b/lib/domains/ne/edu/est.txt
@@ -1,0 +1,5 @@
+Ecole Supérieure des Communications Electroniques et de la Poste
+Higher School of Electronic Communications and Post
+
+EST
+ESCEP


### PR DESCRIPTION
Adding Ecole Supérieure des Communications Electroniques et de la Poste (ESCEP) to ne domain.

Here's the URL of the official website :  https://supecole-dev.net/

Here's the link on the official website where a long-term (>1 year) IT related course is offered by the university : https://supecole-dev.net/hospitality-management/#

**Important :** The school name changed from EST to ESCEP which means (Ecole Supérieure des Communications Electroniques et de la Poste) but we are always on the EST domain. The website url isn't on the est domain but on www.escep.edu.ne which is redirected to https://supecole-dev.net/

A PDF of a document from the school where the domain is recognized in the Headletter :
[PLANNING  30-07-2023.pdf](https://github.com/JetBrains/swot/files/14559173/PLANNING.30-07-2023.pdf)


