### PR TITLE
Reallow edu.bme.hu

### DIFF
--- a/lib/domains/hu/bme.txt
+++ b/lib/domains/hu/bme.txt
@@ -1,1 +1,0 @@
-Technical University of Budapest

--- a/lib/domains/hu/bme/edu.txt
+++ b/lib/domains/hu/bme/edu.txt
@@ -1,0 +1,1 @@
+Budapest University of Technology and Economics

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1924,7 +1924,6 @@ kkumail.com
 cassia.kku.ac.th
 alias.kkumail.com
 imail.sunway.edu.my
-edu.bme.hu
 apps.ajou.ac.kr
 office365.kunsan.ac.kr
 s.konan-u.ac.jp


### PR DESCRIPTION
Please reallow edu.bme.hu, this is the main mailing O365 subdomain for all faculties of BME (Budapest University of Technology end Economics), which includes VIK (Faculty of Electrical Engineering and Informatics) students.
https://www.vik.bme.hu/
https://login.bme.hu/

![image](https://github.com/JetBrains/swot/assets/22570934/7e925676-f256-4fb4-9610-559ac911a1b7)
