### PR TITLE
Add Sekolah Terpadu Pahoa

### DIFF
--- a/lib/domains/id/sch/pahoa/sekolah.txt
+++ b/lib/domains/id/sch/pahoa/sekolah.txt
@@ -1,0 +1,1 @@
+Sekolah Terpadu Pahoa


### PR DESCRIPTION
Official site is https://pahoa.sch.id . A school in Indonesia that cater pre-school up to senior high school.