### PR TITLE
Adding the prof.cesupa.br domain

### DIFF
--- a/lib/domains/br/cesupa/prof.txt
+++ b/lib/domains/br/cesupa/prof.txt
@@ -1,0 +1,3 @@
+Centro Universitário do Pará
+Cesupa
+Pará University Center


### PR DESCRIPTION
University official website UR: https://www.cesupa.br/
URL of the science computer course: https://www.cesupa.br/Graduacao/Ciencia_Computacao/
proof of domain: https://drive.google.com/file/d/1ZGbeaM_NVVdSWmvyJVTDDvTBiPPYkA2W/view?usp=sharing