### PR TITLE
Add "implika.es" as a domain.

### DIFF
--- a/lib/domains/es/implika.txt
+++ b/lib/domains/es/implika.txt
@@ -1,0 +1,1 @@
+Implika


### PR DESCRIPTION
Implika is a Professional Institute in Spain (https://www.implika.es).