### PR TITLE
Added JCHS to lib/domains/net

### DIFF
--- a/lib/domains/net/jcsds.txt
+++ b/lib/domains/net/jcsds.txt
@@ -1,0 +1,1 @@
+Junction City High School


### PR DESCRIPTION
added my school
The link for the school email is www.jcsds.net but the actual school website is www.jchigh.org