### PR TITLE
request to add bu.edu in stoplist (not remove)

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1897,3 +1897,4 @@ eaglesvale.ac.zw
 email.ncu.edu.cn
 gnnu.edu.cn
 smail.xtu.edu.cn
+bu.edu


### PR DESCRIPTION

University name: Boston University

University Email Domain: bu.edu

Please refer to link: https://www.bu.edu/alumni/services/your-bu-profile/your-bu-email/

_Alumni who graduated after 2011 could take their @bu.edu Google-based email account with them when they graduated, but over two-thirds of BU alumni were limited to an email forwarding service. We’re pleased to announce that the time has come when all BU alumni now have the opportunity to register for a full BU email account. A new @bu.edu account entitles you to access all alumni benefits, including BU Google email and the online BU G-Suite apps._

So according to the official alumni website of bu.edu, all graduates will be allowed to use their student email as lifetime alumni email, which could be abused by alumni of this university, so it would be necessary to add bu.edu in stoplist.txt