### PR TITLE
Add Kaohsiung Senior High School

### DIFF
--- a/lib/domains/tw/edu/kh/kshs/student.txt
+++ b/lib/domains/tw/edu/kh/kshs/student.txt
@@ -1,0 +1,2 @@
+高雄市立高雄高級中學
+Kaohsiung Municipal Kaohsiung Senior High School


### PR DESCRIPTION
School site:
https://www.kshs.kh.edu.tw/
School email:
example@student.kshs.kh.edu.tw
School address:
No. 50, Jianguo 3rd Rd., Sanmin Dist., Kaohsiung City 807302 , Taiwan (R.O.C.)