### PR TITLE
Add Don Bosco College - Canlubang

### DIFF
--- a/lib/domains/ph/edu/donbosco.txt
+++ b/lib/domains/ph/edu/donbosco.txt
@@ -1,0 +1,1 @@
+Don Bosco College - Canlubang


### PR DESCRIPTION
Don Bosco College - Canlubang (https://donboscocanlubang.edu.ph) is a member of Don Bosco Educational Centers (DBEC) - Philippines (http://one-bosco.org)