### PR TITLE
Add Don Bosco Educational Centers (DBEC) - PHL

### DIFF
--- a/lib/domains/ph/edu/donbosco.txt
+++ b/lib/domains/ph/edu/donbosco.txt
@@ -1,0 +1,3 @@
+Don Bosco Educational Centers (DBEC) - Philippines
+Don Bosco College
+.group


### PR DESCRIPTION
Official website http://one-bosco.org/ members https://donboscocanlubang.edu.ph/ https://donboscomakati.edu.ph/ https://www.dbtarlac.edu.ph/ http://dbst.edu.ph/

Don Bosco College - Canlubang offers BS Information Technology which is similar/related to BS Computer Science in the Philippines

https://donboscocanlubang.edu.ph/college-admission/

This shows the email with domain donbosco.edu.ph (aside from the domain is shown in the main website http://one-bosco.org)
http://dbst.edu.ph/contact-us/