### PR TITLE
add Muskegon Community College

### DIFF
--- a/lib/domains/edu/muskegoncc.txt
+++ b/lib/domains/edu/muskegoncc.txt
@@ -1,0 +1,1 @@
+Muskegon Community College


### PR DESCRIPTION
College website: [https://www.muskegoncc.edu/](https://www.muskegoncc.edu/)

See the college's [course catalog for 2023](https://www.muskegoncc.edu/academic-affairs/wp-content/uploads/sites/51/2023/06/MCC-Cat-23-24-WEB_UpdatedMay2023.pdf) which lists provided courses including (but not limited to) 
- software development
- web game development entrepeneur
- website development entrepeneur

Under the 'associate in applied science degree'.

On page 52 of the course catalog document [this paragraph](https://github.com/JetBrains/swot/assets/28568841/e51f6268-d1d0-4d22-a24d-3ddec66f375b) demonstrates the aforementioned course is sufficiently long-term.

For proof that the domain is used for student email addresses, I believe these (admittedly dated) documents should suffice: 
- [How to Forward MCC Mail](http://www.muskegoncc.edu/PDFFiles/OIT/Student%20How-To/ForwardMCCMail.pdf)
- [How to access your mail](http://www.muskegoncc.edu/Include/HowtoaccessyourMuskegonCommunityCollegeemailaccount.pdf)