### PR TITLE
Gimnazija vič

### DIFF
--- a/lib/domains/org/gimvic.txt
+++ b/lib/domains/org/gimvic.txt
@@ -1,0 +1,1 @@
+Gimnazija vič, Ljubljana, Slovenija

--- a/lib/domains/si/gimvic.txt
+++ b/lib/domains/si/gimvic.txt
@@ -1,0 +1,1 @@
+Gimnazija vič, Ljubljana, Slovenija


### PR DESCRIPTION
Gimnazija vič. Slovenija.
Gimnazija in Ljubljana Slovenija.
official website: [GIMVIC](https://www.gimvic.org/)