### PR TITLE
Add SMK PGRI Ngadirojo

### DIFF
--- a/lib/domains/id/sch/smkpgringadirojo-pct.txt
+++ b/lib/domains/id/sch/smkpgringadirojo-pct.txt
@@ -1,0 +1,2 @@
+SMK PGRI Ngadirojo
+SMK PGRI Ngadirojo


### PR DESCRIPTION
Hi JetBrains

Please add my school into swot 

SMK PGRI Ngadirojo is Located at Pacitan, Indonesia

Here is a Screenshoot of Web and Maps of SMK PGRI Ngadirojo

<img width="1148" alt="Screenshot 2024-03-30 at 15 36 05" src="https://github.com/JetBrains/swot/assets/2813753/aea313d9-cab1-46f8-8590-ffc6a591b361">

Here is a Proof of cPanel Access into SMK PGRI Ngadirojo

<img width="1337" alt="Screenshot 2024-03-30 at 15 39 28" src="https://github.com/JetBrains/swot/assets/2813753/ff7183aa-fc0b-475d-8262-6bec9619d40f">

Thank you so much for your attention 😃 