### PR TITLE
Add 3rd-level domain name for Yangzhou University

### DIFF
--- a/lib/domains/cn/edu/yzu/365.txt
+++ b/lib/domains/cn/edu/yzu/365.txt
@@ -1,0 +1,1 @@
+Yangzhou University

--- a/lib/domains/cn/edu/yzu/stu.txt
+++ b/lib/domains/cn/edu/yzu/stu.txt
@@ -1,0 +1,1 @@
+Yangzhou University


### PR DESCRIPTION
[Yangzhou University](https://www.yzu.edu.cn) has 3 available email domains infact:

- *@yzu.edu.cn for faculties
- *@stu.yzu.edu.cn for students
- *@365.yzu.edu.cn is special, the mailbox will automatically allocate to users when creating a Microsoft 365 account. Unlike *@yzu.edu.cn and *@stu.yzu.edu.cn, it is operated by Microsoft Outlook 21vianet.