### PR TITLE
Add schools.mk

### DIFF
--- a/lib/domains/mk/schools.txt
+++ b/lib/domains/mk/schools.txt
@@ -1,0 +1,2 @@
+All primary and high schools
+.group


### PR DESCRIPTION
[schools.mk](https://schools.mk/) is a domain run by the Ministry of Education.

**Every student in the country** is given an email account within this domain which they use until they graduate from high school.

The students use **only** this email account for all online services (e.g., Microsoft Office 365).