### PR TITLE
Added Costa i Llobera

### DIFF
--- a/lib/domains/cat/costaillobera.txt
+++ b/lib/domains/cat/costaillobera.txt
@@ -1,0 +1,1 @@
+Institut Escola Costa i Llobera


### PR DESCRIPTION
- https://costaillobera.cat/
- Costa i Llobera Institute, located in Barcelona, Spain, is an educational institution offering high school education, including the baccalaureate program. Situated in the vibrant city of Barcelona, the institute provides a dynamic learning environment for students pursuing their secondary education. With a focus on academic excellence and holistic development, Costa i Llobera Institute aims to nurture students' intellectual curiosity and equip them with the skills necessary for their future endeavors. Embracing Barcelona's rich cultural heritage and diverse community, the institute offers a unique educational experience that prepares students for success in an interconnected world.
- 
![image](https://github.com/JetBrains/swot/assets/96847130/fba7e9f6-a3fc-4daa-9ba2-f9bdb73f5293)
![image](https://github.com/JetBrains/swot/assets/96847130/2add9f4b-f6d8-42e1-a4bb-6f0d69fe9158)
[ACTUALITZACIO-DEL-PEC-IE-Costa-i-Llobera-2nov2022.pdf](https://github.com/JetBrains/swot/files/14909240/ACTUALITZACIO-DEL-PEC-IE-Costa-i-Llobera-2nov2022.pdf)
