### PR TITLE
Adding Paxman Academy

### DIFF
--- a/lib/domains/school/paxmanacademy.txt
+++ b/lib/domains/school/paxmanacademy.txt
@@ -1,0 +1,1 @@
+Paxman Academy


### PR DESCRIPTION
School email domain: paxmanacademy.school
School website: [paxmanacademy.org.uk](https://www.paxmanacademy.org.uk)
School address: Paxman Avenue, Colchester, Essex, CO2 9DB, United Kingdom
You can find proof that the school uses the email domain above [here](https://www.paxmanacademy.org.uk/#custom_html-3) at the bottom of the home page with the admin email

The only place i can find mention of Computer Science or IT is under the curriculum page [here](https://www.paxmanacademy.org.uk/curriculum/curriculum-subjects/)