### PR TITLE
add hongseong high school

### DIFF
--- a/lib/domains/kr/cneo365/hongseong.txt
+++ b/lib/domains/kr/cneo365/hongseong.txt
@@ -1,0 +1,2 @@
+홍성고등학교
+Hongseong High School


### PR DESCRIPTION
School website: http://hongseong.cnehs.kr
School address: 49 Honghak-ro, Hongbuk-eup, Hongseong-gun, Chungcheongnam-do, Republic of Korea