### PR TITLE
CIFP Pere de Son Gall

### DIFF
--- a/lib/domains/org/cifpperedesongall.txt
+++ b/lib/domains/org/cifpperedesongall.txt
@@ -1,0 +1,1 @@
+CIFP Pere de Son Gall


### PR DESCRIPTION
adding college to apply for license "Centre integrat Formació Profesional Pere de Son Gall"
https://cifpperedesongall.org
Higher degree of development applications
domain teachers: @cifpperedesongall.org
domain students: @a.cifpperedesongall.org