### PR TITLE
Create faespi.txt

### DIFF
--- a/lib/domains/br/com/faespi.txt
+++ b/lib/domains/br/com/faespi.txt
@@ -1,0 +1,1 @@
+Faculdade de Ensino Superior do Piauí


### PR DESCRIPTION
Dominio faespi.com.br , da  Faculdade de Ensino Superior do Piauí