### PR TITLE
Queens' School, Bushey, UK

### DIFF
--- a/lib/domains/uk/sch/herts/queens.txt
+++ b/lib/domains/uk/sch/herts/queens.txt
@@ -1,0 +1,1 @@
+Queens' School


### PR DESCRIPTION
Add Queens' School, Bushey which is based in Bushey, Hertfordshire

https://www.queens.herts.sch.uk/
