### PR TITLE
Update

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -461,7 +461,6 @@ wfl.sh.edu.cn
 ict.ac.cn
 stu.nwupl.edu.cn
 uibe.edu.cn
-mail.hnust.edu.cn
 stu.fafu.edu.cn
 uibe.edu.cn
 mail.scuec.edu.cn


### PR DESCRIPTION
I found that my school domain name was removed from the trust list, because I don’t know when it was removed, but according to the current policy, the school has recently updated a new system, and all functions have been integrated into the new app, the school mailbox only allows students to self-register, it should not be abused, If there is any abuse, you can cancel it directly，please conduct an internal investigation Assess whether recovery is possible.Below is the policy link:
[https://nic.hnust.edu.cn/tzzx/ggtz/eea429040b8f4b61bdc2fa2dc9a83c69.htm](url)