### PR TITLE
Update

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -321,7 +321,6 @@ s.upc.edu.cn
 swpu.edu.cn
 swu.edu.cn
 sxlg.ac.cn
-sz.pku.edu.cn
 tijmu.edu.cn
 tjdx.ac.cn
 tju.edu.cn


### PR DESCRIPTION
I found that my school domain name was removed from the trust list, because I don’t know when it was removed, but according to the current policy, This email address is currently only available to students of Shenzhen Graduate School, Alumni who previously used this email address have been transferred to @pku.org.cn according to the new policy, it should not be abused, If there is any abuse, you can cancel it directly，please conduct an internal investigation Assess whether recovery is possible.