### PR TITLE
Add IMPAN

### DIFF
--- a/lib/domains/pl/impan.txt
+++ b/lib/domains/pl/impan.txt
@@ -1,0 +1,1 @@
+Institute of Mathematics, Polish Academy of Sciences


### PR DESCRIPTION
IMPAN together with the Faculty of Mathematics, Informatics and Mechanics of the Warsaw University, is part of the Warsaw Doctoral School of Mathematics and Computer Science (https://www.mimuw.edu.pl/en/studies/phd-studies/)

- List of PhD students at IMPAN, together with e-mails in the impan.pl domain: https://www.impan.pl/en/activities/doktoranci