### PR TITLE
add the EIGSI Casablanca

### DIFF
--- a/lib/domains/ma/eigsica.txt
+++ b/lib/domains/ma/eigsica.txt
@@ -1,0 +1,1 @@
+EIGSI Casablanca


### PR DESCRIPTION
I added the domain of the École d'ingénieurs en génie des systèmes industriels de Casablanca (Engineering school in Industrial Systems Engineering of Casablanca). The school offers a 5 year formation for obtaining a general engineering degree recognized both by the french and moroccan states. The formation contains many courses including IT