### PR TITLE
Add Gomarus College

### DIFF
--- a/lib/domains/nl/gomaruscollege.txt
+++ b/lib/domains/nl/gomaruscollege.txt
@@ -1,0 +1,1 @@
+Gomarus College


### PR DESCRIPTION
Adds Gomarus College, a High School in Groningen, Netherlands offering a computer science course [[source](https://163.wpcdnnode.com/gomaruscollege.nl/wp-content/uploads/2023/09/pta-6gym-vp1-23-24-1-10-23-1.pdf) linked at [Examen & PTA](https://gomaruscollege.nl/praktische-informatie/leerlingen/examen-en-pta/)].

Students are assigned an email with a 6-digit number and the requested domain, eg. 123456@gomaruscollege.nl

