### PR TITLE
Adding KIT Amsterdam university

### DIFF
--- a/lib/domains/nl/kit/student.txt
+++ b/lib/domains/nl/kit/student.txt
@@ -1,0 +1,1 @@
+Royal Tropical Institute, Amsterdam


### PR DESCRIPTION
Adding (KIT, Royal Tropical Institute) in Amsterdam to the university list.