### PR TITLE
Add KKOS Berlin to list of schools

### DIFF
--- a/lib/domains/net/kkos.txt
+++ b/lib/domains/net/kkos.txt
@@ -1,0 +1,1 @@
+Käthe-Kollwitz-Gymnasium Berlin


### PR DESCRIPTION
KKG is a maths and CS focused school in Berlin, Germany.

We offer advanced CS courses (2 years) from 11th to 12th grade. Students can also enroll into "Frühstudium", an early offer to start CS courses from university early before graduation.

https://www.kaethe-kollwitz-gymnasium.de/fachbereiche/mint/informatik/

kkos.net is used for mails only. The abbreviation stems from "Käthe-Kollwitz-Oberschule", the former name of the school.