### PR TITLE
St Johns Grammar School.

### DIFF
--- a/lib/domains/au/edu/sa/stjohns.txt
+++ b/lib/domains/au/edu/sa/stjohns.txt
@@ -1,0 +1,2 @@
+St John's Grammar
+St John's Grammar, 29 Gloucester Ave, Belair SA 5052


### PR DESCRIPTION
St John's Grammar School, 29 Gloucester Ave, Belair SA 5052, (https://stjohns.sa.edu.au).