### PR TITLE
Fork for EPSI computer sciences school

### DIFF
--- a/lib/domains/net/mail-formateur.txt
+++ b/lib/domains/net/mail-formateur.txt
@@ -1,0 +1,1 @@
+EPSI Ecole d'Ingénierie Informatique


### PR DESCRIPTION
Add of EPSI France computer sciences school (www.epsi.fr) with emails domain mail-formateur.net belonging to group Competences et Developpement, IFAG Paris. 

the university official website URL, if it is different from the domain you are submitting : www.epsi.fr
a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university : https://www.epsi.fr/programmes/ingenierie-informatique/
a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students. 

[Pull Request to add EPSI mail-formateur.net domain.pdf](https://github.com/JetBrains/swot/files/15313666/Pull.Request.to.add.EPSI.mail-formateur.net.domain.pdf)
