### PR TITLE
Add The Westleigh School

### DIFF
--- a/lib/domains/org/set/westleigh.txt
+++ b/lib/domains/org/set/westleigh.txt
@@ -1,0 +1,1 @@
+The Westleigh School (Shaw Education Trust)


### PR DESCRIPTION
Another commit to add The Westleigh School (part of Shaw Education Trust). Was detected as fraud last time but thought I would try again.