### PR TITLE
Added Triamudom Suksa School

### DIFF
--- a/lib/domains/th/ac/triamudom/student.txt
+++ b/lib/domains/th/ac/triamudom/student.txt
@@ -1,0 +1,2 @@
+โรงเรียนเตรียมอุดมศึกษา
+Triamudom Suksà School


### PR DESCRIPTION
Added Triamudom Suksa School per request from school director and student 
Website : traimudom.ac.th
Location : 227 Phaya Thai Rd., Pathum wan, Pathum Wan, Bangkok, 10300