### PR TITLE
Add Technical School of Rio de Janeiro

### DIFF
--- a/lib/domains/br/com/eterj.txt
+++ b/lib/domains/br/com/eterj.txt
@@ -1,0 +1,2 @@
+Escola Técnica do Rio de Janeiro
+Technical School of Rio de Janeiro


### PR DESCRIPTION
- [Official website URL](https://eterj.com.br/)
- [URL of the long-term IT-related course offered](https://www.eterj.com.br/nossos-cursos/informatica)
- Screenshot of the recognition of the domain as the official domain:
![Captura de imagem_20240517_011222](https://github.com/JetBrains/swot/assets/104698169/df71a6d9-337e-4798-bd67-b1136e9c3b92)
