### PR TITLE
Add Highlands Community Charter and Technical Schools

### DIFF
--- a/lib/domains/org/hccts/student.txt
+++ b/lib/domains/org/hccts/student.txt
@@ -1,0 +1,2 @@
+Highlands Community Charter and Technical Schools
+Highlands Community Charter and Technical Schools


### PR DESCRIPTION
Add Highlands Community Charter and Technical Schools – Sacramento to domain list