### PR TITLE
Add DIPTI

### DIFF
--- a/lib/domains/bd/com/netpoint/dipti.txt
+++ b/lib/domains/bd/com/netpoint/dipti.txt
@@ -1,0 +1,1 @@
+Daffodil International Professional Training Institute


### PR DESCRIPTION
Name: Daffodil International Professional Training Institute
Website: [https://dipti.com.bd/](https://dipti.com.bd)
Official Address: Daffodil Plaza, Shobhanbag, Dhanmondi, Dhaka, Bangladesh
1 year Courses proof link: [https://dipti.com.bd/professional-diploma-courses.html](https://dipti.com.bd/professional-diploma-courses.html)