### PR TITLE
Add email.ncku.edu.tw

### DIFF
--- a/lib/domains/tw/edu/ncku/email.txt
+++ b/lib/domains/tw/edu/ncku/email.txt
@@ -1,0 +1,2 @@
+國立成功大學
+National Cheng Kung University


### PR DESCRIPTION
Hello, I would like to apply to add email.ncku.edu.tw.

According to the last point of Article 4, Item 1 of the current school email policy([https://cc.ncku.edu.tw/p/412-1213-29175.php?Lang=en](url)) , the email policy for NCKU academic and administrative staff :
Retirees (already and future) may preserve their personal NCKU email accounts (self-created account@mail.ncku.edu.tw) permanently for communicating related school rights and interests after retirement. The school email account (zEmployeeID@email.ncku.edu.tw) will be terminated and deleted.

Therefore, the holders of email.ncku.edu.tw are all current academic staff of our school and should be in compliance with the policies established by your company. Please assist in the review. Thank you.