### PR TITLE
org/mjbha

### DIFF
--- a/lib/domains/org/mjbha.txt
+++ b/lib/domains/org/mjbha.txt
@@ -1,0 +1,1 @@
+Berman Hebrew Academy


### PR DESCRIPTION
Adding domain for Melving J Berman Hebrew Academy mjbha.org (high school US-MD) to access free educational tier