### PR TITLE
Canberra Institute of Technology

### DIFF
--- a/lib/domains/au/edu/cit.txt
+++ b/lib/domains/au/edu/cit.txt
@@ -1,0 +1,1 @@
+Canberra Institute of Technology


### PR DESCRIPTION
Canberra Institute of Technology uses cit.edu.au for teaching staff and students.cit.edu.au for students.

students.cit.edu.au appears to already be in the list of approved domains.