### PR TITLE
Add kiwi.txt for Kiwi College of New Zealand

### DIFF
--- a/lib/domains/nz/ac/kiwi.txt
+++ b/lib/domains/nz/ac/kiwi.txt
@@ -1,0 +1,1 @@
+Kiwi College of New Zealand


### PR DESCRIPTION
## A college located in Auckland, New Zealand

### School Name
**Kiwi College of New Zealand**

### School Official Website
**https://kiwi.ac.nz/**

### Email Users
- [ ] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni

### Education Levels
- [ ] Post-graduate research
- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [x] High School or equivalent
- [ ] Elementary School or equivalent