### PR TITLE
Add IIS Ferraris - Pancaldo (ferrarispancaldo.net)

### DIFF
--- a/lib/domains/net/ferrarispancaldo.txt
+++ b/lib/domains/net/ferrarispancaldo.txt
@@ -1,0 +1,2 @@
+IIS Ferraris - Pancaldo
+Technical School Ferraris - Pancaldo


### PR DESCRIPTION
Add IIS Ferraris - Pancaldo (ferrarispancaldo.net) to domains
Official website is, however, https://ferrarispancaldo.edu.it/ as our Ministry of Education recently refreshed the domains for all schools