### PR TITLE
Add Gymnasium Schiller-Schule Bochum

### DIFF
--- a/lib/domains/de/iserv-schiller-schule.txt
+++ b/lib/domains/de/iserv-schiller-schule.txt
@@ -1,0 +1,1 @@
+Schiller-Schule Bochum


### PR DESCRIPTION
- gymnasium official website: https://www.schiller-bochum.de/

- URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www.schiller-bochum.de/joomla/index.php/lernen/unterrichtsfaecher?view=article&id=17:informatik&catid=15:faecher

- a URL of a page or some other proof showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://www.schiller-bochum.de/joomla/images/Lernen/Downloads/Medienkonzept.pdf (please refer to page 10) 