### PR TITLE
new student domain for berufskolleg technik

### DIFF
--- a/lib/domains/de/berufskolleg-technik.txt
+++ b/lib/domains/de/berufskolleg-technik.txt
@@ -1,0 +1,1 @@
+Berufskolleg Technik des Kreises Siegen-Wittgenstein


### PR DESCRIPTION
- [Official website](https://berufskolleg-technik.de/)
- [Long-term IT related course](https://berufskolleg-technik.de/berufsschule/) (This is a German vocational school. Here the three-year apprenticeship "Fachinformatiker"/IT specialist is taught.)
- The main domain berufskolleg-technik.de now also gets used for student email accounts.