### PR TITLE
[bme.hu] Remove domains that doesn't require status

### DIFF
--- a/lib/domains/hu/bme/sch.txt
+++ b/lib/domains/hu/bme/sch.txt
@@ -1,2 +1,0 @@
-Budapesti Műszaki és Gazdaságtudományi Egyetem
-Budapest University of Technology and Economics


### PR DESCRIPTION
Most people having **sch**.bme.hu are students/teachers, but it is possible to get sch.bme.hu email without any status.