### PR TITLE
Add Uttarakhand Technical University

### DIFF
--- a/lib/domains/in/net/uktech.txt
+++ b/lib/domains/in/net/uktech.txt
@@ -1,0 +1,1 @@
+Uttarakhand Technical University


### PR DESCRIPTION
Please add Veer Madho Singh Bhandari Uttarakhand Technical University (UTU) with the domain 'uktech.net.in' to the list of domains. 
The official website is https://uktech.ac.in/en.