### PR TITLE
Made sure that Technical University of Munich (TUM) follows SWOT-Rules

### DIFF
--- a/lib/domains/de/mytum.txt
+++ b/lib/domains/de/mytum.txt
@@ -1,1 +1,0 @@
-Technical University of Munich

--- a/lib/domains/de/tu-muenchen.txt
+++ b/lib/domains/de/tu-muenchen.txt
@@ -1,1 +1,0 @@
-Technical University of Munich

--- a/lib/domains/de/tum.txt
+++ b/lib/domains/de/tum.txt
@@ -1,1 +1,0 @@
-Technical University of Munich

--- a/lib/domains/de/tum/sw/jetbrains.txt
+++ b/lib/domains/de/tum/sw/jetbrains.txt
@@ -1,0 +1,2 @@
+Technical University of Munich
+Technische Universität München


### PR DESCRIPTION
Hello,

This PR aims to rectify our students being able to scam you.
It is originally motivate by us [being on the stoplist](https://github.com/JetBrains/swot/blob/d9f37f913a6ab6208c86c5ce08fd275a56d010f0/lib/domains/stoplist.txt#L1904-L1904) (somehow that is not in effect any longer 🤷🏻‍♂️)

`tum.de`, `tu-muenchen.de`,`mytum.de` are all provided for students/nonacademic staff/academic staff for life.
Sending emails from these domains stops when the students/staff stops being a member.
Our docs to prove this: https://www.it.tum.de/en/it/faq/e-mail/e-mail-in-general/what-is-lifelong-forwarding/

TUMs IT-Management has introduced a special domain (like for adobe/..) to solve this.
It is scoped to JetBrains' rules and does only allow active students and active academic staff (current professors, current phds) to have this email.

If you want to verify that this information is correct, my email adress is ztpedtbd {at) jetbrains.sw.tum.de

We will publish our wiki article how to access the software after the PR is merged, if possible to avoid unnessesary frustration.

> [!TIP]
> If another student looks at this, you need to activate your email at https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_wbswdist.addresses

PS: thanks for the work you do ^^