### PR TITLE
Added usms.ac.ma and fpk.ac.ma domains

### DIFF
--- a/lib/domains/ma/ac/fpk.txt
+++ b/lib/domains/ma/ac/fpk.txt
@@ -1,0 +1,3 @@
+Faculté Polydisciplinaire de Khouribga
+Polydisciplinary College of Khouribga
+FPK

--- a/lib/domains/ma/ac/usms.txt
+++ b/lib/domains/ma/ac/usms.txt
@@ -1,3 +1,4 @@
 Université Sultan Moulay Slimane
 Sultan Moulay Slimane University
 USMS
+.group


### PR DESCRIPTION
Sultan Moulay Slimane University (USMS) uses two domains for their emails, `@usms.ma` is mainly used by professors, while `@usms.ac.ma` is assigned to students.
You learn more about the university and its several institutions through this page : https://www.usms.ac.ma/en/node/111

The Polydisciplinary College of Khouribga (FPK) is an institution of USMS and mainly uses the same domains for their emails (`@usms.ac.ma` and `@usms.ma`), but sometimes professors can have an `@fpk.ac.ma` email.
You learn more about the college through : http://www.fpk.ac.ma/
And here's a link of a long-term (3 years) IT related course is offered : http://www.fpk.ac.ma/formation/licence-fondamentale/sciences-mathematiques-et-informatique