### PR TITLE
add Suez Canal University

### DIFF
--- a/lib/domains/eg/edu/suez/ci.txt
+++ b/lib/domains/eg/edu/suez/ci.txt
@@ -1,0 +1,2 @@
+Suez Canal University
+Suez Canal University

--- a/lib/domains/eg/edu/suezcanaluni.txt
+++ b/lib/domains/eg/edu/suezcanaluni.txt
@@ -1,0 +1,2 @@
+Suez Canal University
+Suez Canal University


### PR DESCRIPTION
the university official website URL:
- https://suez.edu.eg/ar/en/

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
- https://suez.edu.eg/ar/en/
- https://suez.edu.eg/ar/en/faculty-of-computing-and-information/