### PR TITLE
Update university email domain eppuz.edu.pl to eans-nt.edu.pl

### DIFF
--- a/lib/domains/pl/edu/eans-nt.txt
+++ b/lib/domains/pl/edu/eans-nt.txt
@@ -1,0 +1,1 @@
+Akademia Nauk Stosowanych w Nowym Targu

--- a/lib/domains/pl/edu/eppuz.txt
+++ b/lib/domains/pl/edu/eppuz.txt
@@ -1,1 +1,0 @@
-Podhalańska Państwowa Uczelnia Zawodowa


### PR DESCRIPTION
The university has changed its name from Podhalańska Państwowa Uczelnia Zawodowa to the Akademia Nauk Stosowanych w Nowym Targu. Therefore, the web and email domains have been changed. (old www domail: https://ppuz.edu.pl, old email domain eppuz.edu.pl)

* the university official website URL: https://ans-nt.edu.pl/

* a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://ans-nt.edu.pl/kandydat/studia-i-stopnia/informatyka-ekonomiczna/

*a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://ans-nt.edu.pl/student/ksztalcenie-zdalne/
(google classroom section)
