### PR TITLE
Adding colorado.edu

### DIFF
--- a/lib/domains/edu/colorado.txt
+++ b/lib/domains/edu/colorado.txt
@@ -1,0 +1,1 @@
+University of Colorado Boulder


### PR DESCRIPTION
Adding colorado.edu domain (University of Colorado - Boulder)