### PR TITLE
added the mount vernon school

### DIFF
--- a/lib/domains/org/mountvernonschool.txt
+++ b/lib/domains/org/mountvernonschool.txt
@@ -1,0 +1,1 @@
+The Mount Vernon School


### PR DESCRIPTION
School name: The Mount Vernon School
Email Domain: mountvernonschool.org
Website: www.mountvernonschool.org
Address: 510 Mount Vernon Hwy, Atlanta, GA 30328
Course: https://docs.google.com/document/d/16ROP2MeUeh6sHZwk_SdJWKKeEwfgMqBabMkBieRrfYw/edit#heading=h.3yyw2j45qj64
