### PR TITLE
add the UFABC school domain

### DIFF
--- a/lib/domains/br/edu/ufabc.txt
+++ b/lib/domains/br/edu/ufabc.txt
@@ -1,0 +1,2 @@
+Universidade Federal do ABC
+Federal University of ABC


### PR DESCRIPTION
In Brazil, newer universities have the edu.br domain, such as https://www.ufabc.edu.br