### PR TITLE
Add *@mail.rmutt.ac.th

### DIFF
--- a/lib/domains/th/ac/rmutt/mail.txt
+++ b/lib/domains/th/ac/rmutt/mail.txt
@@ -1,0 +1,3 @@
+Rajamangala University of Technology Thanyaburi
+RMUTT
+มหาวิทยาลัยเทคโนโลยีราชมงคลธัญบุรี


### PR DESCRIPTION
The RMUTT has 2 email domains for their students

- `*@rmutt.ac.th` this is for teacher and the students in master degree or above
- `*@mail.rmutt.ac.th` this is for Bachelor students

The present commit has only domain for the master degree student, so I'm going to add a Bachelor student's domain by simply added the `/lib/domains/th/ac/rmutt/mail.txt`