### PR TITLE
add University of Nigeria (unn) domain

### DIFF
--- a/lib/domains/ng/edu/unn.txt
+++ b/lib/domains/ng/edu/unn.txt
@@ -1,0 +1,2 @@
+University of Nigeria
+University of Nigeria, Nsukka


### PR DESCRIPTION
added domain for the [University of Nigeria, Nsukka](https://www.unn.edu.ng/)
