### PR TITLE
Added Highfield School and 6th form to domains

### DIFF
--- a/lib/domains/uk/sch/herts/highfield.txt
+++ b/lib/domains/uk/sch/herts/highfield.txt
@@ -1,0 +1,1 @@
+The Highfield School and Sixth Form


### PR DESCRIPTION
The Highfield School and Sixth Form

highfield.herts.sch.uk

GCSE Computer Science course and A-Level Computer Science

https://www.highfield.herts.sch.uk/84/sixth-form-courses

The Google Classroom user guide on this page has proof of the domain being used for students.
highfield.herts.sch.uk/53/digital-learning