### PR TITLE
added Karl-Maybach-Gymnasium Friedrichshafen

### DIFF
--- a/lib/domains/de/kmg-fn.txt
+++ b/lib/domains/de/kmg-fn.txt
@@ -1,0 +1,1 @@
+Karl-Maybach-Gymnasium Friedrichshafen

--- a/lib/domains/de/kmgfn.txt
+++ b/lib/domains/de/kmgfn.txt
@@ -1,0 +1,1 @@
+Karl-Maybach-Gymnasium Friedrichshafen


### PR DESCRIPTION
Added the Karl-Maybach-Gymnasium Friedrichshafen.

Teachers use the kmg-fn.de domain
Pupils use the kmgfn.de domain

Both domains are linked to each other. When being on kmg-fn.de you can click on IServ on the header. Then you land on a subdomain of kmgfn.de When clicking the "impressum" on the bottom of this login-screen, you're back on kmg-fn.de

Thanks!