### PR TITLE
Added Step IT Academy domain

### DIFF
--- a/lib/domains/md/itstep/student.txt
+++ b/lib/domains/md/itstep/student.txt
@@ -1,0 +1,1 @@
+STEP IT Academy


### PR DESCRIPTION
Adding the `itstep.md` domain for STEP IT Academy.

Official website  - https://itstep.md
Software Course 2 years with study plan: https://itstep.md/software-development 
Proof of official email domain - so for like global organization Step It Academy uses .org domain in Moldova is infomd@itstep.org how you see from contact page https://itstep.md/contacts_14
But for students from Moldova, they create emails like this Ceba_yp56@student.itstep.md   with the md domain.

![image](https://github.com/JetBrains/swot/assets/69801190/e942432d-5767-449a-b6b0-9467c84e0de0)

if you need more proofs the mail domain is valid please reach to me at  Ceba_yp56@student.itstep.md 
