### PR TITLE
Add ENSA Fès part of Université Sidi Mohammed Ben Abdellah

### DIFF
--- a/lib/domains/ma/ac/usmba.txt
+++ b/lib/domains/ma/ac/usmba.txt
@@ -1,0 +1,1 @@
+École Nationale des Sciences Appliquées de Fès


### PR DESCRIPTION
https://ensaf.ac.ma/
https://ensaf.ac.ma/?controller=pages&action=info

Most teachers mails have the usmba.ac.ma domain which is the same we use as students.
https://ensaf.ac.ma/?controller=pages&action=depgei

And as you can see in this link .. the institutional mail there is the same
https://ensaf.ac.ma/?controller=pages&action=lisa

Also, the institution is part of the Sidi Mohammed Ben Abdellah University as you can see in the home page .. which uses the same domain