### PR TITLE
added epfedu.txt

### DIFF
--- a/lib/domains/fr/epfedu.txt
+++ b/lib/domains/fr/epfedu.txt
@@ -1,0 +1,1 @@
+EPF Ecole d'Ingénieurs


### PR DESCRIPTION
School official website : https://www.epf.fr/

This is educational domain vs epf.fr which is reserved to administration.