### PR TITLE
Add University of Rochester to list of Universities

### DIFF
--- a/lib/domains/edu/rochester/u.txt
+++ b/lib/domains/edu/rochester/u.txt
@@ -1,0 +1,1 @@
+University of Rochester


### PR DESCRIPTION
Added rochester file which contains u.txt in order to add University of Rochester as a university for a Data Spell license.