### PR TITLE
add @morrisonsislandcampus domain

### DIFF
--- a/lib/domains/ie/morrisonsislandcampus.txt
+++ b/lib/domains/ie/morrisonsislandcampus.txt
@@ -1,0 +1,1 @@
+Cork College of Commerce


### PR DESCRIPTION
Domain address: @morrisonsislandcampus.com
College Name: Cork College of Commerce, Cork College of FET
College Website: https://morrisonsislandcampus.ie/
Location: Cork, Ireland