### PR TITLE
Add St Peter's College into this list.

### DIFF
--- a/lib/domains/nz/school/st-peters.txt
+++ b/lib/domains/nz/school/st-peters.txt
@@ -1,0 +1,1 @@
+St Peter's College


### PR DESCRIPTION
St Peter's College is in Auckland, New Zealand.