### PR TITLE
feat: Add Al-Azhar University to JetBrains Free Educational Licenses

### DIFF
--- a/lib/domains/eg/edu/azhar.txt
+++ b/lib/domains/eg/edu/azhar.txt
@@ -1,0 +1,2 @@
+Al-Azhar University
+Al-Azhar University


### PR DESCRIPTION
Included Al-Azhar University in the list of schools eligible for JetBrains Free Educational Licenses.