### PR TITLE
Add Western Caspian University

### DIFF
--- a/lib/domains/az/edu/wcu.txt
+++ b/lib/domains/az/edu/wcu.txt
@@ -1,0 +1,1 @@
+Western Caspian University


### PR DESCRIPTION
Add Western Caspian University

- Website: https://wcu.edu.az/en
- Example for a long-term (>1 year) IT related course: https://wcu.edu.az/en/faculties/computer-engineering


**Note:** 
This is a new domain for https://github.com/JetBrains/swot/blob/master/lib/domains/az/edu/wu.txt, which is already listed in this repository. The university renamed itself as "Western Caspian University" in 2017. You can verify this by visiting https://wu.edu.az, it will redirect you to the new domain https://wcu.edu.az.

Not deleting the old domain because it is still owned and used by the university.
