### PR TITLE
Add Marmara University (marun.edu.tr)

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Marmara University uses both **marmara.edu.tr** and **marun.edu.tr**