### PR TITLE
Add Memorial University of Newfoundland 

### DIFF
--- a/lib/domains/ca/nl/mun.txt
+++ b/lib/domains/ca/nl/mun.txt
@@ -1,0 +1,1 @@
+Memorial University of Newfoundland


### PR DESCRIPTION
Add Memorial University of Newfoundland

    Website: https://www.mun.ca/
    Example for a long-term (>1 year) IT related course: https://www.mun.ca/become/graduate/programs-and-courses/engineering-and-applied-science/

Note:
  The university also goes by the name  - Memorial University of Newfoundland and Labrador