### PR TITLE
New email domain for University of South Alabama

### DIFF
--- a/lib/domains/edu/southalabama/jagmail.txt
+++ b/lib/domains/edu/southalabama/jagmail.txt
@@ -1,0 +1,1 @@
+University of South Alabama


### PR DESCRIPTION
Also present under old domain at lib\domains\edu\usouthal.txt

University of South Alabama
School page:
https://www.southalabama.edu/

Computer Science Page:
https://www.southalabama.edu/colleges/soc/

Confirmation of usage of *@jagmail.southalabama.edu
https://www.southalabama.edu/services/jagnet/about.html