### PR TITLE
Add Robert Morris University

### DIFF
--- a/lib/domains/rmu/mail.txt
+++ b/lib/domains/rmu/mail.txt
@@ -1,0 +1,1 @@
+Robert Morris University


### PR DESCRIPTION
Adding Robert Morris University to the domain list.
https://www.rmu.edu/