### PR TITLE
Added ESPOL to the list of universities in Ecuador

### DIFF
--- a/lib/domains/ec/edu/espol.txt
+++ b/lib/domains/ec/edu/espol.txt
@@ -1,0 +1,1 @@
+Escuela Superior Politecnica del Litoral


### PR DESCRIPTION
Added ESPOL (Escuela Superior Politecnica del Litoral) to the list of domains.