### PR TITLE
Ajout de l'Institut MathFinEco

### DIFF
--- a/file/lib/domains/org/mathfineco.txt
+++ b/file/lib/domains/org/mathfineco.txt
@@ -1,0 +1,2 @@
+ Institut Universitaire MathFinEco
+MathFinEco University Institute

--- a/file/lib/domains/org/mathfineco.txt
+++ b/file/lib/domains/org/mathfineco.txt
@@ -1,2 +1,0 @@
- Institut Universitaire MathFinEco
-MathFinEco University Institute

--- a/lib/domains/org/mathfineco.txt
+++ b/lib/domains/org/mathfineco.txt
@@ -1,0 +1,2 @@
+Institut Universitaire MathFinEco
+MathFinEco University Institute


### PR DESCRIPTION
### Institution
Institut MathFinEco

### Domaine de l'email
mathfineco.edu
mathfineco.edu@gmail.com 
info@mathfineco.org

### Justification
Ajout de l'Institut MathFinEco pour permettre aux étudiants d'obtenir des licences éducatives pour les produits JetBrains.