### PR TITLE
Added colorado.edu domain back to Jetbrains

### DIFF
--- a/lib/domains/edu/colorado.txt
+++ b/lib/domains/edu/colorado.txt
@@ -1,0 +1,1 @@
+University of Colorado at Boulder


### PR DESCRIPTION
University of Colorado at Boulder has two email domains now - cu.edu and colorado.edu - both are missing from this list. Added colorado.edu domain back to the list. 