### PR TITLE
Add State university of economics and technology

### DIFF
--- a/lib/domains/ua/dp/kneu.txt
+++ b/lib/domains/ua/dp/kneu.txt
@@ -1,0 +1,2 @@
+Державний університет економіки і технологій
+State university of economics and technology

--- a/lib/domains/ua/edu/duet.txt
+++ b/lib/domains/ua/edu/duet.txt
@@ -1,0 +1,2 @@
+Державний університет економіки і технологій
+State university of economics and technology


### PR DESCRIPTION
Add "State university of economics and technology" from Kryvyi Rih
Dnipropetrovs'ka oblast.
Site: https://www.duet.edu.ua/en
Mail domain: kneu.dp.ua and duet.edu.ua