### PR TITLE
Add deanza.edu email domain, student emails are @student.deanza.edu

### DIFF
--- a/lib/domains/edu/deanza.txt
+++ b/lib/domains/edu/deanza.txt
@@ -1,0 +1,1 @@
+De Anza College


### PR DESCRIPTION
De Anza College is part of the Foothill-De Anza Community College District. The district domain is [already approved (fhda.edu)](https://github.com/JetBrains/swot/blob/master/lib/domains/edu/fhda.txt)

University URL: https://www.deanza.edu
URL showing list of 2-year college degree programs and certificates: https://www.deanza.edu/academics/degrees-and-certificates.html
URL with instructions on requesting a student email address: https://deanza.edu/students/email.html