### PR TITLE
Added Citrus College domains

### DIFF
--- a/lib/domains/edu/citruscollege.txt
+++ b/lib/domains/edu/citruscollege.txt
@@ -1,0 +1,1 @@
+Citrus College

--- a/lib/domains/edu/citruscollege/student.txt
+++ b/lib/domains/edu/citruscollege/student.txt
@@ -1,0 +1,1 @@
+Citrus College


### PR DESCRIPTION
Citrus College domains include '@student.citruscollege.edu' and '@citruscollege.edu'