### PR TITLE
Add folkestonegirls 

### DIFF
--- a/lib/domains/uk/sch/Kent/folkestonegirls.txt
+++ b/lib/domains/uk/sch/Kent/folkestonegirls.txt
@@ -1,0 +1,1 @@
+Folkestone School for Girls

--- a/lib/domains/uk/sch/Kent/folkestonegirls.txt
+++ b/lib/domains/uk/sch/Kent/folkestonegirls.txt
@@ -1,1 +1,0 @@
-Folkestone School for Girls

--- a/lib/domains/uk/sch/kent/folkestonegirls.txt
+++ b/lib/domains/uk/sch/kent/folkestonegirls.txt
@@ -1,0 +1,1 @@
+Folkestone School for Girls


### PR DESCRIPTION
Folkestone School for Girls

Offering Computer Science at GCSE and ALevel : https://www.folkestonegirls.kent.sch.uk/what-we-do-and-why-we-do-it/curriculum/computing/

