### PR TITLE
Adding marun.edu.tr subdomain

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi 
+Marmara University


### PR DESCRIPTION
Turkey Istanbul Marmara University has also marun.edu.tr email domain which is dedicated for student email addresses. 

You can check https://www.marmara.edu.tr/en student email(Öğrenci E-Posta) link on top navigation bar. 

The entrance address for students is https://posta.marun.edu.tr