### PR TITLE
Add `udo.edo` of TU Dortmund University (Technische Universität Dortmund)

### DIFF
--- a/lib/domains/de/tu-dortmund.txt
+++ b/lib/domains/de/tu-dortmund.txt
@@ -1,1 +1,2 @@
-Dortmund University
+Technische Universität Dortmund
+TU Dortmund University

--- a/lib/domains/edu/udo.txt
+++ b/lib/domains/edu/udo.txt
@@ -1,0 +1,2 @@
+Technische Universität Dortmund
+TU Dortmund University


### PR DESCRIPTION
Hey there, 
in this PR I'm adding another domain of the Technische Universität Dortmund (from Germany, Dortmund): `udo.edo`.

Also, I'm changing the spelling in the file `de/tu-dortmund.txt` to the official spelling, as written on https://www.tu-dortmund.de/en/.

Here are some background information and links:
- _Technische Universität Dortmund_ is the official German name
- _TU Dortmund_ is an commonly used abbreviation of the German name (as in the domain name)
- _TU Dortmund University_ is the translated English name used on the English site
- Information about the mailing system and the domains can be found in the [FAQ](https://service.tu-dortmund.de/en/faq) (search for _edu_). 
- Website in German: https://www.tu-dortmund.de/
- Website in English: https://www.tu-dortmund.de/en/
- https://udo.edu also redirect you to the above site
- Information about Computer Science (German: _Informatik_) at the TU Dortmund can be found at [cs.tu-dortmund.de](https://cs.tu-dortmund.de/en/)