### PR TITLE
Adding domain for CEME, NUST, Pakistan

### DIFF
--- a/lib/domains/pk/edu/ceme/mts.txt
+++ b/lib/domains/pk/edu/ceme/mts.txt
@@ -1,0 +1,1 @@
+College of Electrical and Mechanical Engineering, NUST, Pakistan


### PR DESCRIPTION
This domain is used for student email in the Department of Mechatronics Engineering, CEME, NUST, Pakistan
The official website is: https://ceme.nust.edu.pk/