### PR TITLE
add: YEUNGJIN UNIVERSITY

### DIFF
--- a/lib/domains/kr/ac/yju/g.txt
+++ b/lib/domains/kr/ac/yju/g.txt
@@ -1,0 +1,2 @@
+영진전문대학교
+YEUNGJIN UNIVERSITY


### PR DESCRIPTION
### YEUNGJIN UNIVERSITY
URL : https://www.yju.ac.kr/kr/index.do
IT-related courses URL : https://computer.yju.ac.kr/index.php?mid=page_VrJT47
A URL that is recognized by the university as an official email domain : https://itcenter.yju.ac.kr/xe_board_notice/6834

The URL recognized by the university as the official email domain says: “As a student of the university, you can use MS Office 365 and Windows 10 for free with your issued Gmail account (id@g.yju.ac.kr).” This page also provides instructions on how to sign up for university email and how to install MS Office 365 and Windows 11.