### PR TITLE
Add university email domain for Halla University

### DIFF
--- a/lib/domains/kr/ac/halla/hu.txt
+++ b/lib/domains/kr/ac/halla/hu.txt
@@ -1,0 +1,2 @@
+한라대학교
+Halla  University


### PR DESCRIPTION
A year ago, I received student authorization in the following email format.
@hu.halla.co.kr
When I tried to renew the education pack this time, there was no information about the university I attended.
<img width="889" alt="lol" src="https://github.com/user-attachments/assets/e41e452e-adef-40fe-b92a-8296be4ac741">


[Halla University homepage](https://www.halla.ac.kr/mbs/kr/index.jsp)
[Pages of Computer Science, Halla University](https://computer.halla.ac.kr/main/main.php)
[Computer Science Curriculum Guide Page](https://computer.halla.ac.kr/edu/02.php)

<img width="1255" alt="halla" src="https://github.com/user-attachments/assets/507a7f85-3dcc-43dc-a41b-74d39c217628">

