### PR TITLE
Add domain est.umss.edu for Universidad Mayor de San Simón

### DIFF
--- a/lib/domains/edu/umss/est.txt
+++ b/lib/domains/edu/umss/est.txt
@@ -1,0 +1,1 @@
+Universidad Mayor de San Simón


### PR DESCRIPTION
Add domain est.umss.edu for Universidad Mayor de San Simón.

- Official university URL: http://www.umss.edu.bo
- IT-related course URL: https://posgrado.fcyt.umss.edu.bo/dicscv2
- Proof of domain:
![Screenshot 2024-07-17 114458](https://github.com/user-attachments/assets/95494fee-6e5d-41bc-afc1-6bbe390bb3cc)

Thank you for considering this request!