### PR TITLE
Add domain unn.edu.ng for University of Nigeria

### DIFF
--- a/lib/domains/ng/edu/unn.txt
+++ b/lib/domains/ng/edu/unn.txt
@@ -1,0 +1,2 @@
+University Of Nigeria
+University Of Nigeria, Nsukka


### PR DESCRIPTION
Add domain `unn.edu.ng` for University of Nigeria

- Official University Website: https://unn.edu.ng/
- I.T Related Course URL: https://physicalscs.unn.edu.ng/ (Department of Computer Science can be found there)
- Proof of Student domain: https://www.unn.edu.ng/get-your-student-unn-email-address-today-2/