### PR TITLE
Add Santa Rosa Junior College

### DIFF
--- a/lib/domains/edu/santarosa/bearcubs.txt
+++ b/lib/domains/edu/santarosa/bearcubs.txt
@@ -1,0 +1,1 @@
+Santa Rosa Junior College


### PR DESCRIPTION
[School Website](https://www.santarosa.edu/)

[Domain Proof](https://welcome.santarosa.edu/bearcubs-email) Video at 1:28. Finding an official source for the bearcubs.santarosa.edu domain is difficult. This is the best I could find. But I am a student and can confirm that this is the domain for student emails. 

[Course Catalog](https://catalog.santarosa.edu/)