### PR TITLE
Update Shanghai University of Finance and Economics

### DIFF
--- a/lib/domains/cn/edu/sufe/stu.txt
+++ b/lib/domains/cn/edu/sufe/stu.txt
@@ -1,0 +1,1 @@
+Shanghai University of Finance and Economics


### PR DESCRIPTION
The URL of university's mail service now updated from name@163.sufe.edu.cn to name@stu.sufe.edu.cn (https://github.com/JetBrains/swot/pull/4774)

* University Name: Shanghai University of Finance and Economics
* official website URL: https://www.sufe.edu.cn/
* School of Information Management & Engineering: https://sime.sufe.edu.cn/
* School of Statistics & Management: https://ssm.sufe.edu.cn/
* Domain Proof: https://nitc.sufe.edu.cn/f3/8a/c11668a193418/page.htm ([Screenshot translation](https://files.melonhu.cn/proof_sufe_mail_translation.jpg))


