### PR TITLE
Add Hanoi University of Science and Technology

### DIFF
--- a/lib/domains/vn/edu/hust/sis.txt
+++ b/lib/domains/vn/edu/hust/sis.txt
@@ -1,0 +1,2 @@
+Đại học Bách Khoa Hà Nội
+Hanoi University Of Science And Technology


### PR DESCRIPTION
Add domain for Hanoi University of Science and Technology: https://hust.edu.vn/
URL of a page at the official school website that says that students use this email domain: https://ctt.hust.edu.vn/DisplayWeb/DisplayBaiViet?baiviet=34398#:~:text=K%E1%BB%83%20t%E1%BB%AB%2011%2F2017%2C%20nh%C3%A0,vn%20(GMail%20c%E1%BB%A7a%20Google).