### PR TITLE
add usil domain

### DIFF
--- a/lib/domains/pe/usil.txt
+++ b/lib/domains/pe/usil.txt
@@ -1,0 +1,1 @@
+Universidad San Ignacio de Loyola


### PR DESCRIPTION
Adding Universidad San Ignacio de Loyola, Lima, Peru.

As you can verify on this link: https://usil.edu.pe/mi-usil



<img width="920" alt="Captura de pantalla 2024-07-19 a la(s) 12 20 13 p  m" src="https://github.com/user-attachments/assets/e714a5cb-e3bf-4cd2-83a7-b40c796ad443">


The official link for students redirect to Office 360 with usil.pe as realm.
