### PR TITLE
### Add Northwest-Shoals Community College

### DIFF
--- a/lib/domains/edu/nwscc/webmail.txt
+++ b/lib/domains/edu/nwscc/webmail.txt
@@ -1,0 +1,1 @@
+Northwest-Shoals Community College


### PR DESCRIPTION
### Add Northwest-Shoals Community College

This PR adds the domain `nwscc.edu` for Northwest-Shoals Community College.

- **Institution Name**: Northwest-Shoals Community College
- **Website**: [https://www.nwscc.edu](https://www.nwscc.edu)
- **Email Domain**: `nwscc.edu`

Thank you for considering this addition!