### PR TITLE
Add National Open University of Nigeria (noun.edu.ng)

### DIFF
--- a/lib/domains/ng/edu/noun.txt
+++ b/lib/domains/ng/edu/noun.txt
@@ -1,0 +1,1 @@
+National Open university of Nigeria


### PR DESCRIPTION
This pull request adds the National Open University of Nigeria to the list of educational institutions.

Official website: http://www.nou.edu.ng

Proof of domain: The institution uses the domain `noun.edu.ng` for its official email addresses.

IT-related course: [Link to a long-term IT-related course offered by the university](https://nou.edu.ng/programmes/
![Uploading Screenshot 2024-07-20 at 1.32.18 PM.png…]()
)
