### PR TITLE
Adding utp domain (Universidad Tecnologica de Pereira)

### DIFF
--- a/lib/domains/co/edu/utp.txt
+++ b/lib/domains/co/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica De Pereira


### PR DESCRIPTION
Adding utp domain utp.edu.co (Universidad Tecnológica de Pereira - Colombia)

Oficial website : https://www.utp.edu.co/
Systems engineering site: https://ingenierias.utp.edu.co/ingenieria-en-sistemas/
Pemsum: https://ingenierias.utp.edu.co/ingenieria-en-sistemas/plan-de-estudios/
Address: Carrera 27 #10-02 Barrio Álamos 
City: Pereira
State: Risaralda
Country: Colombia
Maps url: https://maps.app.goo.gl/jrJxCr3qxUVvaXgV6
