### PR TITLE
Adding University of Málaga, Spain, to the domain

### DIFF
--- a/lib/domains/es/uma.txt
+++ b/lib/domains/es/uma.txt
@@ -1,0 +1,2 @@
+Universidad de Málaga
+University of Malaga


### PR DESCRIPTION
Adding University of Malaga, www.uma.es (Spain)