### PR TITLE
Add Catholic Kwandong University

### DIFF
--- a/lib/domains/kr/ac/cku.txt
+++ b/lib/domains/kr/ac/cku.txt
@@ -1,0 +1,2 @@
+가톨릭관동대학교
+Catholic Kwandong University


### PR DESCRIPTION
1. Official website URL : https://www.cku.ac.kr/sites/cku/index.do

2. IT related course( >1 year) : https://www.cku.ac.kr/software/806/subview.do

3. proof that the university recognizes the submitted domain as official student email. : https://www.cku.ac.kr/cku/515/subview.do (E-mail 주소 : ID@cku.ac.kr)