### PR TITLE
Add Institut Icària

### DIFF
--- a/lib/domains/cat/instituticaria.txt
+++ b/lib/domains/cat/instituticaria.txt
@@ -1,0 +1,1 @@
+Institut Icària


### PR DESCRIPTION
Students of this high school use the domain `instituticaria.cat` as specified in the second page of this PDF, "School's digital strategy": https://agora.xtec.cat/iesicaria/wp-content/uploads/usu2339/2023/07/Estrategia-digital-de-centre.pdf.

Thanks in advance.