### PR TITLE
Add uh.edu domain: University of Houston.

### DIFF
--- a/lib/domains/edu/uh.txt
+++ b/lib/domains/edu/uh.txt
@@ -1,0 +1,1 @@
+University of Houston


### PR DESCRIPTION
Additional info:

- the university official website URL: https://uh.edu/
- a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://hpedsi.uh.edu/education/training
- a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://uh.edu/infotech/services/accounts/email/alias/

Note: Two branch campuses, UH Downtown and UH Clear Lake, are already in the directory.