### PR TITLE
Add Medical University of Gdańsk

### DIFF
--- a/lib/domains/pl/edu/gumed.txt
+++ b/lib/domains/pl/edu/gumed.txt
@@ -1,0 +1,2 @@
+Gdański Uniwersytet Medyczny
+Medical University of Gdańsk


### PR DESCRIPTION
Official website: https://mug.edu.pl/
School address: M. Skłodowskiej-Curie 3a street, 80-210 Gdańsk, POLAND (in the footer of the website)
Proof of domain @gumed.edu.pl for students: 
1. It is wrritten on the extranet login page on the right: https://extranet.gumed.edu.pl/login.php
2. The site with mail register instruction also mentions the domain name
IT related course: https://rekrutacja.gumed.edu.pl/1283.html (unfortunately only in polish language) - public health which incorporates statistics and analysis in python.
