### PR TITLE
Add University of Minnesota (USA)

### DIFF
--- a/lib/domains/edu/umn.txt
+++ b/lib/domains/edu/umn.txt
@@ -1,0 +1,1 @@
+University of Minnesota


### PR DESCRIPTION
University of Minnesota, MN, USA
https://twin-cities.umn.edu/
https://cse.umn.edu/cs

Email policy:
https://policy.umn.edu/education/email
https://it.umn.edu/services-technologies/gmail

I notice that the umn.edu domain is in the abused list. However, the email policy has changed recently. Alumni no longer has access to the university email:
Beginning on June 1, 2024, after non-emeritus faculty, staff, and students depart the University, their [UMN email and Google Workspace](https://z.umn.edu/email-changes) will be closed and the contents within will be deleted—including the accounts of people who retire or graduate.

See also:
https://it.umn.edu/news-alerts/news/umn-email-google-workspace-access
https://it.umn.edu/services-technologies/resources/changes-umn-email-google-workspace