### PR TITLE
Add Georgetown University Domain

### DIFF
--- a/lib/domains/edu/georgetown.txt
+++ b/lib/domains/edu/georgetown.txt
@@ -1,0 +1,1 @@
+Georgetown University


### PR DESCRIPTION
University Homepage using the domain URL: https://www.georgetown.edu/
CS Department Undergraduate Programs: https://cs.georgetown.edu/undergraduate-programs/#
Implicity refers to domain for usage in the Google Icon Caption: https://elc.georgetown.edu/sign-in
![image](https://github.com/user-attachments/assets/bb8ac727-c782-4c40-a324-87b48bdd617d)

Page explaining how the FirstName.LastName email with the domain is available for Staff and Faculty: https://uis.georgetown.edu/google-apps/#gafnlnemail point 2
