### PR TITLE
Adding domain for SSUET, Pakistan

### DIFF
--- a/lib/domains/pk/edu/ssuet.txt
+++ b/lib/domains/pk/edu/ssuet.txt
@@ -1,0 +1,1 @@
+Sir Syed University of Engineering and Technology


### PR DESCRIPTION
This domain is used for student email by Sir Syed University of Engineering & Technology (SSUET), Pakistan. The official website is: https://ssuet.edu.pk/

![Sir Syed University of Engineering and Technology](https://github.com/user-attachments/assets/dd3c1268-997a-4af8-912a-4775348ad310)
