### PR TITLE
Submit University of Houston - Victoria

### DIFF
--- a/lib/domains/edu/uhv.txt
+++ b/lib/domains/edu/uhv.txt
@@ -1,0 +1,1 @@
+University of Houston - Victoria


### PR DESCRIPTION
The University of Houston–Victoria (UHV) is a public university in Victoria, Texas. It is part of the University of Houston System. Its campus spans 20 acres (8.1 ha) in Victoria with a satellite location in Katy, Texas. Founded in 1971, UHV has an enrollment of over 4,300 students.

* School official Web site: https://www.uhv.edu
* School street address: \
    University of Houston-Victoria
    3007 N. Ben Wilson St.
    Victoria, TX 77901
    (361) 570-4848
* URL of an IT-related long-term course:
  * BS Computer Science: https://www.uhv.edu/natural-applied-science/undergraduate-degrees/computer-science/
  * MS Computer Science: https://www.uhv.edu/natural-applied-science/graduate-degrees/computer-science/
