### PR TITLE
Added student.sdccd.edu subdomain

### DIFF
--- a/lib/domains/edu/sdccd/student.txt
+++ b/lib/domains/edu/sdccd/student.txt
@@ -1,0 +1,1 @@
+San Diego Community College District


### PR DESCRIPTION
Added student.sdccd.edu subdomain for San Diego Community College District students