### PR TITLE
Add University Domain For UIT

### DIFF
--- a/lib/domains/mm/edu/uit.txt
+++ b/lib/domains/mm/edu/uit.txt
@@ -1,0 +1,1 @@
+University of Information Technology (Yangon)


### PR DESCRIPTION
- Myanmar, Yangon
- Unveristy Of Information Technology (Yangon)
- Domain -> www.uit.edu.mm