### PR TITLE
Add Busan University of Foreign Studies

### DIFF
--- a/lib/domains/kr/ac/bufs/office.txt
+++ b/lib/domains/kr/ac/bufs/office.txt
@@ -1,0 +1,2 @@
+부산외국어대학교
+Busan University of Foreign Studies


### PR DESCRIPTION
pull request adds domain office.bufs.ac.kr
    swot\lib\domains\kr\ac\bufs\office.txt
       
Official Name of the University:
    korean : 부산외국어대학교
    English: Busan University of Foreign Studies

Official Website URL : 
https://www.bufs.ac.kr/
https://www.bufs.ac.kr/bbs/group.php?gr_id=computer