### PR TITLE
Add University of Prishtina file

### DIFF
--- a/lib/domains/edu/uni-pr.txt
+++ b/lib/domains/edu/uni-pr.txt
@@ -1,0 +1,1 @@
+University of Prishtina


### PR DESCRIPTION
Added University of Prishtina domain. A university from Kosovo, which was established in 1969.