### PR TITLE
add University of Buenos Aires - Faculty of Economic Sciences

### DIFF
--- a/lib/domains/ar/uba/economicas/campus.txt
+++ b/lib/domains/ar/uba/economicas/campus.txt
@@ -1,0 +1,2 @@
+Universidad de Buenos Aires - Facultad de Ciencias Económicas
+University of Buenos Aires - Faculty of Economic Sciences


### PR DESCRIPTION
University of Buenos Aires - Faculty of Economic Sciences is added as a valid university.
