### PR TITLE
Add uce.edu.ec domain for the Universidad Central del Ecuador

### DIFF
--- a/lib/domains/ec/edu/uce.txt
+++ b/lib/domains/ec/edu/uce.txt
@@ -1,0 +1,1 @@
+Universidad Central del Ecuador


### PR DESCRIPTION
Added the domain of Universidad Central del Ecuador so that students can access JetBrains licenses.