### PR TITLE
Add kocaeli university Turkey

### DIFF
--- a/lib/domains/tr/edu/kocaeli.txt
+++ b/lib/domains/tr/edu/kocaeli.txt
@@ -1,0 +1,2 @@
+Kocaeli Üniversitesi
+Kocaeli University


### PR DESCRIPTION
Adding Kocaeli University of Turkey

I've seen other pull requests closed due to a claim that the domain is abused, but I think you should provide further information for this. Kocaeli University is a reputable university with more than 30 years of history. 

Also I see that there is a private instituon given access in the repo, I'm very surprised that it has gotten approved but yet an official university is being hold off from here. This doesn't make sense for me.