### PR TITLE
Added `*@teacher.act.ac.th`

### DIFF
--- a/lib/domains/th/ac/act/teacher.txt
+++ b/lib/domains/th/ac/act/teacher.txt
@@ -1,0 +1,2 @@
+อัสสัมชัญธนบุรี
+Assumption College Thonburi


### PR DESCRIPTION
## The university official website URL, if it is different from the domain you are submitting.

The same domain.

## A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university.

https://www.act.ac.th/m1-3_II.php
https://www.act.ac.th/m4-6_Digital-Sci.php

## A URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.

Used by teacher although no proof is anywhere to be found. Mentions of the (sub)domain is found around the school.
