### PR TITLE
Doncaster College

### DIFF
--- a/lib/domains/uk/ac/don.txt
+++ b/lib/domains/uk/ac/don.txt
@@ -1,0 +1,1 @@
+Doncaster College


### PR DESCRIPTION
Education provider website: https://don.ac.uk
Course example: https://don.ac.uk/courses/dfc00466-ict-systems-and-principles-for-it-professionals-cg-diploma-level-3/
