### PR TITLE
Add Northern Essex Community College

### DIFF
--- a/lib/domains/edu/mass/necc.txt
+++ b/lib/domains/edu/mass/necc.txt
@@ -1,0 +1,1 @@
+Northern Essex Community College

--- a/lib/domains/edu/necc/student.txt
+++ b/lib/domains/edu/necc/student.txt
@@ -1,0 +1,1 @@
+Northern Essex Community College


### PR DESCRIPTION
- Two domains to be added (faculty: necc.mass.edu, student: student.necc.edu)
- college domain - https://www.necc.mass.edu/
- Faculty domain is the same as the college main domain
- 2-year degree program - https://www.necc.mass.edu/academics/credit-programs/computer-information-science/computer-science-associate-degree/ 
- student email domain format is described in second paragraph in bold - https://www.necc.mass.edu/student-life/support-services/technology-help/student-email/office-365-help-login/ 
