### PR TITLE
Added "starthub"

### DIFF
--- a/lib/domains/ng/com/starthub.txt
+++ b/lib/domains/ng/com/starthub.txt
@@ -1,0 +1,1 @@
+Start Innovation Hub


### PR DESCRIPTION
Added Start Innovation Hub. 
Start Innovation Hub is a tech incubation institution for young Nigerians in the South Southern region of the country.