### PR TITLE
Add ca/uregina.ca domain (University of Regina)

### DIFF
--- a/lib/domains/ca/uregina.ca
+++ b/lib/domains/ca/uregina.ca
@@ -1,0 +1,1 @@
+University of Regina


### PR DESCRIPTION
Adding the University of Regina domain.

Official domain: https://uregina.ca

Links to a few Software / CS / IT programs:
  - https://www.uregina.ca/engineering/students/programs/software-systems.html
  - https://www.uregina.ca/science/cs/undergraduate/index.html

Support page indicating that students have @uregina.ca domain email addresses: https://www.uregina.ca/is/index.html