### PR TITLE
Add Domain zsl-rss.de

### DIFF
--- a/lib/domains/de/zsl-rss.txt
+++ b/lib/domains/de/zsl-rss.txt
@@ -1,0 +1,1 @@
+Zentrum für Schulqualität und Lehrerbildung Baden-Württemberg, Regionalstelle Stuttgart


### PR DESCRIPTION
zsl-rss.de is a mail-only domain for a subdivision of www.zsl-bw.de