### PR TITLE
Add University of Houston domain (uh.edu)

### DIFF
--- a/lib/domains/edu/uh.txt
+++ b/lib/domains/edu/uh.txt
@@ -1,0 +1,1 @@
+University of Houston


### PR DESCRIPTION
Add University of Houston domain (uh.edu).

Link to university website: https://www.uh.edu