### PR TITLE
Please Add Unifeso

### DIFF
--- a/lib/domains/br/edu/unifeso.txt
+++ b/lib/domains/br/edu/unifeso.txt
@@ -1,0 +1,1 @@
+UNIFESO - Centro Universitário Serra dos Órgãos

--- a/lib/domains/vc/com/unifeso.txt
+++ b/lib/domains/vc/com/unifeso.txt
@@ -1,0 +1,1 @@
+UNIFESO - Centro Universitário Serra dos Órgãos


### PR DESCRIPTION
Official site of Unifeso University
https://www.unifeso.edu.br/

Computer Sciente course page on Unifeso's site
https://www.unifeso.edu.br/cursos/graduacao/ciencia-da-computacao

Students panel: 
Please, note (marked in the image below) that the email address provided from the university to their students has the 'unifeso.com.vc' suffix. Therefore, consider that both domains belongs to Unifeso University.
https://portalint.unifeso.edu.br/FrameHTML/web/app/edu/PortalEducacional/login/

![Screenshot_20240813_120906](https://github.com/user-attachments/assets/686d43fe-79fe-4fcc-b1fd-1ab4c7904484)
![Screenshot_20240813_120618](https://github.com/user-attachments/assets/2a168134-3ce4-4f22-8a47-0294cfce1a9d)
![Screenshot_20240813_120906](https://github.com/user-attachments/assets/ac57a5a0-8d96-4669-aa47-4899611b8430)
![Screenshot_20240813_120618](https://github.com/user-attachments/assets/ed0c8ffd-4bd2-4afa-91cf-b08c9c0e3de5)
