### PR TITLE
Adding domain for PICT, Pune

### DIFF
--- a/lib/domains/edu/pict.txt
+++ b/lib/domains/edu/pict.txt
@@ -1,0 +1,1 @@
+Pune Institute of Computer Technology, Pune


### PR DESCRIPTION
college name: PUNE INSTITUTE OF COMPUTER TECHNOLOGY

college website: https://pict.edu/

Computer Engineering Course at college: https://pict.edu/CE-dept/
Offers 4-year BE course and 2-year ME course

proof of domain, contact mail of HOD of dept ends in @pict.edu, enclosed in black rectangle, under contact information: 
![Screenshot 2024-08-13 232545](https://github.com/user-attachments/assets/e815aca2-6731-4af2-929a-5b9fa8b6ea1c)
