### PR TITLE
Add Hopkins School domain for faculty and students

### DIFF
--- a/lib/domains/edu/hopkins.txt
+++ b/lib/domains/edu/hopkins.txt
@@ -1,0 +1,1 @@
+Hopkins School

--- a/lib/domains/edu/hopkins/students.txt
+++ b/lib/domains/edu/hopkins/students.txt
@@ -1,0 +1,1 @@
+Hopkins School


### PR DESCRIPTION
Hopkins School uses [faculty-identifier]@hopkins.edu for teachers and [student-identifier]@students.hopkins.edu for students. Both are added in this commit. 

[Here is our Computer Science curriculum offerings.](https://www.hopkins.edu/curriculum-detail?fromId=221609&LevelNum=181&DepartmentId=2730) You will also see on that page two example emails of teachers using the proper domain. We do not show any student emails publicly.