### PR TITLE
Add University of Malaga

### DIFF
--- a/lib/domains/es/uma.txt
+++ b/lib/domains/es/uma.txt
@@ -1,0 +1,3 @@
+Universidad de Málaga
+Universidad de Malaga
+University of Malaga


### PR DESCRIPTION
The University of Malaga, which has as original name in spanish _Universidad de Málaga_ has as email domains `uma.es` but the official website of it is not that one, or it is just not working (it never was, at least since my student years). 
The one accessible in the browser is 
```www.uma.es```

But since it is written in the contributing guidelines that we should omit `www` when adding new domains, I've added the file `uma.txt` under the `/es` TLD.

This is a page where a long-term (4 years) study of Software Engineering is offered

```
https://www.uma.es/grado-en-ingenieria-del-software?set_language=en
```