### PR TITLE
Added Lebanese American University (LAU) Domain

### DIFF
--- a/lib/domains/edu/lau.txt
+++ b/lib/domains/edu/lau.txt
@@ -1,0 +1,1 @@
+Lebanese American University (LAU)


### PR DESCRIPTION
Added the Lebanese American University (LAU) Domain