### PR TITLE
add Domain of University of the Frontier

### DIFF
--- a/lib/domains/cl/ufromail.txt
+++ b/lib/domains/cl/ufromail.txt
@@ -1,0 +1,2 @@
+Universidad de la frontera
+University of the Frontier


### PR DESCRIPTION
University of the Frontier
domain: https://www.ufro.cl
Civil Computer Engineering web: https://icinformatica.ufro.cl/
added capture of the university page where you can see that the ufromail domain is valid
![Ufro page that allow domain](https://github.com/user-attachments/assets/85912277-6b7b-4343-a568-f925806e63a1)
