### PR TITLE
Add Stowe Valley Multi Academy Trust

### DIFF
--- a/lib/domains/com/stowevalley.txt
+++ b/lib/domains/com/stowevalley.txt
@@ -1,0 +1,1 @@
+Stowe Valley Multi Academy Trust


### PR DESCRIPTION
`stowevalley.com` is the domain for teachers and students at the Stowe Valley Multi-Academy Trust (https://www.stowevalleymat.com/)

This is a collection of primary and secondary schools in the UK.

Southam College is one member of this trust that offers a Computer Science A-Level: https://www.southamcollege.com/sixth-form (see [course description](https://resources.finalsite.net/images/v1697724237/southamcollegecom/zjvo7ugxuvnwbvhf8od0/CourseDescriptionComputerScience.pdf))

Proof that Southam College is a member of the Stowe Valley MAT is in the fat footer on the main page: https://www.southamcollege.com/ and also the footer on https://www.stowevalleymat.com/

The actual domain `stowevalley.com` is shown as a contact address here: https://www.stowevalleymat.com/about (for the trust) and here: https://www.southamcollege.com/about/contact-us (for the school)