### PR TITLE
Gymnasium Theresianum Mainz added

### DIFF
--- a/lib/domains/de/theresianum-mainz.txt
+++ b/lib/domains/de/theresianum-mainz.txt
@@ -1,0 +1,1 @@
+Gymnasium Theresianum Mainz


### PR DESCRIPTION
Homepage: https://www.theresianum-mainz.de
Computer science on Homepage: https://www.theresianum-mainz.de/lernen/mint/informatik
Me (Martin Hühne) as head of the computer science faculty: https://www.theresianum-mainz.de/kontakt/fachleitungen

Currently, we teach computer science in a 3-year-course (grades 10 to 12) as part of the highest general German school degree ("Abitur"). In two years, we will add a secondary education course in grade 7 continuing to grades 8 and 9 as well as an advanced/intensive course for grades 10 to 12 for students who want to specialize in computer science even more.