### PR TITLE
Create commonwealthu.txt

### DIFF
--- a/lib/domains/edu/commonwealthu.txt
+++ b/lib/domains/edu/commonwealthu.txt
@@ -1,0 +1,1 @@
+Commonwealth University of Pennsylvania


### PR DESCRIPTION
Added domain file for Commonwealth University of Pennsylvania (merger of Bloomsburg, Lock Haven, and Mansfield)