### PR TITLE
Create utp.txt

### DIFF
--- a/lib/domains/co/edu/utp.txt
+++ b/lib/domains/co/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnologica de Pereira


### PR DESCRIPTION
The university name is Universidad Tecnologica de Pereira, located in Pereira, Colombia.
Main website is: https://www.utp.edu.co

We have programs in Electrical Engineering, Computer Engineering, Software Development, among others. A page with academic programs offered at UTP can be found here:  https://programasacademicos.utp.edu.co/

 At the bottom of almost any page, it can be seen that emails for information and contact are always in the domain @utp.edu.co
