### PR TITLE
Adding file for new High School entry

### DIFF
--- a/lib/domains/pr/sanignacio.txt
+++ b/lib/domains/pr/sanignacio.txt
@@ -1,0 +1,2 @@
+Colegio San Ignacio de Loyola
+Saint Ignatius of Loyola School


### PR DESCRIPTION
The school to be added is "Colegio San Ignacio de Loyola", which is located in San Juan, Puerto Rico (U.S. territory). domain name for the official email addreses: @sanignacio.pr