### PR TITLE
Add fci.bsu.edu.eg domain for Beni Suef University

### DIFF
--- a/lib/domains/eg/edu/fcis.text
+++ b/lib/domains/eg/edu/fcis.text
@@ -1,0 +1,2 @@
+كلية الحاسبات والذكاء الاصطناعى جامعة بنى سوسف 
+Faculty of Computer science and Artificial Intelligence BeniSuef University 

--- a/lib/domains/eg/edu/fcis.text
+++ b/lib/domains/eg/edu/fcis.text
@@ -1,2 +1,0 @@
-كلية الحاسبات والذكاء الاصطناعى جامعة بنى سوسف 
-Faculty of Computer science and Artificial Intelligence BeniSuef University 

--- a/lib/domains/eg/edu/fcis.txt
+++ b/lib/domains/eg/edu/fcis.txt
@@ -1,0 +1,2 @@
+كلية الحاسبات والذكاء الاصطناعى - جامعة بنى سويف
+Faculty of Computers & Artificial Intelligence - Beni Suef University


### PR DESCRIPTION
This pull request adds the email domain for Faculty of Computers & Artificial Intelligence - Beni Suef University to the repository.

University Name: Faculty of Computers & Artificial Intelligence - Beni Suef University
Official Website: fci.bsu.edu.eg
