### PR TITLE
Added UNCC (University of North Carolina at Charlotte) to listed edu domains

### DIFF
--- a/lib/domains/edu/charlotte/charlotte.txt
+++ b/lib/domains/edu/charlotte/charlotte.txt
@@ -1,0 +1,1 @@
+University of North Carolina at Charlotte


### PR DESCRIPTION
Standard email format is, for example - dklingen@charlotte.edu