### PR TITLE
Add Suez Canal University domain

### DIFF
--- a/lib/domains/eg/edu/suez/eng.txt
+++ b/lib/domains/eg/edu/suez/eng.txt
@@ -1,0 +1,1 @@
+Suez Canal University


### PR DESCRIPTION
University official website: https://eng.suez.edu.eg/
Photo showing IT Unit of our university sending files through an email of the requested domain:
![image](https://github.com/user-attachments/assets/9ec3188e-d6ef-47db-a08b-1adb4fe6ace8)

