### PR TITLE
new educational institution

### DIFF
--- a/lib/domains/nl/ictaa.txt
+++ b/lib/domains/nl/ictaa.txt
@@ -1,0 +1,1 @@
+ICT Academie Apeldoorn

--- a/lib/domains/nl/ictaa/student.txt
+++ b/lib/domains/nl/ictaa/student.txt
@@ -1,0 +1,1 @@
+ICT Academie Apeldoorn


### PR DESCRIPTION
Official name of the applied university: ICT Academie Apeldoorn. 
We offer a four-year, accredited Bachelor of Science degree in Computer Science.

Official website URL: https://www.ictaa.nl

Long-term (>1 year) IT related course is offered by the university: https://www.ictaa.nl/hbo-software-engineer

Domain which you are submitting as an official email domain for the enrolled student: https://www.ictaa.nl/3rdpartysoftware