### PR TITLE
Added Istanbul University

### DIFF
--- a/lib/domains/tr/edu/iu/ogr.txt
+++ b/lib/domains/tr/edu/iu/ogr.txt
@@ -1,0 +1,2 @@
+İstanbul Üniversitesi
+İstanbul University


### PR DESCRIPTION
ogr.iu.edu.tr is mail domain of istanbul university which can be accessed by: https://www.istanbul.edu.tr/en