### PR TITLE
add domain: Gadjah Mada University

### DIFF
--- a/lib/domains/id/ac/ugm/mail.txt
+++ b/lib/domains/id/ac/ugm/mail.txt
@@ -1,0 +1,2 @@
+Universitas Gadjah Mada
+Gadjah Mada University


### PR DESCRIPTION
mail.ugm.ac.id is mail domain of Gadjah Mada University which can be accessed by: https://ugm.ac.id/