### PR TITLE
Register Hana Academy Seoul's e-mail Subdomain

### DIFF
--- a/lib/domains/kr/hs/has.txt
+++ b/lib/domains/kr/hs/has.txt
@@ -1,0 +1,2 @@
+하나고등학교
+Hana Academy Seoul


### PR DESCRIPTION
Related to [this pr](https://github.com/JetBrains/swot/pull/13584), make a new pr for school's email subdomain.

This school use hana.hs.kr domain via Google Workspace, and use has.hs.kr domain via Microsoft 365. 

Currently this domain is not connected to school's official website, but the ownership of this domain can be found in WHOIS record. (Address and AC-Email's domain - hana.hs.kr)

<img width="768" alt="Screenshot 2024-08-20 at 8 38 02 AM" src="https://github.com/user-attachments/assets/b807ac42-4477-4984-b764-6919d03ce306">
