### PR TITLE
Add Oak Grove School District, CA, USA

### DIFF
--- a/lib/domains/net/ogsd.txt
+++ b/lib/domains/net/ogsd.txt
@@ -1,0 +1,1 @@
+Oak Grove School District, California, USA


### PR DESCRIPTION
# Change

I suggest adding Oak Grove School District using `ogsd.net` domain. This is the domain that educators and students use for their email addresses. This school district covers several schools in San Jose, California, USA. 

The district covers Herman Intermediate https://herman.ogsd.net/ and AdVENTURE option http://www.adventurestemprogram.com/ with STEM programs.

For details please see https://www.ogsd.net/