### PR TITLE
Add Faculty Of Engineering Suez Canal University

### DIFF
--- a/lib/domains/eg/edu/suez/eng.txt
+++ b/lib/domains/eg/edu/suez/eng.txt
@@ -1,0 +1,2 @@
+Faculty Of Engineering Suez Canal University
+Suez Canal University


### PR DESCRIPTION
Adding Faculty Of Engineering Suez Canal University
Domain: eng.suez.edu.eg
Official Website : https://eng.suez.edu.eg/