### PR TITLE
HitachiGymnasiet

### DIFF
--- a/lib/domains/se/hitachigymnasiet.txt
+++ b/lib/domains/se/hitachigymnasiet.txt
@@ -1,0 +1,2 @@
+Hitachigymnasiet
+Hitachi High School


### PR DESCRIPTION
HitachiGymnasiet rebranded from ABB Industri Gymnasiet (Old URL: https://abbgymnasiet.se/)!

Proof:

Website: https://vasteras.hitachigymnasiet.se/
Contacts: https://vasteras.hitachigymnasiet.se/om-oss/personal
Educations: https://vasteras.hitachigymnasiet.se/teknikprogrammet