### PR TITLE
fix_mdc_edu_domain_college_name

### DIFF
--- a/lib/domains/edu/mdc.txt
+++ b/lib/domains/edu/mdc.txt
@@ -1,1 +1,1 @@
-Miami Dads College
+Miami Dade College


### PR DESCRIPTION
Fixed the name of the Miami Dade College institution.

Reason: The name of the Miami Dade College is not "_Miami Dads College_".

Such wrong name was added by the owner of this account: https://github.com/philipto, on August 2nd 2024. 
 
![Screenshot 2024-08-24 at 10 23 34 PM copy](https://github.com/user-attachments/assets/dab2f598-85b1-47fc-9970-08c2e5be8f07)


**Notes:**

1. The domain mdc.edu is used by all the Miami Dade College's employees (the MDC students use the domain mymdc.net).
2. The Miami Dade College is located at Miami, Miami-Dade County, Florida, USA.
3. The MDC Website is this one: https://www.mdc.edu/

