### PR TITLE
Registering Faculty of Electrical Engineering in East Sarajevo to the List of Registered Educational Institutions in JetBrains

### DIFF
--- a/lib/domains/ba/rs/ues/etf/student.txt
+++ b/lib/domains/ba/rs/ues/etf/student.txt
@@ -1,0 +1,1 @@
+The Faculty of Electrical Engineering of the University of East Sarajevo


### PR DESCRIPTION
What this change does?

- Registers Faculty of Electrical Engineering in East Sarajevo (Bosnia and Herzegovina) as an educational institution recognized by JetBrains in order for it's students to be able to apply for Student licenses.
- Url to the Web Site of the University in East Sarajevo: https://www.ues.rs.ba/en/ues/ 
- Url to the Web Site of the Faculty of Electrical Engineering in East Sarajevo: https://www.etf.ues.rs.ba/eng/
- My student email is: dragana.divljan.1755@student.etf.ues.rs.ba