### PR TITLE
Add University of West Attica domain to access JetBrains Free Educational Licenses 

### DIFF
--- a/lib/domains/gr/uniwa.txt
+++ b/lib/domains/gr/uniwa.txt
@@ -1,0 +1,1 @@
+University of West Attica


### PR DESCRIPTION
Add University of West Attica domain to access JetBrains Free Educational Licenses 