### PR TITLE
Add Universidad de Costa Rica's domain as a known domain.

### DIFF
--- a/lib/domains/cr/ac/ucr.txt
+++ b/lib/domains/cr/ac/ucr.txt
@@ -1,0 +1,2 @@
+Universidad de Costa Rica
+University of Costa Rica


### PR DESCRIPTION
Adds Universidad de Costa Rica to the list of known academic domains.

For more information about the university, visit [this link](https://www.ucr.ac.cr).