### PR TITLE
Add domain unn.edu.ng

### DIFF
--- a/lib/domains/ng/edu/unn.txt
+++ b/lib/domains/ng/edu/unn.txt
@@ -1,0 +1,1 @@
+University of Nigeria, Nsukka


### PR DESCRIPTION
This PR adds the domain for the University of Nigeria, Nsukka - unn.edu.ng