### PR TITLE
Add domain: hawkmail.hfcc.edu

### DIFF
--- a/lib/domains/edu/hfcc/hawkmail.txt
+++ b/lib/domains/edu/hfcc/hawkmail.txt
@@ -1,0 +1,1 @@
+Henry Ford College


### PR DESCRIPTION
Add domain hawkmail.hfcc.edu

Official URL: https://www.hfcc.edu/

All college IT programs: https://www.hfcc.edu/programs/computer-information-systems
Information Systems Program:  https://catalog.hfcc.edu/programs/computer-information-systems-aas

Technology page lists "Hawkmail", the official email for students (Gmail based) (subdomain of hfcc.edu).
https://www.hfcc.edu/student-services/technology