### PR TITLE
Add email.vccs.edu domain for Northern Virginia Community College

### DIFF
--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,1 +1,2 @@
 Northern Virginia Community College
+.group

--- a/lib/domains/edu/vccs/email.txt
+++ b/lib/domains/edu/vccs/email.txt
@@ -1,0 +1,1 @@
+Northern Virginia Community College


### PR DESCRIPTION
[Northern Virginia Community College Homepage](https://www.nvcc.edu/)

[Computer Science A.S.](https://catalog.nvcc.edu/preview_program.php?catoid=12&poid=3058)

[Proof of Domain Recognition](https://www.nvcc.edu/student-resources/technology/email.html)