### PR TITLE
Bogazici University boun.edu.tr  added

### DIFF
--- a/lib/domains/tr/edu/boun.txt
+++ b/lib/domains/tr/edu/boun.txt
@@ -1,0 +1,2 @@
+Boğaziçi Üniversitesi
+Bogazici University


### PR DESCRIPTION
https://boun.edu.tr/ is also a Bogazici University domain. 