### PR TITLE
Fixed wrong domain

### DIFF
--- a/lib/domains/ph/edu/sti/caloocan.txt
+++ b/lib/domains/ph/edu/sti/caloocan.txt
@@ -1,0 +1,1 @@
+STI Caloocan


### PR DESCRIPTION
Wrong Domaing registered: caloocan.sti.ph
Corrected: caloocan.sti.edu.ph