### PR TITLE
Chung-Ang University add

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+CHUNG-ANG UNIVERSITY


### PR DESCRIPTION
Chung-Ang University add
main school site is https://www.cau.ac.kr/index.do