### PR TITLE
Added alamo colleges student domain

### DIFF
--- a/lib/domains/edu/alamo/student.txt
+++ b/lib/domains/edu/alamo/student.txt
@@ -1,0 +1,2 @@
+Alamo Colleges District
+.group


### PR DESCRIPTION
The alamo.edu domain is already in use for faculty, but we are now adding student.alamo.edu for students.