### PR TITLE
Adding student mail.broward.edu domain

### DIFF
--- a/lib/domains/edu/broward/mail.txt
+++ b/lib/domains/edu/broward/mail.txt
@@ -1,0 +1,1 @@
+Broward College


### PR DESCRIPTION
adding Broward College student email domain to whitelist.