### PR TITLE
adding Colorado Mesa University

### DIFF
--- a/lib/domains/edu/coloradomesa/mavs.txt
+++ b/lib/domains/edu/coloradomesa/mavs.txt
@@ -1,0 +1,1 @@
+Colorado Mesa University


### PR DESCRIPTION
I instructor was able to get the license through his university email but because professors and students had different email names the students aren't able to get this benefit. So I am doing this pull request to hopefully fix this as the only difference is between @coloradomesa.edu and @mavs.coloradomesa.edu. 

Please email me at aaavila@mavs.coloradomesa.edu if this runs into any issues. Thank you!