### PR TITLE
Add domain for Kyungdong University

### DIFF
--- a/lib/domains/kr/ac/kduniv.txt
+++ b/lib/domains/kr/ac/kduniv.txt
@@ -1,0 +1,2 @@
+경동대학교
+Kyungdong University


### PR DESCRIPTION
Official website is https://www.kduniv.ac.kr/kor/Main.do

The email domain is v.kduniv.ac.kr