### PR TITLE
[ADD] Chung-Ang Univ(CAU) domain

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
### Description
This PR is aimed at adding the school email domain txt file for student certification at Chung-Ang University, South Korea.

### Type of change
- New File: `lib/domains/kr/ac/cau.txt`

### Test
- Not applicable
