### PR TITLE
Add El Camino College domain (elcamino.txt)

### DIFF
--- a/lib/domains/edu/elcamino.txt
+++ b/lib/domains/edu/elcamino.txt
@@ -1,0 +1,6 @@
+El Camino College
+El Camino
+El Camino Community College
+El Camino CC
+Elco
+ECC


### PR DESCRIPTION
Adding El Camino College text file that contains:

- Official name (El Camino College) on the first line
- Alternative names on subsequent lines

See below links for information on El Camino College in Los Angeles County, California, USA.

[Main Website] (https://www.elcamino.edu/)

[All active ECC students are provided with a College email account (@elcamino.edu).]
(https://www.elcamino.edu/departments/its/student-resources.php)

<img width="1171" alt="Screenshot 2024-08-30 at 1 49 37 PM" src="https://github.com/user-attachments/assets/40c2bdfe-998e-44cd-a45d-3079789e627c">