### PR TITLE
Add stockport college other domain

### DIFF
--- a/lib/domains/uk/ac/stockport.txt
+++ b/lib/domains/uk/ac/stockport.txt
@@ -1,0 +1,1 @@
+Stockport College


### PR DESCRIPTION
For some reason it looks like stockport college has several domains used for emails.
you can validate this yourself by going on the github student page and putting the shool as Stockport College as it list all the formats.