### PR TITLE
Add domain for Ain Shams University, Faculty of Computer and Information Sciences

### DIFF
--- a/lib/domains/asu/cis.txt
+++ b/lib/domains/asu/cis.txt
@@ -1,0 +1,1 @@
+Ain Shams University, Computer and Information Sciences


### PR DESCRIPTION
Add domain for the Egyptian university: Ain Shams University, Faculty of Computer and Information Sciences.
Its domain is: cis.asu.edu.eg