### PR TITLE
Add Jyothy Institute of Technology Domain (jyothyit.ac.in)

### DIFF
--- a/lib/domains/in/ac/jyothyit.txt
+++ b/lib/domains/in/ac/jyothyit.txt
@@ -1,0 +1,1 @@
+Jyothy Institute of Technology


### PR DESCRIPTION
The domain for Jyothy Institute of Technology is missing in the swot repo, and it has to be added for student verification.