### PR TITLE
Register Keiser University Student Subdomain to Jetbrains List

### DIFF
--- a/lib/domains/edu/keiseruniversity/student.txt
+++ b/lib/domains/edu/keiseruniversity/student.txt
@@ -1,2 +1,1 @@
 Keiser University
-Keiser University

--- a/src/lib/domains/edu/keiseruniversity/student.txt
+++ b/src/lib/domains/edu/keiseruniversity/student.txt
@@ -1,0 +1,2 @@
+Keiser University
+Keiser University


### PR DESCRIPTION
Keiser University has its main subdomain for staff and faculty and also a subdomain "students.keiseruniversity.edu" for students.