### PR TITLE
Add Ozenne University

### DIFF
--- a/lib/domains/info/ozenne.txt
+++ b/lib/domains/info/ozenne.txt
@@ -1,0 +1,2 @@
+ozenne
+Ozenne general and technological high school


### PR DESCRIPTION
I put my university in ```.info``` because our email is like ```[name]@ozenne.info```, even though our site is in ```.fr```.
Official university Website: https://eugene-montel.mon-ent-occitanie.fr/
Whois : https://who.is/whois/ozenne.info