### PR TITLE
Added rtu.txt and reverted accidental deletions

### DIFF
--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@swot,0

--- a/lib/domains/in/ac/rtu.txt
+++ b/lib/domains/in/ac/rtu.txt
@@ -1,0 +1,1 @@
+Rajasthan Technical University, Kota


### PR DESCRIPTION
This pull request adds the domain rtu.ac.in for Rajasthan Technical University to the swot repository. The file rtu.txt has been placed under the appropriate directory structure lib/domains/in/ac/rtu/. This addition will allow students and staff from RTU to utilize the services that rely on the swot repository for domain verification.

I also reverted an accidental deletion of Compiler.kt and Swot.kt files, ensuring that no critical files were removed in this process.