### PR TITLE
Add My University

### DIFF
--- a/lib/domains/kr/ac/jmail.txt
+++ b/lib/domains/kr/ac/jmail.txt
@@ -1,0 +1,2 @@
+Joongbu University
+Joongbu University


### PR DESCRIPTION
Hi there!My university's official website is: https://www.joongbu.ac.kr
My student email domain name is: jmail.ac.kr
I am a new student and need to apply for JetBrains benefits, but it shows that I am not eligible and need to add the school. I hope you can help me apply successfully. At the same time, I also understand that our school may have been added to the abuse list for some reasons before, but now I understand that our school has restricted many IPs. Most of the time, only students from this campus can access it. I hope to be able to review and assess whether it can be restored. Thank you!