### PR TITLE
Frostburg domain ungrouped from UMD

### DIFF
--- a/lib/domains/edu/frostburg.txt
+++ b/lib/domains/edu/frostburg.txt
@@ -1,0 +1,1 @@
+Frostburg State University

--- a/lib/domains/edu/umd.txt
+++ b/lib/domains/edu/umd.txt
@@ -1,2 +1,1 @@
-Frostburg State University
 University of Maryland at College Park


### PR DESCRIPTION
frostburg.edu must not have existed when this repo was created - seemed to have been piggy-backing off of its parent college's domain but has not for some time. All other University System of Maryland domains have been split off already.

Link: [https://www.frostburg.edu](url)
IT course link: [https://www.frostburg.edu/academics/majorminors/bachelor/bachelor-in-computer-science.php](url)
Unsure how to confirm email outside of use in faculty information: [https://www.frostburg.edu/academics/colleges-and-departments/computer-science/faculty--staff.php](url)