### PR TITLE
Add pstu.edu domain

### DIFF
--- a/lib/domains/edu/pstu.txt
+++ b/lib/domains/edu/pstu.txt
@@ -1,0 +1,2 @@
+Приазовський державний технічний університет
+Pryazovskyi State Technical University


### PR DESCRIPTION
There is a link to the [university](https://pstu.edu/uk/). 

The university includes [Faculty of information technologies](https://pstu.edu/uk/fakultety-2/fakultet-informaczijnyh-tehnologij/), so there are obviously IT study programs. For example, [one of Computer Science programs for postgraduates](https://pstu.edu/uk/educational_program/informaczijni-systemy-ta-tehnologiyi/).

University-issued emails are with @pstu.edu and @students.pstu.edu. Students can use either the first option or the second one. To check, you can look at list of student's emails on the official website, [here](https://pstu.edu/uk/studentu/stud_e-mail/).
