### PR TITLE
ICL Graduate Business School

### DIFF
--- a/lib/domains/nz/school/icl.txt
+++ b/lib/domains/nz/school/icl.txt
@@ -1,0 +1,1 @@
+ICL Graduate Business School


### PR DESCRIPTION
Domain: icl.school.nz
Name: ICL Graduate Business School