### PR TITLE
Added Lyceum 142, Kyiv

### DIFF
--- a/lib/domains/ua/kyiv/l142.txt
+++ b/lib/domains/ua/kyiv/l142.txt
@@ -1,0 +1,2 @@
+Ліцей №142 – міста Києва. https://l142.kiev.ua/
+Kyiv Lyceum №142


### PR DESCRIPTION
Ліцей №142 – міста Києва. 
https://l142.kiev.ua/
Kyiv Lyceum №142