### PR TITLE
Added Hill House School

### DIFF
--- a/lib/domains/uk/sch/doncaster/hillhouse.txt
+++ b/lib/domains/uk/sch/doncaster/hillhouse.txt
@@ -1,0 +1,1 @@
+Hill House School


### PR DESCRIPTION
Hi there,

This pull request was recently denied due to the domain being 'hillhouse.uk', since then an email forward has been set up so that students can use the 'hillhouse.doncaster.sch.uk' domain for email too.

Website is: https://thehillhouseschool.com

Offers Comp. Science A Level, along with university preperation classes.

Thanks.