### PR TITLE
Register Keiser University main domain for the Faculty

### DIFF
--- a/lib/domains/edu/keiseruniversity.txt
+++ b/lib/domains/edu/keiseruniversity.txt
@@ -1,0 +1,2 @@
+Keiser University
+Keiser University


### PR DESCRIPTION
Dear team,

Recently, we added the student subdomain (student.keiseruniversity.edu) to the domain list Now, we also need to add the main domain as that is the one the faculty at this institution uses.