### PR TITLE
Add NCKU domain file

### DIFF
--- a/lib/domains/tw/edu/ncku/gs.txt
+++ b/lib/domains/tw/edu/ncku/gs.txt
@@ -1,0 +1,2 @@
+國立成功大學
+National Cheng Kung University

--- a/lib/domains/tw/edu/ncku/mail.txt
+++ b/lib/domains/tw/edu/ncku/mail.txt
@@ -1,0 +1,2 @@
+國立成功大學
+National Cheng Kung University


### PR DESCRIPTION
University official website:
https://www.ncku.edu.tw/

Proof of long-term IT-related courses:
The NCKU College of Electrical Engineering and Computer Science (EECS) offers long-term undergraduate and graduate IT-related courses, including programs taught in English. You can find detailed information about the courses and programs offered by EECS here:
https://eecs.ncku.edu.tw/p/404-1020-239633.php?Lang=en

Proof of official student email domain usage:
NCKU provides all active students with Google Workspace accounts, and the official email format for students is student_number@gs.ncku.edu.tw. Detailed information about the email service can be found on the university's Computer and Network Center website:
https://cc.ncku.edu.tw/p/412-1213-29107.php?Lang=en