### PR TITLE
Register Eastern Mediterranean University domain name

### DIFF
--- a/lib/domains/tr/edu/emu/emu.txt
+++ b/lib/domains/tr/edu/emu/emu.txt
@@ -1,0 +1,2 @@
+Doğu Akdeniz Üniversitesi
+Eastern Mediterranean University


### PR DESCRIPTION
We request the inclusion of the "emu.edu.tr" domain(for Eastern Mediterranean University) in the JetBrains licensing system to support our students and academics who wish to use JetBrains products in their software development activities.