### PR TITLE
Adding PHI In Egypt

### DIFF
--- a/lib/domains/eg/edu/phi.txt
+++ b/lib/domains/eg/edu/phi.txt
@@ -1,0 +1,2 @@
+معهد الأهرامات العالي للهندسة والتكنولوجيا
+Pyramids Higher Institute of Engineering and Technology


### PR DESCRIPTION
معهد الأهرامات العالي للهندسة والتكنولوجيا
Pyramids Higher Institute of Engineering and Technology

Official Website
https://phi.edu.eg/

Related Long-term Courses :
https://phi.edu.eg/programdetails/2