### PR TITLE
Add John Innes Centre

### DIFF
--- a/lib/domains/uk/ac/jic.txt
+++ b/lib/domains/uk/ac/jic.txt
@@ -1,0 +1,1 @@
+John Innes Centre


### PR DESCRIPTION
John Innes Centre is a research institute located in Norwich, UK - world-leading in the use of large-scale genomic data to advance biology. The institute runs a PhD and Masters programmes (together with the University of East Anglia) and offers other training opportunities in computational biology and IT areas (apprenticeships, internships): https://www.jic.ac.uk/training-careers/