### PR TITLE
Centre d'Education aux Adultes des Navigateurs

### DIFF
--- a/lib/domains/ca/qc/gouv/cssdn.txt
+++ b/lib/domains/ca/qc/gouv/cssdn.txt
@@ -1,0 +1,2 @@
+Centre d'Education aux Adultes des Navigateurs
+Education Center for Adults of Navigateurs


### PR DESCRIPTION
Part of CSSDN (Centre de Service Scolaire des Navigateurs)
English: School Services Center of Navigateurs