### PR TITLE
add university domain svu.ac.kr

### DIFF
--- a/lib/domains/kr/ac/svu.txt
+++ b/lib/domains/kr/ac/svu.txt
@@ -1,0 +1,2 @@
+서울벤처대학원대학교
+SEOUL VENTURE UNIVERSITY


### PR DESCRIPTION
HOMEPAGE : [https://www.svu.ac.kr/ ](https://www.svu.ac.kr/)
University name : SEOUL VENTURE UNIVERSITY
ADDRESS : 405, Bongeunsa-ro, Gangnam-gu, Seoul, Republic of Korea (06097)