### PR TITLE
add GUMI UNIVERSITY

### DIFF
--- a/lib/domains/kr/ac/gumi1.txt
+++ b/lib/domains/kr/ac/gumi1.txt
@@ -1,0 +1,2 @@
+구미대학교
+GUMI UNIVERSITY


### PR DESCRIPTION
The university provides e-mail addresses using Microsoft Office 365.
I think they answered that it's a domain that doesn't exist because of the upper domain (o365). Will this information solve it?
https://o365.gumi1.ac.kr

@gumi1.ac.kr (student mail address)

1) the university official website URL
https://www.gumi.ac.kr/pages/index.htm

2) a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university https://www.gumi.ac.kr/pages/sub.htm?nav_code=gum1545995285

![rules](https://github.com/user-attachments/assets/6d0c4cf8-e416-4b13-bac9-0463ada0714b)

Article 5 (School Period) 
① Our university shall have two, three, or four years, but three and four years If so, it shall be a department authorized by the Minister of Education. (revised on May 13, 2009) (revised on December 10, 2014) ② The period of instruction in a major intensive course shall be one or two years, and graduates of a three-year professional bachelor's degree course shall be One year or more and two-year graduates shall be two years or more. (Newly established on February 28, 2017)

3) a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students. 
https://o365.gumi1.ac.kr/Notice.aspx

![emailaddr](https://github.com/user-attachments/assets/b69e314c-3cf9-47e1-bd14-ff49bcf890eb)

2. Account application 
 2.2 Mail address
- A login account will be created with the UserId@gumi1.ac.kr address.
- Send and receive mail to the UserId@gumi1.ac.kr address.