### PR TITLE
Add domain for Clark College

### DIFF
--- a/lib/domains/edu/clark/students.txt
+++ b/lib/domains/edu/clark/students.txt
@@ -1,0 +1,2 @@
+Clark College
+Clark College


### PR DESCRIPTION
This merge request proposes to merge in the students domain for [Clark College](https://www.clark.edu/), a community college in Vancouver, WA. Student emails are `@students.clark.edu`. Staff emails are just `@clark.edu`, I'm not sure if I should add that to this MR as well.

Clark College's address is:
1933 Fort Vancouver Way
Vancouver, WA 98663

Documentation on student emails: https://www.clark.edu/its/documentation-and-resources/students/student-email.php