### PR TITLE
Create tukorea.txt

### DIFF
--- a/lib/domains/kr/ac/tukorea.txt
+++ b/lib/domains/kr/ac/tukorea.txt
@@ -1,0 +1,2 @@
+한국공학대학교
+TECH UNIVERSITY OF KOREA


### PR DESCRIPTION
- [학교 공식 홈페이지 URL](https://www.tukorea.ac.kr)
- 도시와 국가를 포함한 학교의 거리 주소
  - 경기도 시흥시 산기대학로 237 (정왕동) 한국공학대학교
  - 237, Sangidaehak-ro, Siheung-si, Gyeonggi-do, Republic of Korea
- 학교가 귀하가 제출한 도메인을 학생들의 공식 이메일 도메인으로 인정하고 있다는 것을 보여주는 증거 자료
<img width="2032" alt="스크린샷 2024-09-10 오후 3 06 05" src="https://github.com/user-attachments/assets/acf15964-280b-445b-934e-48a4f8154e1e">
