### PR TITLE
Add UST (University of Science & Technology) domain

### DIFF
--- a/lib/domains/kr/ac/ust.txt
+++ b/lib/domains/kr/ac/ust.txt
@@ -1,0 +1,2 @@
+UST 과학기술연합대학원대학교
+University of Science & Technology


### PR DESCRIPTION
### PR Description

#### Summary
This Pull Request adds the UST (University of Science & Technology, Korea) domain to the project, allowing users with `@ust.ac.kr` email addresses to register and use the service.

#### Background
I am a student at UST, Korea, and I noticed that our domain was not included in the list of supported educational domains. This PR aims to rectify that by including UST’s email domain in the project.