### PR TITLE
add student mail domain for Guangzhou University

### DIFF
--- a/lib/domains/cn/edu/gzhu/e.txt
+++ b/lib/domains/cn/edu/gzhu/e.txt
@@ -1,0 +1,1 @@
+Guangzhou University


### PR DESCRIPTION
homepage: https://www.gzhu.edu.cn/
university name: Guangzhou University
address: 230 Wai Huan Xi Road, Guangzhou Higher Education Mega Center, Guangzhou 510006 P.R.China

The domain e.gzhu.edu.cn is provided as students email domain by Guangzhou University and the previous mail domain gzhu.edu.cn is available for teachers.

mail portal url: http://mail.e.gzhu.edu.cn