### PR TITLE
adding istanbul university domain suffix for emails.

### DIFF
--- a/lib/domains/tr/edu/iu/ogr.txt
+++ b/lib/domains/tr/edu/iu/ogr.txt
@@ -1,0 +1,2 @@
+İstanbul Ünivesitesi
+Istanbul University


### PR DESCRIPTION

- Student emails end with @ogr.iu.edu.tr (https://ogr.iu.edu.tr/  for email services.)
