### PR TITLE
Add Bridgwater & Taunton College

### DIFF
--- a/lib/domains/uk/ac/btc.txt
+++ b/lib/domains/uk/ac/btc.txt
@@ -1,0 +1,1 @@
+Bridgwater & Taunton College


### PR DESCRIPTION
Bridgwater & Taunton College is a college/university in Somerset, England. It offers a variety of courses in the Computer Science space, one of them being: https://www.btc.ac.uk/courses/higher-education/computing-digital-industries/computing-and-digital-technologies-foundation-degree/. The email address for BTC is `@btc.ac.uk`.