### PR TITLE
Domain for "Carol I" National College, Craiova

### DIFF
--- a/lib/domains/ro/cnc.txt
+++ b/lib/domains/ro/cnc.txt
@@ -1,0 +1,2 @@
+Colegiul Național „Carol I", Craiova
+"Carol I" National College, Craiova


### PR DESCRIPTION
Added the domain for "Carol I" National College, Craiova