### PR TITLE
adds Hillside Public Schools to  Domain List

### DIFF
--- a/lib/domains/net/hillsidek12.txt
+++ b/lib/domains/net/hillsidek12.txt
@@ -1,0 +1,1 @@
+Hillside Public Schools

--- a/lib/domains/org/hillsidek12.txt
+++ b/lib/domains/org/hillsidek12.txt
@@ -1,0 +1,1 @@
+Hillside Public Schools


### PR DESCRIPTION
makes hillsidek12.net and .org as recognized educational domains