### PR TITLE
Added GLA University Domain

### DIFF
--- a/lib/domains/in/ac/gla.txt
+++ b/lib/domains/in/ac/gla.txt
@@ -1,0 +1,1 @@
+GLA University, Mathura


### PR DESCRIPTION
Added domain (gla.ac.in) of GLA University.