### PR TITLE
Adding University of Jamestown (uj.edu)

### DIFF
--- a/lib/domains/edu/uj.txt
+++ b/lib/domains/edu/uj.txt
@@ -1,0 +1,1 @@
+University of Jamestown


### PR DESCRIPTION
This request is to add `edu/uj.txt` to `domains`. The school is the University of Jamestown, which is located in Jamestown, North Dakota. Students will initially use WebStorm for this course: https://uj.smartcatalogiq.com/en/2024-2025/2024-2025-undergraduate-catalog/courses/tech-technology/400/tech-441/. The uj.edu domain is used by the university for all student email accounts. Thanks!