### PR TITLE
Add University of Laverne

### DIFF
--- a/lib/domains/edu/laverne.txt
+++ b/lib/domains/edu/laverne.txt
@@ -1,0 +1,2 @@
+The University of La Verne
+La Verne Univeristy


### PR DESCRIPTION
Added domain for University of La Verne.

- **Official website**: [https://laverne.edu/](https://laverne.edu/)
- **IT-related course**: [https://artsci.laverne.edu/compsci/](https://artsci.laverne.edu/compsci/)
- **Proof of domain usage**: The president’s page shows the official email domain: [https://laverne.edu/president/](https://laverne.edu/president/)