### PR TITLE
Append stu.ouc.edu.cn for students of `Ocean University of China`(OUC)

### DIFF
--- a/lib/domains/cn/edu/ouc/stu.txt
+++ b/lib/domains/cn/edu/ouc/stu.txt
@@ -1,0 +1,1 @@
+Ocean University of China


### PR DESCRIPTION
[Here](https://github.com/JetBrains/swot/blob/master/lib%2Fdomains%2Fcn%2Fedu%2Fouc.txt) `ouc.edu.cn` was added years ago, but that's only for OUC's teathers.

Students of OUC, since 2018,  can apply for a email with prefix(subdomain) of `stu`, a.k.a. `stu.ouc.edu.cn`

### Proof of domain usage

Details are shown by this announcement from Network Information Center of OUC <http://nic.ouc.edu.cn/_s152/2018/0105/c4688a132953/page.psp>.
