### PR TITLE
Indonesia Open University

### DIFF
--- a/lib/domains/id/ac/ut/ecampus.txt
+++ b/lib/domains/id/ac/ut/ecampus.txt
@@ -1,0 +1,2 @@
+Universitas Terbuka
+Indonesia Open University


### PR DESCRIPTION
I hope you can add Indonesia Open University to JetBrains. Indonesia Open University (Universitas Terbuka) is the campus with the largest number of students in Indonesia. I hope as a student you can approve my request, Thanks.