### PR TITLE
Add nl/eur/student.txt for Erasmus University Rotterdam

### DIFF
--- a/lib/domains/nl/eur/student.txt
+++ b/lib/domains/nl/eur/student.txt
@@ -1,0 +1,3 @@
+Erasmus Universiteit Rotterdam
+Erasmus University Rotterdam
+


### PR DESCRIPTION
This pull request adds the domain nl/eur/student.txt for Erasmus University Rotterdam. The file includes both the Dutch and English names of the university:

- Erasmus Universiteit Rotterdam (Dutch)
- Erasmus University Rotterdam (English)

The domain eur.nl is exclusively used by Erasmus University Rotterdam.