### PR TITLE
Added domain for utech, jamaica

### DIFF
--- a/lib/domains/jm/edu/utech/students.txt
+++ b/lib/domains/jm/edu/utech/students.txt
@@ -1,0 +1,1 @@
+University of Technology, Jamaica


### PR DESCRIPTION
Added support for university of Technology, Jamaica

University Website Address: https://www.utech.edu.jm/ 