### PR TITLE
Add greenriver.edu domain.

### DIFF
--- a/lib/domains/edu/greenriver.txt
+++ b/lib/domains/edu/greenriver.txt
@@ -1,0 +1,1 @@
+Green River College


### PR DESCRIPTION
- student.greenriver.edu was already added, but greenriver.edu separately is needed for faculty.