### PR TITLE
Adding the domain of YOUNITED, the Givat Haviva International School

### DIFF
--- a/lib/domains/org/gh-is.txt
+++ b/lib/domains/org/gh-is.txt
@@ -1,0 +1,1 @@
+YOUNITED - Givat Haviva International School


### PR DESCRIPTION
**YOUNITED, the Givat Haviva International School's** domain name is younitedschool.org, but current student emails are still stuck with the gh-is.org domain, so that is being registered instead. The old gh-is.org domain redirects to younitedschool.org as proof of usage.

We have a 2-year Computer Science course which follows the International Baccalaureate Diploma Programme, as seen in https://younitedschool.org/academics/. The school is located in Israel's Haifa District.