### PR TITLE
Add CREF domain

### DIFF
--- a/lib/domains/it/cref.txt
+++ b/lib/domains/it/cref.txt
@@ -1,0 +1,1 @@
+Centro Ricerche Enrico Fermi


### PR DESCRIPTION
CREF website: www.cref.it
CREF is a public research institution that offers a phd program in physics: https://www.cref.it/la-ricerca/phd/ The official emails of all the students are available in each student's page, all with a cref.it domain.