### PR TITLE
Add PWHS and PWSFC as education institutions 

### DIFF
--- a/lib/domains/uk/co/pwhs.txt
+++ b/lib/domains/uk/co/pwhs.txt
@@ -1,0 +1,1 @@
+Parrs Wood High School

--- a/lib/domains/uk/org/pwsfc.txt
+++ b/lib/domains/uk/org/pwsfc.txt
@@ -1,0 +1,1 @@
+Parrs Wood Sixth Form College


### PR DESCRIPTION
Parrs Wood High School (PWHS) and Parrs Wood Sixth Form College (PWSFC) are a High School and a further education Sixth Form college located in Didsbury, Manchester. The following are links to each one's home page:

[Parrs Wood High School](https://pwhs.co.uk/)
[Parrs Wood Sixth Form College](https://www.pwsfc.org.uk/)

Both schools offer education in Computer Science and IT. 

The high school offers the J277 OCR Computer Science GCSE course and the Digital Information Technology Level 2 BTEC Award. For more info about each course, refer to the school's [Key Stage 4 Choices Booklet (2024)](https://github.com/user-attachments/files/17067378/KS4-Choices-2024.pdf).

The college offers a Computer Science A-Level qualification and a Computing BTEC, as well as other subjects in a similar area such as E-sports and Crimonology. Booklet for Comp. Sci. [here](https://github.com/user-attachments/files/17067424/Computer_Science_A_Level.pdf) and Computing BTEC [here](https://github.com/user-attachments/files/17067429/Computing_BTEC_-_Subject_Sheet_v2.pdf).

Both the high school and the college use the @pwhs.co.uk email, which can be seen by going to either website and scrolling to the bottom, wherein the schools have mailto protocol links featuring the @pwhs.co.uk email.

I am submitting this pull request as a student of the school, I am not an admin or anything similar who works for the school.

Thank you.