### PR TITLE
North East Futures changed domain.

### DIFF
--- a/lib/domains/academy/tynecoast/nef.txt
+++ b/lib/domains/academy/tynecoast/nef.txt
@@ -1,0 +1,1 @@
+North East Futures UTC

--- a/lib/domains/uk/co/nefuturesutc.txt
+++ b/lib/domains/uk/co/nefuturesutc.txt
@@ -1,1 +1,0 @@
-North East Futures UTC


### PR DESCRIPTION
My school changed its domain from the old nefuturesutc.co.uk to the new one, nef.tynecoast.academy

This PR Removes the old domain and adds the new one.