### PR TITLE
added the "cufs - Cyber Hankuk University of Foreign Studies"

### DIFF
--- a/lib/domains/kr/ac/cufs.txt
+++ b/lib/domains/kr/ac/cufs.txt
@@ -1,0 +1,2 @@
+한국사이버외국어대학교
+Cyber Hankuk University of Foreign Studies


### PR DESCRIPTION
Hi team, I added 'cufs.ac.kr' domain, an acronym of the "Cyber Hankuk University of Foreign Studies" in Korea.

* https://www.cufs.ac.kr/eng/main.do