### PR TITLE
Add uchicago to edu domain

### DIFF
--- a/lib/domains/edu/uchicago.txt
+++ b/lib/domains/edu/uchicago.txt
@@ -1,0 +1,1 @@
+University of Chicago


### PR DESCRIPTION
School URL: https://www.uchicago.edu/en
Full school name: The University of Chicago