### PR TITLE
Added University of Jos

### DIFF
--- a/lib/domains/ng/edu/unijos.txt
+++ b/lib/domains/ng/edu/unijos.txt
@@ -1,0 +1,1 @@
+University of Jos, Plateau State Nigeria


### PR DESCRIPTION
1. official University of Jos website showing computer science as a course offered by the university
     [https://unijos.edu.ng/node/514](url)
2. University of Jos student mail 
![ujmail](https://github.com/user-attachments/assets/a72c2194-7c2a-449e-bba8-b07d6c9ea0ff)
