### PR TITLE
add Citrus College to college lists

### DIFF
--- a/lib/domains/edu/citruscollege/student.txt
+++ b/lib/domains/edu/citruscollege/student.txt
@@ -1,0 +1,1 @@
+Citrus College


### PR DESCRIPTION
Add the Citrus Community College to the College lists as directed through the website: https://www.jetbrains.com/shop/eform/students/contributeUniversity
