### PR TITLE
add Marmara University marun.edu.tr domain

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Marmara University domain included in marmara.txt, however **marmara.edu.tr** used only for academics and administrative personnels. There's another domain as **_marun.edu.tr_** which is used by students.

Here [FAQ](https://bidb.marmara.edu.tr/en/frequently-asked-questions-student-e-mail) you can see related information.