### PR TITLE
Add email domains and university information for current and previous schools

### DIFF
--- a/lib/domains/cn/ujn/README.md
+++ b/lib/domains/cn/ujn/README.md
@@ -1,0 +1,5 @@
+# University of Jinan
+
+济南大学
+
+https://www.ujn.edu.cn/

--- a/lib/domains/cn/ujn/mail_stu.txt
+++ b/lib/domains/cn/ujn/mail_stu.txt
@@ -1,0 +1,1 @@
+mail.stu.ujn.edu.cn

--- a/lib/domains/cn/ujn/stu.txt
+++ b/lib/domains/cn/ujn/stu.txt
@@ -1,0 +1,1 @@
+stu.ujn.edu.cn

--- a/lib/domains/cn/ujn/stumail.txt
+++ b/lib/domains/cn/ujn/stumail.txt
@@ -1,0 +1,1 @@
+stumail.ujn.edu.cn

--- a/lib/domains/cn/zstu/README.md
+++ b/lib/domains/cn/zstu/README.md
@@ -1,0 +1,5 @@
+# Zhejiang Sci-Tech University
+
+浙江理工大学
+
+https://www.zstu.edu.cn/

--- a/lib/domains/cn/zstu/mails.txt
+++ b/lib/domains/cn/zstu/mails.txt
@@ -1,0 +1,1 @@
+mails.zstu.edu.cn

--- a/lib/domains/cn/zstu/stu_alias.txt
+++ b/lib/domains/cn/zstu/stu_alias.txt
@@ -1,0 +1,1 @@
+mails.zist.edu.cn

--- a/lib/domains/cn/zstu/teacher.txt
+++ b/lib/domains/cn/zstu/teacher.txt
@@ -1,0 +1,1 @@
+zstu.edu.cn


### PR DESCRIPTION
This pull request adds email domains for students and teachers of the Zhejiang Sci-Tech University and also students of the University of Jinan. It also includes the Chinese and English names of the universities along with their official links in a README file. I am making this pull request because my current and previous universities domains were not added.