### PR TITLE
Add Istanbul University, Turkiye

### DIFF
--- a/lib/domains/tr/edu/iu/ogr.txt
+++ b/lib/domains/tr/edu/iu/ogr.txt
@@ -1,0 +1,2 @@
+İstanbul Üniversitesi
+Istanbul University


### PR DESCRIPTION
Add Istanbul University to the education domain list:
Domain: `@ogr.iu.edu.tr`
Webmail: https://ogr.iu.edu.tr/