### PR TITLE
Added fci.bu.edu.eg domain

### DIFF
--- a/lib/domains/eg/edu/bu/fci.txt
+++ b/lib/domains/eg/edu/bu/fci.txt
@@ -1,0 +1,2 @@
+كلية الحاسبات والذكاء الاصطناعى جامعة بنها
+Benha Faculty of Computers and Artificial Intelligence (BFCAI)


### PR DESCRIPTION
Added a domain for the Benha Faculty of Computers and Artificial Intelligence (fci.bu.edu.eg)