### PR TITLE
marun.edu.tr domain add

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Marmara University is using marmara.edu.tr domain for websites, but it creates student email addresses by using marun.edu.tr domain.

I shared the details below

University Official Website URL: https://www.marmara.edu.tr/
IT Related Department URL: https://cse-eng.marmara.edu.tr/en
Student Email Login Page: https://posta.marun.edu.tr/

[screenshots.pdf](https://github.com/user-attachments/files/17113045/screenshots.pdf)
