### PR TITLE
Add .be for ECI

### DIFF
--- a/lib/domains/be/eci-liege.txt
+++ b/lib/domains/be/eci-liege.txt
@@ -1,0 +1,1 @@
+ECI - École de commerce et d'informatique


### PR DESCRIPTION
https://eci-liege.info is the official site, but they use @eci-liege.be for email, I forgot to add it in my first pull request.
Everything is the same as #23756 


![direct](https://github.com/user-attachments/assets/b9cec955-027c-42c0-9197-28bca3ec7f09)


You can see they own the domain here: https://www.dnsbelgium.be/fr/whois/info/eci-liege.be/details