### PR TITLE
Add carrollu.edu

### DIFF
--- a/lib/domains/edu/carrollu.txt
+++ b/lib/domains/edu/carrollu.txt
@@ -1,0 +1,1 @@
+Carroll University


### PR DESCRIPTION
carrollu.edu is the official domain of Carroll University in Waukesha, Wisconsin.