### PR TITLE
added new domain to KKG Berlin

### DIFF
--- a/lib/domains/berlin/kkg/iserv.txt
+++ b/lib/domains/berlin/kkg/iserv.txt
@@ -1,0 +1,1 @@
+Käthe-Kollwitz-Gymnasium Berlin


### PR DESCRIPTION
Official homepage is https://www.kaethe-kollwitz-gymnasium.de/service/

On the linked page, under "IServ Portalseite" you see the reference to the domain I am adding here. This domain and the other one already in the repository (kkos.net) will run in parallel.