### PR TITLE
Add New University - New Jersey Institute of Technology

### DIFF
--- a/lib/domains/edu/njit.txt
+++ b/lib/domains/edu/njit.txt
@@ -1,0 +1,1 @@
+New Jersey Institute of Technology


### PR DESCRIPTION
Student License expired and does not accept @njit.edu as a student account.