### PR TITLE
Add uniwa.gr domain for University of West Attica.

### DIFF
--- a/lib/domains/gr/uniwa.txt
+++ b/lib/domains/gr/uniwa.txt
@@ -1,0 +1,5 @@
+Πανεπιστήμιο Δυτικής Αττικής
+University of West Attica
+
+Web: https://msc-aivc.uniwa.gr/
+Hub: I use this domain to attend my classes https://eclass.uniwa.gr/ you can only access with mails @uniwa.gr

--- a/uniwa.txt
+++ b/uniwa.txt
@@ -1,0 +1,1 @@
+University of West Attica


### PR DESCRIPTION
This pull request adds the domain "uniwa.gr" for the University of West Attica.

University of West Attica


- Official website: https://msc-aivc.uniwa.gr/
- Hub for attending classes: https://eclass.uniwa.gr/ (access limited to emails using @uniwa.gr)

The university uses the domain for educational purposes and official communications.
