### PR TITLE
Added new web domain for NBI/Handelsakademin

### DIFF
--- a/lib/domains/se/nbi.txt
+++ b/lib/domains/se/nbi.txt
@@ -1,0 +1,1 @@
+NBI/Handelsakademin


### PR DESCRIPTION
Added because the school's email domain has changed and therefore student's email addresses are now of the form student.name@nbi.se instead of student.name@student.nbi-handelsakademin.se, so cannot access authorisation emails from Jetbrains to addresses at the old domain.