### PR TITLE
Add Marmara University's Student Domain

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Add Marmara University's student domain; "@marun.edu.tr" to the repository. Even though the regular "@marmara.edu.tr" is included that is used by teachers and staff. Student mail mentioned here; https://bidb.marmara.edu.tr/en/frequently-asked-questions-student-e-mail