### PR TITLE
Add: eaportal.org domain

### DIFF
--- a/lib/domains/org/eaportal.txt
+++ b/lib/domains/org/eaportal.txt
@@ -1,1 +1,2 @@
 Colégio Adventista de Viamão
+Viamao Adventist Academy

--- a/lib/domains/org/eaportal.txt
+++ b/lib/domains/org/eaportal.txt
@@ -1,0 +1,1 @@
+Colégio Adventista de Viamão


### PR DESCRIPTION
The eaportal.org domain is given to students of the South American division of the Seventh-Day Adventist educational system.

Official site: http://www.educacaoadventista.org.br/
Spanish version of the site for non-Portuguese speaking countries: https://www.educacionadventista.com/

This specific domain is used by students to log into the school portal.