### PR TITLE
Colegio Sagrada Familia de Madrid

### DIFF
--- a/lib/domains/com/safamadrid/a.txt
+++ b/lib/domains/com/safamadrid/a.txt
@@ -1,0 +1,1 @@
+Colegio Sagrada Familia de Madrid


### PR DESCRIPTION
Hola, solicito incorporar este colegio al repositorio.

Colegio: Sagrada Familia de Madrid (SAFAMADRID)
URL: https://safamadrid.com
