### PR TITLE
Create students.txt

### DIFF
--- a/lib/domains/org/mggs/students.txt
+++ b/lib/domains/org/mggs/students.txt
@@ -1,0 +1,2 @@
+Maidstone Grammar School for Girls
+MGGS


### PR DESCRIPTION
Maidstone Grammar School for Girls (also known as MGGS) offers a course in Computer Science at secondary and high school level which can be found [here](https://www.kentprospectus.co.uk/courses/detail/computer-science-86609) and [here](https://www.mggs.org/your-journey/sixth-form/sixth-form-curriculum/).