### PR TITLE
domain added

### DIFF
--- a/lib/domains/pro/axiz.txt
+++ b/lib/domains/pro/axiz.txt
@@ -1,0 +1,1 @@
+Lycées blaise pascal


### PR DESCRIPTION
domain added for Lycées blaise pascal at st-dizier (52100) in france