### PR TITLE
adds bruckneruni.at

### DIFF
--- a/lib/domains/at/bruckneruni.txt
+++ b/lib/domains/at/bruckneruni.txt
@@ -1,0 +1,3 @@
+Anton Bruckner Privatuniversität
+Anton Bruckner University
+Bruckneruni


### PR DESCRIPTION
> the university official website URL

https://www.bruckneruni.at

> a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university

https://www.bruckneruni.at/en/institutes/composition-conducting-and-computer-music/studium

* Computer Music 
* Postdigital Lutherie

> a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.

On https://www.bruckneruni.at/en/university/international-relations/erasmus/erasmus-student-mobility-outgoing under "Application Procedure" it says:

> Please use only your student e-mail address (...@student.bruckneruni.at)
