### PR TITLE
Addition of the njit.hu domain.

### DIFF
--- a/lib/domains/hu/njit.txt
+++ b/lib/domains/hu/njit.txt
@@ -1,0 +1,2 @@
+BMSZC Neumann János Informatikai Technikum
+BMSZC John von Neumann Secondary School


### PR DESCRIPTION
Request to add the "njit.hu" domain, belonging to the BMSZC John von Neumann Secondary School, or it's Hungarian name, "BMSZC Neumann János Informatikai Technikum" in Budapest, Hungary. I've noticed that the "njszg.hu" domain is also present in the lib, this was the old domain of this school, before its renaming a few years ago.