### PR TITLE
Add Marmara University student domain name (MarUn)

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Marmara University has 2 domain names for email.
marmara.edu.tr for teachers in Marmara University
marun.edu.tr is for students in Marmara University
We, Marmara University students use marun.edu.tr addresses to send and get mails.