### PR TITLE
Add Domain for Eastern Mediterranean University (emu)

### DIFF
--- a/lib/domains/tr/edu/emu.txt
+++ b/lib/domains/tr/edu/emu.txt
@@ -1,0 +1,2 @@
+Doğu Akdeniz Üniversitesi
+Eastern Mediterranean University


### PR DESCRIPTION
Students from Eastern Mediterranean University use the emu.edu.tr address for our student emails.

- School official website URL: [website link](https://www.emu.edu.tr/en)
- School address: Famagusta, North Cyprus via Mersin 10, Turkey
- IT-related long-term course URL: [course link](https://www.emu.edu.tr/en/programs/computer-engineering-software-engineering-double-major-program/1431)
- [Link](https://www.emu.edu.tr/en/contact/570) of the school's official contact page that shows emu.edu is the official domain they use.