### PR TITLE
ADD Dominio universidad Cooperativa de Colombia

### DIFF
--- a/lib/domains/co/edu/campusucc.txt
+++ b/lib/domains/co/edu/campusucc.txt
@@ -1,0 +1,1 @@
+Universidad Cooperativa de Colombia


### PR DESCRIPTION
se agrega archivo para el dominio de la Universidad cooperativa de Colombia
Web Site: https://ucc.edu.co/