### PR TITLE
Add Faculté d'ingénierie ULC-Icam, www.ulc-icam.com

### DIFF
--- a/lib/domains/com/ulc-icam.txt
+++ b/lib/domains/com/ulc-icam.txt
@@ -1,0 +1,3 @@
+Faculté d'ingénierie ULC-Icam
+Université Loyola du Congo
+Institut Catholique d'Arts et Métiers


### PR DESCRIPTION
La Faculté d’ingénierie ULC-Icam est cogérée par l’Université Loyola du Congo et le groupe Icam. 
https://www.ulc-icam.com/presentation/ 