### PR TITLE
added marmara university student mail domain

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Marmara University uses both marun.edu.tr and marmara.edu.tr as seen:
https://bidb.marmara.edu.tr/en/e-mail-service