### PR TITLE
Adding "Lycée Marcelin Berthelot", a french school

### DIFF
--- a/lib/domains/fr/lycee-berthelot/eleves.txt
+++ b/lib/domains/fr/lycee-berthelot/eleves.txt
@@ -1,0 +1,2 @@
+Lycée Marcelin Berthelot
+Marcelin Berthelot High School


### PR DESCRIPTION
Website: https://lycee-berthelot.fr

This is an high school but it provides higher education through France's exclusives "CPGE" (i.e: public preparatory classes for commercial and engineering schools).