### PR TITLE
added Faculty Of Computer Science and Artificial Intelligence Helwan university

### DIFF
--- a/lib/domains/eg/edu/helwan/fci.txt
+++ b/lib/domains/eg/edu/helwan/fci.txt
@@ -1,0 +1,1 @@
+Helwan University


### PR DESCRIPTION
the domain is (fci.helwan.edu.eg)
site (https://www.helwan.edu.eg/)