### PR TITLE
Add afpa.training to domains

### DIFF
--- a/lib/domains/training/afpa.txt
+++ b/lib/domains/training/afpa.txt
@@ -1,0 +1,1 @@
+Agence nationale pour la Formation Professionnelle des Adultes


### PR DESCRIPTION
Hello,
Our organization "Afpa" has a new official domain name "afpa.training".
You'll find information about the school here : https://www.afpa.fr/

Afpa offers multiple long-terme trainings about computer science (both development and networking) :
- [https://www.afpa.fr/formation-qualifiante/concepteur-developpeur-d-applications](https://www.afpa.fr/formation-qualifiante/concepteur-developpeur-d-applications)
- [https://www.afpa.fr/formation-qualifiante/concepteur-developpeur-d-applications](https://www.afpa.fr/formation-qualifiante/concepteur-developpeur-d-applications)
- [https://www.afpa.fr/formation-qualifiante/administrateur-systeme-devops-3](https://www.afpa.fr/formation-qualifiante/administrateur-systeme-devops-3)