### PR TITLE
Add Univeristy of South Carolina, Aiken

### DIFF
--- a/lib/domains/edu/usca.txt
+++ b/lib/domains/edu/usca.txt
@@ -1,0 +1,1 @@
+University of South Carolina Aiken 


### PR DESCRIPTION
Adding the domain for the University of South Carolina, Aiken (usca.edu)