### PR TITLE
Added STI College Carmona

### DIFF
--- a/lib/domains/ph/edu/sti/carmona.txt
+++ b/lib/domains/ph/edu/sti/carmona.txt
@@ -1,0 +1,2 @@
+STI College Carmona
+STI College Carmona


### PR DESCRIPTION
STI College's Website: https://www.sti.edu/
School Addresses: Lot 2A Brgy. Maduya, Carmona, Cavite, Philippines
IT related courses: [Bachelor of Science in Information and Technology](https://www.sti.edu/programs-details.asp?p=Mw==)
Proof of Email Domain:
<img width="840" alt="Screenshot 2024-10-11 at 7 29 36 PM" src="https://github.com/user-attachments/assets/9c41029c-c1cc-43fb-b457-7ab789f75e75">
