### PR TITLE
marun.edu.tr mails - Marmara university

### DIFF
--- a/lib/domains/tr/edu/marun.txt
+++ b/lib/domains/tr/edu/marun.txt
@@ -1,0 +1,2 @@
+Marmara Üniversitesi
+Marmara University


### PR DESCRIPTION
Marmara University in Turkey now uses addresses with the extension "marun.edu.tr". Therefore, a new registration is required.