### PR TITLE
Add Superior Collegiate & Vocational Institute(a Canadian high school in Thunder Bay)

### DIFF
--- a/lib/domains/ca/lakeheadschools.txt
+++ b/lib/domains/ca/lakeheadschools.txt
@@ -1,0 +1,1 @@
+Superior Collegiate & Vocational Institute


### PR DESCRIPTION
Hello,
Superior Collegiate& Vocational Institute is a Canadian high school in Thunder Bay (lakehead district).The schools including universities in Canada do not use the domin name ".edu", instead, they all use the domin name of "schoolname.ca", so these schools do not meet your requirement. The information is available on its [website](https://superior.lakeheadschools.ca/). Please kindly add the school on your list so that  I can register as a student.
Thank you for you time and support.

Regards
