### PR TITLE
Add Tarrant County College

### DIFF
--- a/lib/domains/edu/tccd/my.txt
+++ b/lib/domains/edu/tccd/my.txt
@@ -1,0 +1,1 @@
+Tarrant County College


### PR DESCRIPTION
Tarrant County College should be added to the list of domains. The website for the college is https://www.tccd.edu/ and there are multiple computer science classes available. @my.tccd.edu is the domain used for student emails.