### PR TITLE
Add go.bist.ac.kr domain (This is our school's Google student account.)

### DIFF
--- a/lib/domains/kr/ac/bist/go.txt
+++ b/lib/domains/kr/ac/bist/go.txt
@@ -1,0 +1,2 @@
+부산과학기술대학교
+Busan Institute of Science and Technology


### PR DESCRIPTION
I would like to get my school's domain verified.
The domain in question was issued through a Google student account, and a school domain(bist.ac.kr) cannot be issued through any other method, so we are requesting this.

School URL : https://www.bist.ac.kr/univ/main/index.php
Domain Course : https://computer.bist.ac.kr/contents/contents_view.php?site_id=computer&TREE_NO=1660&DEPTH=3