### PR TITLE
Added Istituto Campostrini

### DIFF
--- a/lib/domains/org/scuolacampostrini.txt
+++ b/lib/domains/org/scuolacampostrini.txt
@@ -1,0 +1,1 @@
+Istituto Campostrini


### PR DESCRIPTION
### Istituto Campostrini ([Via S. M. in Organo, 2, 37100 Verona VR](https://www.google.com/maps/place//data=!4m2!3m1!1s0x477f5f34280c8403:0xe1b8cb47e7cae005?sa=X&ved=1t:8290&ictx=111))

**Official School Website**: https://scuola.campostrini.it/
**Istitutional Website**: https://www.campostrini.it/