### PR TITLE
Add unal - Universidad Nacional de Colombia

### DIFF
--- a/lib/domains/co/edu/unal.txt
+++ b/lib/domains/co/edu/unal.txt
@@ -1,0 +1,2 @@
+Universidad Nacional de Colombia
+National University of Colombia


### PR DESCRIPTION
Added Universidad Nacional de Colombia, the biggest puplic university in Colombia,  website: https://unal.edu.co/