### PR TITLE
Add bs-intra domain

### DIFF
--- a/lib/domains/de/bs-intra.txt
+++ b/lib/domains/de/bs-intra.txt
@@ -1,0 +1,1 @@
+Staatliches Berufliches Schulzentrum Roth


### PR DESCRIPTION
@bs-intra.de
Offizielle Website der Schule: https://www.bsz-roth.de/
IT-bezogener Kurs: https://www.bsz-roth.de/berufsfachschule-fuer-informatik/anwendungsentwicklung/
Nachweis der Domain-Nutzung: 
![Screenshot 2024-10-15 103651](https://github.com/user-attachments/assets/4b21221d-3290-4f56-9fea-b1c57a436dce)
