### PR TITLE
Add Chung-Ang University

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
University Name: Chung-Ang University

Official University Website: https://neweng.cau.ac.kr/

URL for Long-term (>1 year) IT Related Courses:
While the specific URL directly showcasing IT-related courses wasn't provided, you can usually find such information under departments like Computer Science, Software Engineering, or Information Technology on the university's official site or through course listings for engineering or science faculties.

Proof of Student Email Domain:
Email Verification URL: https://mportal.cau.ac.kr/
This URL can be used to verify that the email domain @cau.ac.kr or similar is officially used for student communications. Here, students typically log in to check their university email or related services, implicitly proving the domain's association with the student body.

File Information:
File Path: lib/domains/kr/ac/cau.txt
File Content:
Chung-Ang University

Notes for Reviewers:
Chung-Ang University operates with the domain cau.ac.kr for its official communications and student email systems. The provided portal link can serve as verification since it's where students would access their university email accounts, thereby confirming the email domain's legitimacy for student use.
