### PR TITLE
add Georgia Northwestern Technical College (gntc.edu)

### DIFF
--- a/lib/domains/edu/gntc.txt
+++ b/lib/domains/edu/gntc.txt
@@ -1,0 +1,1 @@
+Georgia Northwestern Technical College


### PR DESCRIPTION
Adds [Georgia Northwestern Technical College](https://gntc.edu). I am in the [cybersecurity degree program](https://gntc.smartcatalogiq.com/en/2024-2025/semester-catalog/programs-of-study-business-and-cyber-related-technologies/cybersecurity-is23-associate-of-applied-science-degree/). 