### PR TITLE
Update stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -57,7 +57,6 @@ ecupl.edu.cn
 ecut.edu.cn
 educn.ac.cn
 email.cugb.edu.cn
-email.ncu.edu.cn
 email.szu.edu.cn
 email.zzuli.edu.cn
 emlmuak.cn


### PR DESCRIPTION
I found that my school domain name was removed from the trust list, because I don’t know when it was removed. But according to the current policy, The school will delete email addresses that alumni have not been used for half a year. So it should not be abused now, If there is any abuse, you can cancel it directly，please conduct an internal investigation Assess whether recovery is possible.