### PR TITLE
 support uphsl.edu.ph emails.

### DIFF
--- a/lib/domains/ph/edu/uphsl.txt
+++ b/lib/domains/ph/edu/uphsl.txt
@@ -1,0 +1,1 @@
+University of Perpetual Help System DALTA


### PR DESCRIPTION
A patch to support uphsl.edu.ph emails.
Official website: https://uphsl.edu.ph/index.html
Computer engineering course: https://uphsl.edu.ph/programs/ccs/ccs.html#ccs-bscs