### PR TITLE
Create ece.auth.gr entry

### DIFF
--- a/lib/domains/gr/auth/ece.txt
+++ b/lib/domains/gr/auth/ece.txt
@@ -1,0 +1,1 @@
+School of Electrical & Computer Engineering, Aristotle University of Thessaloniki


### PR DESCRIPTION
Website of university (Aristotle University of Thessaloniki) https://www.auth.gr/en/

Mention of top-level email domain from official page (near end of page -- also in screenshot) https://it.auth.gr/en/institutional-account-guide/

![auth_mail](https://github.com/user-attachments/assets/6b994249-9fbe-4710-a063-8a17ce7f63e3)


Website of ECE school (https://ece.auth.gr/en/home/). Note at the bottom under contact, the requested subdomain can be observed.

Could not procure a full up-to-date undergraduate curriculum in English, I quote instead an excerpt from the general information page (https://ece.auth.gr/en/general-information/).

> The curriculum comprises the core (semesters 1-5) and 3 parallel specializations (semesters 6-10).
The core cycle is common to all students and provides the necessary background knowledge in mathematics, physics and informatics, as well as in Electrical and Computer Engineering (ECE) in the areas of electrical energy, electronic & computer engineering and telecommunications.