### PR TITLE
Add office.koje.ac.kr domain

### DIFF
--- a/lib/domains/kr/ac/koje/office.txt
+++ b/lib/domains/kr/ac/koje/office.txt
@@ -1,0 +1,2 @@
+거제대학교
+Geoje(Koje) University


### PR DESCRIPTION
Document Name: 2024 Admissions Guide for International Students
URL: https://enter.koje.ac.kr/site/resource/koje/enter/file/2024%20Admissions%20Guide%20for%20International%20Students(regular)240430.pdf
Description: This document includes information regarding the official email domains (@office.koje.ac.kr) used by the university staff responsible for student admissions. The provided link is to an official document that helps verify the authenticity of the domain being submitted.
The University Website: https://www.koje.ac.kr/www
