### PR TITLE
[200~https://principal.url.edu.gt/~

### DIFF
--- a/file/lib/domains/gt/edu/url/correo.txt
+++ b/file/lib/domains/gt/edu/url/correo.txt
@@ -1,0 +1,1 @@
+Universidad Rafael Landívar 


### PR DESCRIPTION
Adding Universidad Rafael Landívar email domain.