### PR TITLE
Add Faculty of Engineering - Helwan University (h-eng.helwan.edu.eg) Domain

### DIFF
--- a/lib/domains/eg/edu/helwan/h-eng.txt
+++ b/lib/domains/eg/edu/helwan/h-eng.txt
@@ -1,0 +1,2 @@
+جامعة حلوان
+Helwan University


### PR DESCRIPTION
This pull request adds the domain h-eng.helwan.edu.eg for the Faculty of Engineering at Helwan University in Egypt. The domain has been added under the correct directory path:
lib\domains\eg\edu\helwan\h-eng.txt.

The file will allow students from the Faculty of Engineering at Helwan University to apply for JetBrains educational licenses using their institutional email addresses.