### PR TITLE
Added Wolkenberg Gymnasium Michendorf

### DIFF
--- a/lib/domains/de/wgmail.txt
+++ b/lib/domains/de/wgmail.txt
@@ -1,0 +1,1 @@
+Wolkenberg-Gymnasium Michendorf


### PR DESCRIPTION
Unfortunately, https://wgmail.de does not redirect to the homepage of the school. You can find the homepage here: https://www.wolkenberg-gymnasium.de/.

I hope it's still possible to verify that the wgmail.de domain is affiliated with the school. (I've seen a few @wgmail.de addresses used on the homepage).

If you need me to do anything more for verification, please reach out.