### PR TITLE
add bournemouth and poole college email

### DIFF
--- a/lib/domains/uk/ac/bpc/student.txt
+++ b/lib/domains/uk/ac/bpc/student.txt
@@ -1,0 +1,1 @@
+bournemouth and poole college


### PR DESCRIPTION
add bournemouth and poole college email

-- proof of mail 
http://mail.bpc.ac.uk/