### PR TITLE
Add Jämsän lukio

### DIFF
--- a/lib/domains/fi/jamsa/edu.txt
+++ b/lib/domains/fi/jamsa/edu.txt
@@ -1,0 +1,2 @@
+Jämsän lukio
+Jämsä General Upper Secondary School


### PR DESCRIPTION
Adds Jämsän lukio (official translation Jämsä General Upper Secondary School, Finnish equilevant of a high school)

https://www.jamsa.fi/en/child-care-and-education/education-and-child-care-upper-secondary-education/

Page on the Finnish National Agency of Education's Studyinfo: https://opintopolku.fi/konfo/en/oppilaitos/1.2.246.562.10.89836037138

