### PR TITLE
Add huel.edu.cn

### DIFF
--- a/lib/domains/cn/edu/huel.txt
+++ b/lib/domains/cn/edu/huel.txt
@@ -1,0 +1,1 @@
+Henan University of Economics and Law


### PR DESCRIPTION
Add Henan University of Economics and Law.

Official website: https://www.huel.edu.cn/