### PR TITLE
[ADD] hufs.ac.kr

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
Add hufs.ac.kr(Hankuk University of Foreign Studies) for student license.