### PR TITLE
feat: Add Staatliche Berufsschule Fürstenfeldbruck to JetBrains/swot

### DIFF
--- a/lib/domains/de/bs-ffb/schueler.txt
+++ b/lib/domains/de/bs-ffb/schueler.txt
@@ -1,0 +1,1 @@
+Staatliche Berufsschule Fürstenfeldbruck


### PR DESCRIPTION
- Added domain for Staatliche Berufsschule Fürstenfeldbruck to allow students access to JetBrains educational products.
- Updated lib/domains/de/bs-ffb/ directory to include schueler.txt which is the subdomain domain used for students

This is the official school website: [https://www.bs-ffb.de/](bs-ffb.de)