### PR TITLE
Add UNICAMP (BR)

### DIFF
--- a/lib/domains/br/unicamp/g.txt
+++ b/lib/domains/br/unicamp/g.txt
@@ -1,0 +1,2 @@
+UNICAMP
+State University of Campinas


### PR DESCRIPTION
Adds UNICAMP (https://unicamp.br), which uses @g.unicamp.br e-mails for students.

Official website: https://unicamp.br

Courses page: https://www.comvest.unicamp.br/cursos/
- e.g.: Computer Science: https://www.comvest.unicamp.br/cursos/curso-ciencia-da-computacao/

Link to the student e-mail system: https://www.dac.unicamp.br/portal/acesso/estudantes

![image](https://github.com/user-attachments/assets/c763af78-197f-44c2-93f8-f54dd6fd04a0)
