### PR TITLE
Adding domain for Hellenic Open University

### DIFF
--- a/lib/domains/gr/eap.txt
+++ b/lib/domains/gr/eap.txt
@@ -1,0 +1,2 @@
+Ελληνικο Ανοιχτό Πανεπιστήμιο
+Hellenic Open University


### PR DESCRIPTION
Adding domain ac.eap.gr for Hellenic Open University 

University official website: https://www.eap.gr/

A 2-years MSc course offered, relevant to IT:
https://www.eap.gr/en/data-science-and-machine-learning/

Proof that the domain is officially recognized by the university: My account activation email
![account activation](https://github.com/user-attachments/assets/531406ab-178a-4665-bd3b-48f6456f8327)
