### PR TITLE
Added email domain for ecole de turing

### DIFF
--- a/lib/domains/school/ecoledeturing.txt
+++ b/lib/domains/school/ecoledeturing.txt
@@ -1,0 +1,2 @@
+ecoledeturing.fr
+Ecole de Turing

--- a/lib/domains/school/ecoledeturing.txt
+++ b/lib/domains/school/ecoledeturing.txt
@@ -1,2 +1,1 @@
-ecoledeturing.fr
 Ecole de Turing


### PR DESCRIPTION
Already added ecoledeturing.fr although our students mail addresses use domain ecoledeturing.school.