### PR TITLE
Request to add domain hufs.ac.kr

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
our official website : https://www.hufs.ac.kr/
our university’s representative domain(email) : hufs.ac.kr