### PR TITLE
Add UVP domain for students

### DIFF
--- a/lib/domains/mx/uvp.txt
+++ b/lib/domains/mx/uvp.txt
@@ -1,0 +1,3 @@
+Universidad del Valle de Puebla
+University of the Valley of Puebla
+UVP


### PR DESCRIPTION
I am submitting this pull request to add the domain uvp.edu.mx to the SWoT repository. This domain belongs to the Universidad del Valle de Puebla (UVP), a higher education institution in Mexico. The inclusion of this domain will allow students and faculty members from UVP to request free educational licenses for JetBrains products.

the university official website URL:   https://uvp.mx/