### PR TITLE
Address of the Secretariat of Education of the Federal District

### DIFF
--- a/lib/domains/br/gov/df/se/estudante.txt
+++ b/lib/domains/br/gov/df/se/estudante.txt
@@ -1,0 +1,2 @@
+Centro Educacional 02 Do Paranoá - Distrito Federal
+Paranoá Educational Center 02 - Federal District


### PR DESCRIPTION
added one of the schools in the Federal District's Public Education Network (Important: the @estudante.se.df.gov.br address belongs to the Federal District Government's Department of Education and is given to students enrolled in public schools and not only linked to the Centro Educacional 02 do Paranoá school, it can also be given to students from other schools in the Federal District's Public Education Network) 