### PR TITLE
Adiciona domínio unicamp.br para JetBrains educacional

### DIFF
--- a/lib/domains/br/unicamp.txt
+++ b/lib/domains/br/unicamp.txt
@@ -1,0 +1,1 @@
+Universidade Estadual de Campinas


### PR DESCRIPTION
Adicionei o domínio unicamp.br para permitir que estudantes e professores da Universidade Estadual de Campinas obtenham licenças educacionais da JetBrains.