### PR TITLE
Added SBCC Folder

### DIFF
--- a/lib/domains/edu/sbcc/pipeline.txt
+++ b/lib/domains/edu/sbcc/pipeline.txt
@@ -1,0 +1,1 @@
+Santa Barbara Community College


### PR DESCRIPTION
College Name: Santa Barbara City College
Official College Website: [sbcc.edu](https://www.sbcc.edu)
Official Page for long term IT Courses: [https://cs.sbcc.edu/index.php/all/](https://cs.sbcc.edu/index.php/all/)
Official page with recongnition of email domain: [https://www.sbcc.edu/frc/training/help_gmail.php](https://www.sbcc.edu/frc/training/help_gmail.php)