### PR TITLE
add university of phayao

### DIFF
--- a/lib/domains/th/ac/up.txt
+++ b/lib/domains/th/ac/up.txt
@@ -1,0 +1,2 @@
+มหาวิทยาลัยพะเยา
+University of Phayao


### PR DESCRIPTION
Add University of Phayao to allow students to use JetBrains for free during their studies