### PR TITLE
https://ogr.iu.edu.tr/

### DIFF
--- a/lib/domains/edu/iu/ogr.txt
+++ b/lib/domains/edu/iu/ogr.txt
@@ -1,0 +1,1 @@
+İstanbul Üniversitesi

--- a/lib/lib/domains/tr/edu/iu/ogr.txt
+++ b/lib/lib/domains/tr/edu/iu/ogr.txt
@@ -1,0 +1,2 @@
+İstanbul Üniversitesi
+İstanbul University


### PR DESCRIPTION
https://ogr.iu.edu.tr/ correct student mail domain. University official domain is https://istanbul.edu.tr. in Turkey every university domains must be end with .tr. 