### PR TITLE
Add The Kisumu National Polytechnic

### DIFF
--- a/lib/domains/ke/ac/kisumupoly.txt
+++ b/lib/domains/ke/ac/kisumupoly.txt
@@ -1,0 +1,1 @@
+The Kisumu National Polytechnic


### PR DESCRIPTION
**Add The Kisumu National Polytechnic**

_The university's official website URL_: https://kisumupoly.ac.ke/

_A URL of a page on the official website where a long-term (>1 year) IT-related course is offered by the university: 
https://kisumupoly.ac.ke/computer-and-informatics/
https://application.kisumupoly.ac.ke/Home/PublicProgramDetails?id=9909172b-5586-43a5-bfb0-05eb07c801f1

