### PR TITLE
add diu.edu.bd

### DIFF
--- a/lib/domains/bd/edu/diu.txt
+++ b/lib/domains/bd/edu/diu.txt
@@ -1,0 +1,1 @@
+Daffodil Internation University


### PR DESCRIPTION
Daffodil International University is one of the leading universities in Bangladesh offering many long term IT related courses. The university uses multiple domains for email. diu.edu.bd is one of them.

website link: https://daffodilvarsity.edu.bd/

https://diu.edu.bd/ also redirects to https://daffodilvarsity.edu.bd/