### PR TITLE
Add Shenzhen Polytechnic University

### DIFF
--- a/lib/domains/cn/edu/szpu/mail.txt
+++ b/lib/domains/cn/edu/szpu/mail.txt
@@ -1,0 +1,1 @@
+Shenzhen Polytechnic University


### PR DESCRIPTION
Shenzhen Polytechnic University (SZPU), formerly Shenzhen Polytechnic, is a public undergraduate school founded in 1993. In June 2023, the Ministry of Education granted SZPU the rights and privileges to issue bachelor degrees in addition to 3-year diplomas.