### PR TITLE
Adding London Business School domain to the list

### DIFF
--- a/lib/domains/edu/london.txt
+++ b/lib/domains/edu/london.txt
@@ -1,0 +1,1 @@
+London Business School


### PR DESCRIPTION
london.edu for london business school is suggested to be added to the edu domain directory, Thank you so much