### PR TITLE
Add UofT CS email domain

### DIFF
--- a/lib/domains/edu/toronto/cs.txt
+++ b/lib/domains/edu/toronto/cs.txt
@@ -1,0 +1,1 @@
+University of Toronto (Computer Science Department)


### PR DESCRIPTION
Request to add University of Toronto's Computer Science department to the approved domain list