### PR TITLE
Add Franciscan University of Steubenville

### DIFF
--- a/lib/domains/edu/franciscan.txt
+++ b/lib/domains/edu/franciscan.txt
@@ -1,0 +1,1 @@
+Franciscan University of Steubenville


### PR DESCRIPTION
Domain is franciscan.edu, which is also the website, https://franciscan.edu.
It offers a 4-year Software Engineering program, catalog page [here](<https://franciscan.smartcatalogiq.com/2024-2025/undergraduate-catalog-2024-2025/academic-programs/engineering/software-engineering/>).