### PR TITLE
add maredschool

### DIFF
--- a/lib/domains/be/maredschool.txt
+++ b/lib/domains/be/maredschool.txt
@@ -1,0 +1,1 @@
+Collège Saint-Benoît de Maredsous


### PR DESCRIPTION
Ajout du domaine pour Collège Saint-Benoît de Maredsous.
Site officiel : https://college.maredsous.be/
Le site ne possède pas de page d'inscription pour l'utilisation de se domaine dans les études. Mais celui-ci est bien présent dans l'option sciences économiques et PES.
