### PR TITLE
Add Fergana State University domain file (fdu.uz)

### DIFF
--- a/lib/domains/uz/fdu.txt
+++ b/lib/domains/uz/fdu.txt
@@ -1,1 +1,2 @@
-Fergana state university
+Farg'ona Davlat Universiteti
+Fergana State University


### PR DESCRIPTION
Adding Fergana State University to the JetBrains Student License program. The official domain is fdu.uz.