### PR TITLE
added cjits.org domain for licenses.

### DIFF
--- a/lib/domains/org/cjits.txt
+++ b/lib/domains/org/cjits.txt
@@ -1,0 +1,1 @@
+Christu Jyothi Institute Of Technology and Science


### PR DESCRIPTION
Add cjits.org domain to JetBrains' recognized domain list.