### PR TITLE
Added Australian Institute of Higher Education updated student email address

### DIFF
--- a/lib/domains/au/edu/aih/students.txt
+++ b/lib/domains/au/edu/aih/students.txt
@@ -1,0 +1,1 @@
+Australian Institute of Higher Education


### PR DESCRIPTION
[AIH Website](https://aih.edu.au/)

AIH from 30th August 2024 moved its email service provider from Gmail to Microsoft Outlook and have started using domain `students.aih.edu.au`
[Gmail - Reminder your student email has transitioned from Gmail to Microsoft Outlook.pdf](https://github.com/user-attachments/files/17786645/Gmail.-.Reminder.your.student.email.has.transitioned.from.Gmail.to.Microsoft.Outlook.pdf)
