### PR TITLE
Add nvu.bg to the known university domains

### DIFF
--- a/lib/domains/bg/nvu.txt
+++ b/lib/domains/bg/nvu.txt
@@ -1,0 +1,2 @@
+Национален Военен Университет „Васил Левски"
+National Military University "Vasil Levski"


### PR DESCRIPTION
Add the domain of bulgarian National Military School(Natsionalno Voenno Uchilishte in bulgarian, hence the NVU abbreviation) to the known domains. Reference to the website of the institution https://www.nvu.bg/bg