### PR TITLE
another extension for Istanbul University

### DIFF
--- a/lib/domains/tr/edu/iu.txt
+++ b/lib/domains/tr/edu/iu.txt
@@ -1,0 +1,1 @@
+İstanbul Üniversitesi


### PR DESCRIPTION
@ogr.iu.edu.tr

the university seems to be attached but I cannot register with my e-mail with this extension

"Your email address does not belong to any university that we know. You can apply with another method (see tabs above) or add your school to JetBrains' list."