### PR TITLE
Add FCI Helwan University domain

### DIFF
--- a/fci.txt
+++ b/fci.txt
@@ -1,0 +1,5 @@
+Faculty of Computers And Artificial Intelligence, Helwan University
+FCI Helwan University
+FCIH
+FCAI Helwan University
+FCAIH


### PR DESCRIPTION
Adding Faculty of Computers And Artificial Intelligence, Helwan University, Cairo, Egypt.

Official faculty website: http://fci.helwan.edu.eg -> http://fcih.helwan.edu.eg
Computer Science Program: http://fcih.helwan.edu.eg/computer-science-program
Helwan university website: https://www.helwan.edu.eg/index.php/en
Registered faculties of Helwan university: https://www.helwan.edu.eg/index.php/en/academics/faculties
