### PR TITLE
Add Shahjalal University of Science and Technology

### DIFF
--- a/lib/domains/edu/sust/student.txt
+++ b/lib/domains/edu/sust/student.txt
@@ -1,0 +1,1 @@
+Shahjalal University of Science and Technology


### PR DESCRIPTION
Shahjalal University of Science and Technology (SUST) was established in 1986. The only university of its kind at that time, it started its operations on the 1st Phalgun (13th of February 1991) with only three departments: Physics, Chemistry, and Economics, with 13 teachers and 205 students. It has now expanded to 7 schools, 27 departments, and two institutes. The number of teachers has grown to 566 and the number of students to 8,596. Additionally, the University has 12 affiliated medical colleges under the School of Medical Sciences with 4,000 students.

SUST introduced the integrated honors course in Bangladesh for the first time. It implemented the semester system from the 1996-97 session, and there was a remarkable improvement in the quality of education after the introduction of this system, which was visible even in the national arena. Every student at SUST must take two language courses, one in Bangla and the other in English. Every student must also take two computer courses, one for computer literacy and the other for learning a computer language.

The computer center of SUST offers courses to all employees, and one can say without any hesitation that SUST is the most IT-enabled university in this country. SUST has started its graduate programs by offering master's degrees to graduating bachelors from most departments. While it is difficult to start a world-class research program without a well-funded graduate school, SUST teachers strive to create a research environment on campus.

Two research journals are published regularly from SUST, one in Bangla and the other in English, where hundreds of research papers are submitted every year. Several departments have hosted International Conferences and are planning to organize similar events in the near future.