### PR TITLE
update univ list

### DIFF
--- a/lib/domains/kr/seoultech.txt
+++ b/lib/domains/kr/seoultech.txt
@@ -1,3 +1,5 @@
 서울과학기술대학교
 SeoulTech
+Seoultech
+SEOULTECH
 Seoul National University of Science and Technology

--- a/lib/domains/kr/seoultech.txt
+++ b/lib/domains/kr/seoultech.txt
@@ -1,0 +1,3 @@
+서울과학기술대학교
+SeoulTech
+Seoul National University of Science and Technology


### PR DESCRIPTION
the university official website URL,
https://en.seoultech.ac.kr/

The university email domain is `@seoultech.ac.kr`

### Introduction of Seoul National University of Science and Technology(Seoultech)

Seoul National University of Science and Technology (Seoultech) was established in 1910, originally starting as "Kyungsung Technical School." After undergoing several transformations, it was officially renamed Seoul National University of Science and Technology in 1993.

Currently, Seoultech operates 9 colleges and 47 undergraduate and graduate programs, serving approximately 14,000 students and over 600 faculty members. The university offers excellent education and research across various fields, including engineering, science, humanities, social sciences, and business.

Seoultech has a strong tradition in engineering, particularly in IT and computer engineering, and provides practical, industry-oriented education through various industry-academia collaboration programs and internship opportunities.

Moreover, the university is committed to globalization, fostering international research environments through partnerships with prestigious universities worldwide. It hosts numerous international academic conferences and publishes various scholarly journals to disseminate research findings.

Seoultech mandates English and a second foreign language education for its students, along with required courses in computer literacy. These diverse educational offerings aim to equip students with the competitiveness needed in the global society.

The university also has established research institutes and centers, where researchers actively engage in various fields of study. Through continuous research development and educational innovation, Seoultech contributes to the advancement of science and technology in South Korea.