### PR TITLE
Add TUK, Tech University of Korea

### DIFF
--- a/lib/domains/kr/ac/tukorea.txt
+++ b/lib/domains/kr/ac/tukorea.txt
@@ -1,0 +1,2 @@
+한국공학대학교
+Tech University of Korea


### PR DESCRIPTION
한국공학대학교 (Tech University of Korea)
https://www.tukorea.ac.kr/tukorea/index.do

In 2022, Korea Polytechnic University (KPU) changed its name to Tech University of Korea (TUK).

<b>Introduce</b>
The Korea Polytechnic University (abbreviated as KPU or TU Korea in English, from its official English name "Tech University of Korea") is a four-year private university specializing in engineering, located in Siheung, Gyeonggi Province. It was established in 1997 under the supervision of the Ministry of Trade, Industry, and Energy (MOTIE) and operates as an affiliate of the Korea Industrial Complex Corporation (KICOX), a subsidiary of the Ministry.

KPU was founded to nurture skilled industrial technology professionals and started as the Korea University of Technology and Education (KPU). To overcome limitations posed by its status as an industrial university, it transitioned into a general university in 2012. In 2017, legislation was passed to place the university under the umbrella of KICOX, and it officially became a part of the corporation in 2018. In 2022, on its 25th anniversary, the university rebranded itself as Korea Engineering University to mark a new leap forward as a leading institution in engineering and technology.

Guided by its founding philosophy of Silsa Gu Sisa (seeking truth through fact-based practices), the university aims to nurture creative knowledge leaders who will drive the knowledge-based information society of the 21st century, practical experts who lead corporate growth and technological innovation, and global-minded individuals who contribute to international industrial collaboration and progress. By fostering hands-on, high-level technical professionals with creative thinking skills, Korea Engineering University seeks to establish a new model for engineering education, focusing on practical, field-oriented expertise over theoretical knowledge, thus enhancing national competitiveness.