### PR TITLE
Adding Collège saint-louis

### DIFF
--- a/lib/domains/ch/stls/elv.txt
+++ b/lib/domains/ch/stls/elv.txt
@@ -1,0 +1,1 @@
+Collège Saint-Louis


### PR DESCRIPTION
The mail is @elv.stls.ch for students and @college-stlouis.ch for teachers.
Here is the site: https://www.college-stlouis.ch/
The adress is present in the site : https://www.college-stlouis.ch/infos-pratiques/