### PR TITLE
Added STI College Balayan

### DIFF
--- a/lib/domains/ph/edu/sti/balayan.txt
+++ b/lib/domains/ph/edu/sti/balayan.txt
@@ -1,0 +1,1 @@
+STI College Balayan


### PR DESCRIPTION
Added STI College Balayan School from Balayan, Batangas, Philippines.

Website Link: https://www.sti.edu/
Programs: https://www.sti.edu/programs-tertiary.asp
Campus List: https://www.sti.edu/campuses.asp
Company Disclosures: https://www.sti.edu/stiedu-disclosures_details.asp