### PR TITLE
Add cberi.go.kr

### DIFF
--- a/lib/domains/kr/go/cberi.txt
+++ b/lib/domains/kr/go/cberi.txt
@@ -1,2 +1,2 @@
 충청북도교육연구정보원
-Chungcheongbuk-do Education Research&Information Institute
+Chungcheongbuk-do Education Research and Information Institute

--- a/lib/domains/kr/go/cberi.txt
+++ b/lib/domains/kr/go/cberi.txt
@@ -1,0 +1,2 @@
+운호고등학교
+Unho High School

--- a/lib/domains/kr/go/cberi.txt
+++ b/lib/domains/kr/go/cberi.txt
@@ -1,2 +1,2 @@
-운호고등학교
-Unho High School
+충청북도교육연구정보원
+Chungcheongbuk-do Education Research&Information Institute


### PR DESCRIPTION
‘cberi.go.kr’ is the domain address for emails provided to high school students in North Chungcheong Province, South Korea. This domain is owned by the Chungcheongbuk-do Education Research and Information Institute.