### PR TITLE
REQ: Add City University of Seattle (cityuniversity.edu)

### DIFF
--- a/lib/domains/edu/cityuniversity.txt
+++ b/lib/domains/edu/cityuniversity.txt
@@ -1,0 +1,1 @@
+City University of Seattle


### PR DESCRIPTION
Please add City University of Seattle (cityuniversity.edu).

School Name:
City University of Seattle

School Domain:
cityuniversity.edu

School Home Page:
https://www.cityu.edu/

Note:
The "cityuniversity.edu" domain is used for email addresses and maps to "cityu.edu".