### PR TITLE
Universidad Politécnica de Madrid (UPM)

### DIFF
--- a/lib/domains/es/upm.txt
+++ b/lib/domains/es/upm.txt
@@ -1,0 +1,1 @@
+Universidad Politécnica de Madrid


### PR DESCRIPTION
Engineering university in Madrid, Spain

URL: https://www.upm.es/

IT course details: [Computer Engineering (offered since 2009)](https://www.etsiinf.upm.es/?id=gradoingenieriainformatica/visiongeneral) (etsiinf prefix corresponds to the Computer Science faculty)
Software Engineering, Hardware Engineering, Data Science and many other IT courses offered. 

Proof of domain:
 - Current students have "@alumnos.upm.es": domain is shown in [email login portal](https://www.upm.es/webmail_alumnos/?_task=mail&_mbox=INBOX) ('alumnos' means students in Spanish)
 - Faculty has "@upm.es": domain also shown in [email login portal](https://www.upm.es/webmail_personal/)
 - Alumni are not given an email address

Thus, "upm.es" has been added in the pull request as is shared by students and faculty.