### PR TITLE
Add Human Booster students domain name

### DIFF
--- a/lib/domains/com/stagiaire-humanbooster.txt
+++ b/lib/domains/com/stagiaire-humanbooster.txt
@@ -1,0 +1,2 @@
+HUMAN BOOSTER
+https://humanbooster.com/


### PR DESCRIPTION
Students at Human Booster are using @stagiaire-humanbooster.com as domain name.
The Human Booster website is accessible here : https://humanbooster.com/
The whois showing the domain name is belonging to Human Booster : https://who.is/whois/stagiaire-humanbooster.com