### PR TITLE
Added vku.udn to the list of .udn domains

### DIFF
--- a/lib/domains/vn/udn/vku.txt
+++ b/lib/domains/vn/udn/vku.txt
@@ -1,0 +1,2 @@
+Trường Đại học Công nghệ Thông tin và Truyền thông Việt Hàn
+Vietnam - Korea University of Information and Communication Technology


### PR DESCRIPTION
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university : https://elib.vku.udn.vn
URL of a page showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students :
https://www.facebook.com/vku.udn.vn/?locale=vi_VN