### PR TITLE
Create afk for schools in Akershus

### DIFF
--- a/lib/domains/no/afk
+++ b/lib/domains/no/afk
@@ -1,0 +1,1 @@
+Akershus Fylkeskommune schools. https://afk.no/tjenester/skole-og-opplaring/

--- a/lib/domains/no/afk
+++ b/lib/domains/no/afk
@@ -1,1 +1,0 @@
-Akershus Fylkeskommune schools. https://afk.no/tjenester/skole-og-opplaring/

--- a/lib/domains/no/afk.txt
+++ b/lib/domains/no/afk.txt
@@ -1,0 +1,2 @@
+Akershus Fylkeskommune schools
+https://afk.no/tjenester/skole-og-opplaring/


### PR DESCRIPTION
### Create afk for schools in Akershus
Starting from this school year viken.no is replaced with 3 different domains. This can be seen in the url in this [file](https://github.com/JetBrains/swot/blob/master/lib/domains/no/viken.txt).

### Proof
https://afk.no/lillestrom-vgs/kontakt-oss/ is Lillestrøm videregående's contact us page and you can see a bunch of @afk.no emails.
https://afk.no/royken-vgs/utdanningstilbud/ shows Røyken videregående's programs list which includes some programs related to programming and information technologies.

### Format
Both the student and the teachers have their name and the first couple letters of their surname followed by @akf.no as their e-mails.
F.eks: Patrick Jane could have janepa@afk.no