### PR TITLE
Add seoultech ac kr domain

### DIFF
--- a/lib/domains/kr/ac/seoultech.txt
+++ b/lib/domains/kr/ac/seoultech.txt
@@ -1,0 +1,5 @@
+서울과학기술대학교
+SeoulTech
+Seoultech
+SEOULTECH
+Seoul National University of Science and Technology


### PR DESCRIPTION
This pull request includes a small change to the `lib/domains/kr/ac/seoultech.txt` file. The change adds several variations of the name "Seoul National University of Science and Technology" to the file.

* [`lib/domains/kr/ac/seoultech.txt`](diffhunk://#diff-331db3b23910a0190da6d14791352cb46a9136bfcb0ac303e739231d3a989ae8R1-R5): Added multiple variations of the university's name, including "서울과학기술대학교", "SeoulTech", "Seoultech", "SEOULTECH", and "Seoul National University of Science and Technology".