### PR TITLE
Submit Hufs

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,1 +1,3 @@
 hufs.ac.kr
+한국외국어대학교
+HankukUniversityofForeignStudies

--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,1 @@
+hufs.ac.kr


### PR DESCRIPTION
School Name: 한국외국어대학교 (Hankuk University of Foreign Studies)
domain: hufs.ac.kr
URL: https://www.hufs.ac.kr/