### PR TITLE
Ajout du domaine usms.ac.ma pour Université Sultan Moulay Slimane

### DIFF
--- a/lib/domains/ma/ac/usms.txt
+++ b/lib/domains/ma/ac/usms.txt
@@ -1,0 +1,2 @@
+Université Sultan Moulay Slimane
+Sultan Moulay Slimane University


### PR DESCRIPTION
J'ai ajouté le domaine usms.ac.ma à la liste des domaines académiques, car l'Université Sultan Moulay Slimane (USMS) au Maroc utilise ce domaine pour ses étudiants. Cela permettra aux étudiants de cette institution d'obtenir une licence gratuite pour les outils JetBrains dans le cadre de leurs études en informatique.

L'Université Sultan Moulay Slimane propose des cours dans des domaines liés à l'informatique et aux technologies, et ce domaine est utilisé exclusivement par les étudiants inscrits dans des programmes d'enseignement supérieur.

https://www.usms.ac.ma/en