### PR TITLE
Add domain iqs-blanquerna.url.edu

### DIFF
--- a/lib/domains/edu/url/iqs-blanquerna.txt
+++ b/lib/domains/edu/url/iqs-blanquerna.txt
@@ -1,0 +1,1 @@
+Instituto Químico de Sarriá (Universidad Ramon Llull)


### PR DESCRIPTION
This corresponds to  Instituto Químico de Sarriá (Universidad Ramon Llull)