### PR TITLE
tekura.org.nz

### DIFF
--- a/lib/domains/nz/org/tekura.txt
+++ b/lib/domains/nz/org/tekura.txt
@@ -1,0 +1,1 @@
+Te Aho o Te Kura Pounamu


### PR DESCRIPTION
the current domain for Te Kura is outdated, mytekura.school.nz is not used anymore (at least for new accounts). tekura.org.nz is now used.

![image](https://github.com/user-attachments/assets/26e3b135-6703-4c2f-8f84-990832fe55fc)

Also see on this page under the "Set up Te Kura Google Account" dropdown: https://www.tekura.school.nz/learn-with-us/get-started/get-started-online/

![image](https://github.com/user-attachments/assets/9723de0e-69af-4da5-b90d-eb413fdf8951)