### PR TITLE
Add Sidi Mohamed Ben Abdellah University domain

### DIFF
--- a/lib/domains/ma/ac/usmba.txt
+++ b/lib/domains/ma/ac/usmba.txt
@@ -1,0 +1,2 @@
+Université Sidi Mohamed Ben Abdellah
+Sidi Mohamed Ben Abdellah University


### PR DESCRIPTION
This pull request adds the domain for Sidi Mohamed Ben Abdellah University to the repository. The following changes are included:  
Added lib/domains/ma/ac/usmba.txt .
The file contains the official name of the university.
Verification:  
The official website of the university: https://www.usmba.ac.ma/~usmba2/
https://en.wikipedia.org/wiki/Sidi_Mohamed_Ben_Abdellah_University
Please review and merge the request if it meets the repository's requirements. Thank you!