### PR TITLE
Add FH Münster 

### DIFF
--- a/lib/domains/de/fh-muenster.txt
+++ b/lib/domains/de/fh-muenster.txt
@@ -1,0 +1,1 @@
+FH Münster


### PR DESCRIPTION
FH Münster is a public university of applied science in North Rhine-Westphalia, Germany. 