### PR TITLE
Add Jeju National University

### DIFF
--- a/lib/domains/kr/ac/jejunu.txt
+++ b/lib/domains/kr/ac/jejunu.txt
@@ -1,0 +1,2 @@
+제주대학교
+Jeju National University


### PR DESCRIPTION
Add Jeju National University. 

Some information about the university is available here:

**Main Page:**

https://www.jejunu.ac.kr/eng/index.htm

**Department of Computer Engineering (page is in Korean, may need to be put through Google Translate):**

https://ce.jejunu.ac.kr/

**Department of Computer Engineering Faculty (with jejunu.ac.kr domain in email addresses):**

https://www.jejunu.ac.kr/eng/university/colleges/engine/computer/faculty.htm