### PR TITLE
Ajout du lycée saint Joseph la Salle

### DIFF
--- a/lib/domains/com/stjo-vannes.txt
+++ b/lib/domains/com/stjo-vannes.txt
@@ -1,0 +1,1 @@
+Lycée Saint Joseph La Salle, Vannes


### PR DESCRIPTION
Ajout du lycée Saint Joseph La Salle, a Vannes (56400) en France (fr) à la liste d'établissements possibles pour participer a l'offre étudiante.
Ce lycée rempli toutes les conditions en proposant par exemple des BTSs dans le domaine de l'informatique.