### PR TITLE
Added Sainte-Genevieve preparatory class

### DIFF
--- a/lib/domains/fr/bginette.txt
+++ b/lib/domains/fr/bginette.txt
@@ -1,0 +1,3 @@
+Lycée Privée Sainte-Geneviève
+St-Genevieve preparatory classes
+Ginette 


### PR DESCRIPTION
The St-Genevieve preparatory class is an higher education institution which prepare French students to enter engineering school.

https://en.wikipedia.org/wiki/Lyc%C3%A9e_priv%C3%A9_Sainte-Genevi%C3%A8ve

https://www.bginette.com/