### PR TITLE
Included Universidad de Salamanca as a new /es/ domain

### DIFF
--- a/lib/domains/es/usal.txt
+++ b/lib/domains/es/usal.txt
@@ -1,0 +1,1 @@
+Universidad de Salamanca


### PR DESCRIPTION
Included Universidad de Salamanca as a new /es/ domain