### PR TITLE
add domain for SMK Negeri 1 Pacitan

### DIFF
--- a/lib/domains/id/sch/smkn1pacitan.txt
+++ b/lib/domains/id/sch/smkn1pacitan.txt
@@ -1,0 +1,2 @@
+SMK Negeri 1 Pacitan
+State Vocational High School 1 Pacitan


### PR DESCRIPTION
SMK Negeri 1 Pacitan is a State-owned vocational high school located in Pacitan Regency, East Java, Indonesia