### PR TITLE
Add etu.edu.tr

### DIFF
--- a/lib/domains/tr/edu/etu.txt
+++ b/lib/domains/tr/edu/etu.txt
@@ -1,0 +1,2 @@
+TOBB Ekonomi ve Teknoloji Üniversitesi
+TOBB University of Economics & Technology


### PR DESCRIPTION
- The universty official full name: TOBB University of Economics & Technology
- The university official website URL: https://www.etu.edu.tr/en
- the university street address, including city and country: Söğütözü Cd. No:43, 06510 Çankaya/Ankara, Turkey
- (https://www.google.com/maps/place//data=!4m2!3m1!1s0x14d348b7e9f733ab:0xdf1bcdf3b364e3d8?sa=X&ved=1t:8290&ictx=111)
- An URL of a page on the official website where the school offers an Computer Engineering Program (>4 year): https://www.etu.edu.tr/en/bolum/computer-engineering