### PR TITLE
Add texascollege.edu.np for free educational licenses

### DIFF
--- a/lib/domains/np/edu/texascollege.txt
+++ b/lib/domains/np/edu/texascollege.txt
@@ -1,0 +1,1 @@
+Texas College of Management & IT


### PR DESCRIPTION
Description
This pull request adds the domain texascollege.edu.np to the JetBrains/swot repository to enable students and faculty of Texas International College, located in Nepal, to apply for free JetBrains educational licenses.

Details
Domain: texascollege.edu.np
Institution Name: Texas International College
Location: Kathmandu, Nepal
Verification
The domain is owned by Texas International College and is used for official email addresses of students and faculty.

Checklist
 Added lib/domains/np/edu/texascollege.txt
 File includes the institution name only.
 Verified the domain format follows repository guidelines.