### PR TITLE
Added Székely Mikó National College

### DIFF
--- a/lib/domains/ro/szekelymikokollegium.txt
+++ b/lib/domains/ro/szekelymikokollegium.txt
@@ -1,0 +1,2 @@
+Székely Mikó Kollégium
+"Székely Mikó" National College


### PR DESCRIPTION
Link to the school's official website:
https://www.szekelymikokollegium.ro/