### PR TITLE
Add Gloucestershire College

### DIFF
--- a/lib/domains/uk/ac/gloscol.txt
+++ b/lib/domains/uk/ac/gloscol.txt
@@ -1,0 +1,1 @@
+Gloucestershire College


### PR DESCRIPTION
Main website URL https://gloscol.ac.uk/

3 year Information Technology programme (include programming, as well as software development pathway) - https://www.gloscol.ac.uk/course-details/?id=ITBSC&occId=61CTOP/25-Y1

2 year Software Engineering and Development - https://www.gloscol.ac.uk/course-details/?id=IT2SD2&occId=GSDED3/25-Y1