### PR TITLE
add Yosemite Community College District

### DIFF
--- a/lib/domains/edu/yosemite.txt
+++ b/lib/domains/edu/yosemite.txt
@@ -1,0 +1,1 @@
+Modesto Junior College

--- a/lib/domains/edu/yosemite/my.txt
+++ b/lib/domains/edu/yosemite/my.txt
@@ -1,0 +1,2 @@
+Modesto Junior College
+Modesto Junior College


### PR DESCRIPTION
adds Modesto Junior College & Columbia College

it seems MJC was added 4 years ago with 169b5c7acbd39eafa86ce9c099d5be5989f46b74, but YCCD gives several different formats for student emails... some are `<email>@my.yosemite.edu`, but some also seem to be `<email>@student.yosemite.edu`, and some also seem to be `<email>@yosemite.edu`.