### PR TITLE
To add MCST.EDU.PH as educational institution

### DIFF
--- a/lib/domains/ph/edu/mcst.txt
+++ b/lib/domains/ph/edu/mcst.txt
@@ -1,0 +1,1 @@
+Mandaluyong College of Science and Technology


### PR DESCRIPTION
The mcst.edu.ph domain is used by Mandaluyong College of Science and Technology, which offers at least one long-term course (one year or longer), and the course is related to IT (Bachelor of Science in Information System and Bachelor of Science in Mathematics)

The educational institution is a physical entity with student attendance and recognized as providing a learning curriculum for the educational system, or the institution is an accredited online educational organization providing their students with: (1) online courses with a curriculum at least one year long, (2) a dedicated email address which is provided to students only until their graduation.