### PR TITLE
add sgps.edu.bd

### DIFF
--- a/lib/domains/bd/edu/sgps.txt
+++ b/lib/domains/bd/edu/sgps.txt
@@ -1,0 +1,1 @@
+Saratnagar Goverment Primary School


### PR DESCRIPTION
I am submitting a request to add **Saratnagar Government Primary School** to the JetBrains educational institutions list.

**Details:**

- **School Name**: Saratnagar Government Primary School  
- **Domain**: sgps.edu.bd  
- **Address**: Saratnagar, Pabna District, Bangladesh  
- **Official Website**: [https://sgps.edu.bd/](https://sgps.edu.bd)

**Supporting Information**:
1. The domain `sgps.edu.bd` is officially used by the school for communication and email services.
2. Saratnagar Government Primary School is an educational institution that provides long-term foundational courses for students in primary education, fostering academic development in the region.

If you need additional proof or documentation, please let me know!
