### PR TITLE
Add Kocaeli University domain

### DIFF
--- a/lib/domains/tr/edu/kocaeli.txt
+++ b/lib/domains/tr/edu/kocaeli.txt
@@ -1,0 +1,1 @@
+Kocaeli Üniversitesi


### PR DESCRIPTION
Added `kocaeli.txt` to include Kocaeli University in the list of supported domains for student licenses.
