### PR TITLE
Add Malaga University

### DIFF
--- a/lib/domains/es/uma.txt
+++ b/lib/domains/es/uma.txt
@@ -1,0 +1,2 @@
+Universidad de Málaga
+Malaga University


### PR DESCRIPTION
Hi team! I am submitting a request to add Malaga University to the JetBrains educational institutions list.

Details:

    School Name: Malaga University (Universidad de Málaga in Spanish)
    Domain: uma.es
    Address: Av. de Cervantes, 2, Distrito Centro, 29016 Málaga
    Official Website: https://www.uma.es

Supporting Information:

    The domain uma.es is officially used by the school for communication and email services.
    Malaga University is an educational institution that provides bachelor degrees and post degree masters in the south of Spain.

If you need additional proof or documentation, please let me know!
