### PR TITLE
Add STI College of Davao

### DIFF
--- a/lib/domains/ph/edu/sti/davao.txt
+++ b/lib/domains/ph/edu/sti/davao.txt
@@ -1,0 +1,1 @@
+STI College Davao


### PR DESCRIPTION
## STI College of Davao
- **Website:** [davao.sti.edu](https://davao.sti.edu)
- **Note:** STI College has already been added previously, but only for other branches and not the Davao branch