### PR TITLE
CMCC - Central Maine Community College

### DIFF
--- a/lib/domains/edu/cmcc/cmconnect.txt
+++ b/lib/domains/edu/cmcc/cmconnect.txt
@@ -1,0 +1,1 @@
+Central Maine Community College


### PR DESCRIPTION
**Central Maine Community College** - _CMCC_
https://cmconnect.cmcc.edu/ICS (matching subdomain of student email)
https://www.cmcc.edu/ (Main CMCC website)