### PR TITLE
Add domain ogr.iu.edu.tr for Istanbul University

### DIFF
--- a/ogr.txt
+++ b/ogr.txt
@@ -1,0 +1,1 @@
+İstanbul Üniversitesi


### PR DESCRIPTION
This pull request adds the domain ogr.iu.edu.tr for Istanbul University to the list of recognized educational institutions