### PR TITLE
Adding Ahram canaling university domain

### DIFF
--- a/lib/domains/eg/edu/acu.txt
+++ b/lib/domains/eg/edu/acu.txt
@@ -1,0 +1,2 @@
+Ahram Canadian University
+Ahram Canadian University


### PR DESCRIPTION
**Hello, I'm Ahram canaling university student, Al-Ahram Canadian University is a private non-profit university in 6th of October City, Egypt. It was established by the Al-Ahram newspaper in 2005.
and you can find our university website here: https://acu.edu.eg/
for more information: https://en.wikipedia.org/wiki/Ahram_Canadian_University
We hope you accept our request!**
