### PR TITLE
Add institut G4 France

### DIFF
--- a/lib/domains/fr/institut-g4.txt
+++ b/lib/domains/fr/institut-g4.txt
@@ -1,0 +1,1 @@
+Institut G4


### PR DESCRIPTION
Ajout de l'Institut G4 www.institut-g4.fr, ecole supérieur en formation d'informatique