### PR TITLE
Add Universidad Politécnica de Madrid domain

### DIFF
--- a/lib/domains/es/upm/alumnos.txt
+++ b/lib/domains/es/upm/alumnos.txt
@@ -1,0 +1,1 @@
+Universidad politécnica de madrid


### PR DESCRIPTION
This pull request adds the domain for "Universidad Politécnica de Madrid" to the repository.

- **Institution Name (English):** Polytechnic University of Madrid
- **Institution Name (Spanish):** Universidad Politécnica de Madrid
- **Domain Added:** upm.es
- **Folder Structure:** `lib/domains/es/upm/`
- **Purpose:** To enable students and staff from the Universidad Politécnica de Madrid to access JetBrains products for educational purposes.

Please review and approve this change. Thank you!
