### PR TITLE
Apply to add duc.ac.cn to Chengdu University of the Arts

### DIFF
--- a/lib/domains/cn/ac/duc.txt
+++ b/lib/domains/cn/ac/duc.txt
@@ -1,0 +1,2 @@
+成都艺术职业大学
+Chengdu Vocational University of the Arts


### PR DESCRIPTION
Domain name: duc.ac.cn
School: Chengdu Vocational University of the Arts
Purpose: Add a new domain name so that teachers and students of our school can use the education email to verify their qualifications.