### PR TITLE
Add bcot.ac.uk Basingstoke College of Technology

### DIFF
--- a/lib/domains/uk/ac/bcot/student.txt
+++ b/lib/domains/uk/ac/bcot/student.txt
@@ -1,0 +1,1 @@
+Basingstoke College of Technology


### PR DESCRIPTION
“This PR adds the domain bcot.ac.uk for Basingstoke College of Technology to enable students and staff to use JetBrains educational tools.”