### PR TITLE
Add students domain edu.upct.es

### DIFF
--- a/lib/domains/es/edu/upct.txt
+++ b/lib/domains/es/edu/upct.txt
@@ -1,0 +1,1 @@
+Universidad Politécnica de Cartagena


### PR DESCRIPTION
## Who uses this domain?
While the current domain `@upct.es` is used by teachers, all students are asigned to the `@edu.upct.es` domain

## Additional information
The UPCT is a Politechnic university, which means that most of their offer is related to IT or students on their degrees are good candidates due to working with coding, IoT, or industrial software based on, for example, Phyton or Rusy.


### Official website
* Spanish: [https://upct.es](https://upct.es)

### Long-term IT related studies offer
* Degree in Telematics Engineering: [https://estudios.upct.es/grado/5051/inicio](https://estudios.upct.es/grado/5051/inicio)

### Domain Proof
While there is not a lot of public information about this domain, we can see it in a couple of places:
* [IT Support Wiki page](https://siwiki.upct.es/mediawiki/index.php/Descripci%C3%B3n_del_servicio_de_correo)
* [Students onboarding wiki page](https://opencontent.upct.es/e64ad8955b994ec8b2380a61f2b2360e/f487031cf3024b64a50056d89d3fcc31/)

