### PR TITLE
Added uft.edu (Finis Terrae University)

### DIFF
--- a/lib/domains/edu/uft.txt
+++ b/lib/domains/edu/uft.txt
@@ -1,0 +1,2 @@
+Universidad Finis Terrae
+Finis Terrae University


### PR DESCRIPTION
They use `@uft.cl` domain for teachers, `@uft.edu` for students.

Web page domains: `uft.cl`, `finis.cl` (main one), `finisterrae.cl`

computer science: `https://admision.finis.cl/carrera/ingenieria-civil-en-informatica-y-telecomunicaciones/`

they mention giving edu mails here: `https://finis.cl/estudiantes/recursos-estudiantiles/`, `https://finis.cl/wp-content/uploads/2024/04/instructivo-ingreso-a-plataformas.pdf` page 7