### PR TITLE
Domain for Rizal Technological University added

### DIFF
--- a/lib/domains/ph/edu/rtu.txt
+++ b/lib/domains/ph/edu/rtu.txt
@@ -1,0 +1,1 @@
+Rizal Technological University


### PR DESCRIPTION
School website: https://www.rtu.edu.ph/