### PR TITLE
Adding CADI AYYAD UNIVERSITY

### DIFF
--- a/lib/domains/ma/ac/uca.txt
+++ b/lib/domains/ma/ac/uca.txt
@@ -1,0 +1,1 @@
+université cadi ayyad


### PR DESCRIPTION
URL of Cadi Ayyad University: https://www.uca.ma
domain: uca.ac.ma