### PR TITLE
Add CIFP Francesc de Borja Moll

### DIFF
--- a/lib/domains/eu/cifpfbmoll.txt
+++ b/lib/domains/eu/cifpfbmoll.txt
@@ -1,0 +1,1 @@
+CIFP Francesc de Borja Moll


### PR DESCRIPTION
CIFP Francesc de Borja Moll (Spain).
Educational center with vocational training in IT.
- Official webpage: https://www.cifpfbmoll.eu/
- Long term courses: https://www.cifpfbmoll.eu/cfgs-desenvolupament-daplicacions-web/
- Proof of the email domain for students: https://www.cifpfbmoll.eu/github-campus-program/