### PR TITLE
Added University of Edinburgh domain to JetBrains swot repository

### DIFF
--- a/lib/domains/uk/ac/ed/ed.txt
+++ b/lib/domains/uk/ac/ed/ed.txt
@@ -1,0 +1,2 @@
+University of Edinburgh 
+University of Edinburgh


### PR DESCRIPTION
Added the domain `ed.ac.uk` for the University of Edinburgh to the swot repository. This will allow students and staff to request JetBrains educational licenses. [https://www.ed.ac.uk/] 
