### PR TITLE
Add lpu.edu.ph domain for Lyceum of the Philippines University

### DIFF
--- a/lib/domains/ph/edu/lpu.txt
+++ b/lib/domains/ph/edu/lpu.txt
@@ -1,0 +1,2 @@
+Lyceum of the Philippines University
+Lyceum of the Philippines University, Manila

--- a/lpunetwork.txt
+++ b/lpunetwork.txt
@@ -1,0 +1,1 @@
+lyceum of the philippines university


### PR DESCRIPTION
This pull request adds the domain lpu.edu.ph for the Lyceum of the Philippines University to the repository.

File Path: lib/domains/ph/edu/lpu.txt

Domain Details:
Official Name: Lyceum of the Philippines University
Alternative Name: Lyceum of the Philippines University, Manila

The directory structure and file contents adhere to the repository guidelines. Please review the submission for approval. Thank you!