### PR TITLE
solicitud para incluir la secretaría de educación de Bogotá, Colombia

### DIFF
--- a/lib/domains/co/edu/educacionbogota.txt
+++ b/lib/domains/co/edu/educacionbogota.txt
@@ -1,0 +1,1 @@
+Secretaría de Educación del Distrito

--- a/lib/domains/co/edu/educacionbogota.txt
+++ b/lib/domains/co/edu/educacionbogota.txt
@@ -1,1 +1,3 @@
 Secretaría de Educación del Distrito
+A group of 750 municipal schools
+.group


### PR DESCRIPTION
Soy docente en un colegio que pertenece a la secretaría de educación del Bogotá 
Los dominios que entregan son educacionbogota.edu.co
Agradezco la ayuda que me puedan brindar. Gracias.