### PR TITLE
Add njit.txt

### DIFF
--- a/lib/domains/us/njit.txt
+++ b/lib/domains/us/njit.txt
@@ -1,0 +1,1 @@
+New Jersey Institute of Technology


### PR DESCRIPTION
Adding the domain for New Jersey Institute of Technology (njit.edu) to enable teacher/student license.

*   Official website: https://www.njit.edu
*   Example IT-related program: https://catalog.njit.edu/graduate/computing-sciences/informatics/business-information-systems-ms/
*   Proof of email domain: Brian Rauch <bxr0354@njit.edu>

This change adds the file lib/domains/us/njit.txt