### PR TITLE
Adding parkland high school domain

### DIFF
--- a/lib/domains/net/parklandsd.txt
+++ b/lib/domains/net/parklandsd.txt
@@ -1,0 +1,1 @@
+Parkland High School


### PR DESCRIPTION
This helps all parkland high school students obtain a license to Pycharm. The school website is here: https://phs.parklandsd.org/

and our emails are (7 digits) followed by @parklandsd.net