### PR TITLE
iac.edu.pk domain added

### DIFF
--- a/lib/domains/pk/edu/iac.txt
+++ b/lib/domains/pk/edu/iac.txt
@@ -1,0 +1,1 @@
+Institute for Art and Culture


### PR DESCRIPTION
The institute URL is [iac.edu.pk](https://iac.edu.pk/) and here is the [google profile](https://g.co/kgs/JkbztVf)