### PR TITLE
ZSEE school added

### DIFF
--- a/lib/domains/pl/szczecin/zsee.txt
+++ b/lib/domains/pl/szczecin/zsee.txt
@@ -1,0 +1,2 @@
+Zespół Szkół Elektryczno-Elektronicznych im. prof. Maksymiliana Tytusa Hubera w Szczecinie
+Electrical-Electronic Schools Complex named after Prof. Maksymilian Tytus Huber in Szczecin


### PR DESCRIPTION
#### Institution/School Name 
ZSEE - Zespół Szkół Elektryczno-Elektronicznych im. prof. Maksymiliana Tytusa Hubera w Szczecinie formerly known as
TME - Technikum Elektryczno Elektroniczne w Szczecinie

#### Instiution/School Website
https://tme.edupage.org/
https://tme.szczecin.pl/
https://www.facebook.com/p/Zesp%C3%B3%C5%82-Szk%C3%B3%C5%82-Elektryczno-Elektronicznych-ZSEETME-100040041257203/?locale=pl_PL

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [x] High School or equivalent
- [ ] Elementary School or equivalent