### PR TITLE
Add upn.pe domain for Northern Private University

### DIFF
--- a/lib/domains/pe/upn.txt
+++ b/lib/domains/pe/upn.txt
@@ -1,0 +1,2 @@
+Universidad Privada del Norte
+Northern Private University


### PR DESCRIPTION
This PR adds the upn.pe domain associated with Universidad Privada del Norte (Northern Private University).