### PR TITLE
Add Industrial University of Ho Chi Minh City

### DIFF
--- a/lib/domains/vn/edu/iuh/student.txt
+++ b/lib/domains/vn/edu/iuh/student.txt
@@ -1,0 +1,2 @@
+Đại học Công nghiệp Thành phố Hồ Chí Minh
+Industrial University of Ho Chi Minh City


### PR DESCRIPTION
Wiki: https://en.wikipedia.org/wiki/Industrial_University_of_Ho_Chi_Minh_City
Website | www.iuh.edu.vn/en
The Industrial University of Ho Chi Minh City (IUH), formerly known as Ho Chi Minh University of Industry (esquire: HUI) ([Vietnamese](https://en.wikipedia.org/wiki/Vietnamese_language): Trường Đại học Công nghiệp Thành phố Hồ Chí Minh)[[1]](https://en.wikipedia.org/wiki/Industrial_University_of_Ho_Chi_Minh_City#cite_note-Introduction_general_to_University_of_Industry_School,_Ho_Chi_Minh_City-1) (esquire: ĐHCN TP. HCM), is a university in [Go Vap District](https://en.wikipedia.org/wiki/Go_Vap_District), [Ho Chi Minh City](https://en.wikipedia.org/wiki/Ho_Chi_Minh_City), [Vietnam](https://en.wikipedia.org/wiki/Vietnam).