### PR TITLE
Added FH Muenster to the list fo schools

### DIFF
--- a/lib/domains/de/fh-muenster.txt
+++ b/lib/domains/de/fh-muenster.txt
@@ -1,0 +1,2 @@
+FH Münster
+University of Applied Sciences Muenster


### PR DESCRIPTION
Added the University of Applied Sciences Muenster (German: "FH Münster") to the list, as this school was previously listed but, to an unknown reason, removed.