### PR TITLE
Add glh.de

### DIFF
--- a/lib/domains/de/glh.txt
+++ b/lib/domains/de/glh.txt
@@ -1,0 +1,1 @@
+Gymnasium Lüneburger Heide


### PR DESCRIPTION
Add Domain for GLH (Gymnasium Lüneburger Heide).

Official website: https://www.glh.de/
Explicit mentioning of computer science (informatik) classes: https://www.glh.de/unterricht-gymnasium-privatschule-lueneburg/