### PR TITLE
Rudolph-Brandes-Gymnasium

### DIFF
--- a/lib/domains/nrw/rbg.txt
+++ b/lib/domains/nrw/rbg.txt
@@ -1,0 +1,1 @@
+Rudolph-Brandes-Gymnasium


### PR DESCRIPTION
[Rudolph-Brandes-Gymnasium](https://www.rudolph-brandes-gymnasium.de/)
As the domain isn't listed on the website you can use a whois lookup to verify that the registrar is the Rudolph-Brandes-Gymnasium.