### PR TITLE
Add jnu.ac.kr domain for Chonnam National University

### DIFF
--- a/lib/domains/kr/ac/jnu.txt
+++ b/lib/domains/kr/ac/jnu.txt
@@ -1,0 +1,2 @@
+전남대학교
+chonnam national university


### PR DESCRIPTION
This file contains the official name of 전남대학교 (Chonnam National University)