### PR TITLE
Añadir dominio ucsm.edu.pe para la Universidad Católica de Santa María

### DIFF
--- a/lib/domains/pe/edu/ucsm.txt
+++ b/lib/domains/pe/edu/ucsm.txt
@@ -1,0 +1,1 @@
+Universidad Católica de Santa María


### PR DESCRIPTION
"Este cambio agrega el dominio ucsm.edu.pe correspondiente a la Universidad Católica de Santa María en Arequipa, Perú. El archivo ucsm.txt incluye el nombre oficial de la universidad."