### PR TITLE
Add Seoul National University of Science and Technology domain

### DIFF
--- a/lib/domains/kr/ac/seoultech.txt
+++ b/lib/domains/kr/ac/seoultech.txt
@@ -1,0 +1,2 @@
+서울과학기술대학교
+Seoul National University of Science and Technology


### PR DESCRIPTION
Official website of IUH: https://www.seoultech.ac.kr

IT course description page: https://computer.seoultech.ac.kr/

Prove for the email domain is official: https://mail.seoultech.ac.kr/