### PR TITLE
Add Hochschule Burgenland

### DIFF
--- a/lib/domains/at/hochschule-burgenland.txt
+++ b/lib/domains/at/hochschule-burgenland.txt
@@ -1,0 +1,2 @@
+Hochschule Burgenland
+University of Applied Sciences


### PR DESCRIPTION
Hochschule Burgenland (english name University of Applied Sciences) is a university in Austria. It was formerly known as Fachhochschule Burgenland and is actually in the repository to be found at lib/domains/at/fh-burgenland.txt. However since our rebranding at the end of 2024 the school is known as Hochschule Burgenland and the system does seem to not regocnize it anymore, I think it could be that our E-Mail-Addresses were changed to fit the rebranding. If my fork was to be merged you would find the new file at lib/domains/at/hochschule-burgenland.txt.

Our Website: https://hochschule-burgenland.at/