### PR TITLE
Add [jnu.ac.kr] to the educational domains list

### DIFF
--- a/lib/domains/kr/ac/jnu.txt
+++ b/lib/domains/kr/ac/jnu.txt
@@ -1,0 +1,2 @@
+전남대학교
+Chonnam National University


### PR DESCRIPTION
This pull request adds the domain [your-school.edu] to the JetBrains SWOT repository.

- School Name: Chonnam National University
- Domain: jnu.ac.kr
- This domain is used by students and staff for educational purposes, and we are requesting it to be added for JetBrains educational licenses.

Thank you for reviewing and considering this request.