### PR TITLE
Add University of the West Indies at Cave Hill domain

### DIFF
--- a/lib/domains/edu/uwi/mycavehill.txt
+++ b/lib/domains/edu/uwi/mycavehill.txt
@@ -1,0 +1,1 @@
+University of the West Indies at Cave Hill


### PR DESCRIPTION
Official website URL: https://www.cavehill.uwi.edu/home
IT related course URL: https://www.cavehill.uwi.edu/fst/cmp/programmes/undergraduate/computer-science.aspx
Proof showing that the university recognizes the email domain: https://www.cavehill.uwi.edu/cits/services/for-students/mycavehill-student-mail.aspx