### PR TITLE
Add school domain for Prince of Songkla University

### DIFF
--- a/lib/domains/th/ac/psu/email.txt
+++ b/lib/domains/th/ac/psu/email.txt
@@ -1,0 +1,1 @@
+Prince of Songkla University


### PR DESCRIPTION
for email.psu.ac.th, Prince of Songkla University.