### PR TITLE
Add ICMS (International College of Management, Sydney) domain

### DIFF
--- a/lib/domains/au/edu/icms/students.txt
+++ b/lib/domains/au/edu/icms/students.txt
@@ -1,0 +1,1 @@
+International College of Management, Sydney


### PR DESCRIPTION
official website URL: https://www.icms.edu.au/
address: 151 Darley Rd, Manly NSW 2095, Australia
IT related course: https://www.icms.edu.au/courses/undergraduate/bachelor-of-Information-Technology/
domain: https://www.icms.edu.au/contact/