### PR TITLE
Added domain tromsfylke.no for Nord-Troms Videregående Skole

### DIFF
--- a/lib/domains/no/tromsfylke.txt
+++ b/lib/domains/no/tromsfylke.txt
@@ -1,0 +1,2 @@
+Nord-Troms Videregående Skole
+Nord-Troms High School


### PR DESCRIPTION
## Added domain tromsfylke.no

**Official website:** https://nordtroms.vgs.no/

**Proof of domain usage:**

- https://nordtroms.vgs.no/kontakt-oss/kontaktinformasjon/

- https://www.tromsfylke.no/AnsattOversikt.aspx?pkid=9395&MId1=433#/details/27174a98-a274-4ae3-bc01-696befccf56d

**IT-related course:** https://nordtroms.vgs.no/utdanningstilbud/informasjonsteknologi-og-medieproduksjon/


