### PR TITLE
Add Hankuk University of Foreign Studies(HUFS)

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
**Official Website** : https://www.hufs.ac.kr

**Address**
- Seoul Campus : 107 Imun-ro, Dongdaemun-gu, Seoul(02450) 
- Global Campus : 81 Oedae-ro, Mohyeon-eup, Cheoin-gu, Yongin-si, Gyeonggi-do(17035)

**IT related course** : https://computer.hufs.ac.kr/computer/index.do