### PR TITLE
Add Berufsschule III Regensburg to domain list

### DIFF
--- a/lib/domains/de/regensburg.txt
+++ b/lib/domains/de/regensburg.txt
@@ -1,0 +1,3 @@
+Berufsschule III Regensburg (Vocational School III Regensburg)
+Staatliche Berufsschule III Regensburg (State Vocational School III Regensburg)
+.group


### PR DESCRIPTION
Please find the requested domain addition for Berufsschule III Regensburg.

- **Official website**: [https://www.regensburg.de/bs3](https://www.regensburg.de/bs3)
- **IT-related course**: [https://www.regensburg.de/bs3/bs-iii/ausbildungsberufe/abt-it-berufe](https://www.regensburg.de/bs3/bs-iii/ausbildungsberufe/abt-it-berufe)

<img width="1710" alt="Screenshot 2025-01-14 at 09 17 18" src="https://github.com/user-attachments/assets/85c5d7cc-f852-46af-bfa9-8d10a2626ae4" />
