### PR TITLE
Add alternative domain of Alexandria University

### DIFF
--- a/lib/domains/eg/edu/alexu.txt
+++ b/lib/domains/eg/edu/alexu.txt
@@ -1,0 +1,1 @@
+Alexandria University


### PR DESCRIPTION
Add an alternative domain of Alexandria University in Egypt used by Faculty of Science