### PR TITLE
Add Hankuk University of Foreign Studies

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
It's Hankuk University of Foreign Studies. 
Please review, and if everything look good, merge please.
Thank you.