### PR TITLE
Add Institut Jaume Mimó

### DIFF
--- a/lib/domains/cat/insjaumemimo.txt
+++ b/lib/domains/cat/insjaumemimo.txt
@@ -1,0 +1,1 @@
+Institut Jaume Mimó


### PR DESCRIPTION
Added "Institut Jaume Mimó", from Cerdanyola del Vallès, Spain.

I'd like to clarify that, although it might seem that the domain of **Institut Jaume Mimó** is [agora.xtec.cat](https://agora.xtec.cat/iesjaumemimo/), this is not the actual domain of the school, that is a different domain that all public schools in Catalonia use, and it's not often used on mails for that reason.
The school's actual domain is insjaumemimo.cat. You can verify this in this [link](https://educaciodigital.cat/iesjaumemimo/moodle/login/index.php) (where students log in), where there is a button to automatically log in with any mail with the @insjaumemimo.cat domain.

You can also find the site where students log in by clicking the "Moodle" button on the [homepage](https://agora.xtec.cat/iesjaumemimo/).
