### PR TITLE
Add hampshire.edu domain

### DIFF
--- a/lib/domains/edu/hampshire.txt
+++ b/lib/domains/edu/hampshire.txt
@@ -1,0 +1,1 @@
+Hampshire College


### PR DESCRIPTION
Add Hampshire College (hampshire.edu) to recognized domains.