### PR TITLE
Added Politeknik Perkapalan Negeri Surabaya

### DIFF
--- a/lib/domains/id/ac/ppns/student.txt
+++ b/lib/domains/id/ac/ppns/student.txt
@@ -1,0 +1,2 @@
+Politeknik Perkapalan Negeri Surabaya
+Shipbuilding Institute of Polytechnic Surabaya


### PR DESCRIPTION
Adding Politeknik Perkapalan Negeri Surabaya to JetBrains SWOT

**Official Institution Name**: Politeknik Perkapalan Negeri Surabaya (PPNS)
**English Name**: Shipbuilding Institute of Polytechnic Surabaya (SHIPS)
**Location**: Surabaya, Indonesia
**Email Domain**: student.ppns.ac.id
**Official Website**: https://ppns.ac.id/