### PR TITLE
Create unihumboldt.txt

### DIFF
--- a/lib/domains/co/edu/unihumboldt.txt
+++ b/lib/domains/co/edu/unihumboldt.txt
@@ -1,0 +1,1 @@
+Corporación Universitaria Empresarial Alexander von Humboldt


### PR DESCRIPTION
Name of the institution: Corporación Universitaria Alexander von Humboldt
Institutional domain: unihumboldt.edu.co
Official website: https://www.unihumboldt.edu.co
Description: Corporación Universitaria Alexander von Humboldt is a higher education institution in Colombia. This domain is used for institutional email accounts and educational services.