### PR TITLE
Add Kaposvari Tancsics Mihaly Gimnazium

### DIFF
--- a/lib/domains/hu/tancsics.txt
+++ b/lib/domains/hu/tancsics.txt
@@ -1,0 +1,1 @@
+Kaposvári Táncsics Mihály Gimnázium


### PR DESCRIPTION
Hungarian High School:
Kaposvári Táncsics Mihály Gimnázium

website:
www.tancsics.hu
