### PR TITLE
cslsj scool added to domains in Canada => province of Quebec

### DIFF
--- a/lib/domains/ca/qc/cslsj.txt
+++ b/lib/domains/ca/qc/cslsj.txt
@@ -1,0 +1,2 @@
+École Jean-Gautier 
+


### PR DESCRIPTION
Hello, here is the PR regarding the addition of the Jean-Gauthier school of the Lac Saint-Jean school board located in the province of Quebec in Canada. The school is a public school of the Lac-Saint-Jean School Services Center. Thank you
https://csslsj.gouv.qc.ca/
https://ecolejeangauthier.com/