### PR TITLE
Add ic.edu.lb domain

### DIFF
--- a/lib/domains/edu/IC.txt
+++ b/lib/domains/edu/IC.txt
@@ -1,0 +1,2 @@
+International College (IC) Lebanon
+IC


### PR DESCRIPTION
International College (IC) Lebanon
https://www.ic.edu.lb/welcome
https://www.ic.edu.lb/academics/steam
ic.edu.lb

The `ic.edu.lb` email domain is actively used by students and staff for educational purposes. Let me know if you need additional information or documentation.