### PR TITLE
Add canariaseducacion.es domain

### DIFF
--- a/lib/domains/es/canariaseducacion.txt
+++ b/lib/domains/es/canariaseducacion.txt
@@ -1,0 +1,3 @@
+Consejería de Educación, Universidades, Cultura y Deportes - Gobierno de Canarias
+Gobierno de Canarias
+.group


### PR DESCRIPTION
This pull request adds the domain `canariaseducacion.es` to the repository.

### Information about the domain:
- **Official website of the organization:**  
  [https://www.gobiernodecanarias.org/educacion](https://www.gobiernodecanarias.org/educacion)

- **URL of a page offering long-term IT-related courses:**  
  [Curso de Desarrollo de Aplicaciones Web](https://todofp.es/que-estudiar/grados-d/grado-superior.html)

- **Proof that the domain is officially used for students:**  
  The domain `@canariaseducacion.es` is the official email domain provided to students by the Consejería de Educación, Universidades, Cultura y Deportes - Gobierno de Canarias. This can be verified on their official website or email-related pages.

If additional details or clarifications are needed, please let me know. Thank you for reviewing this request!