### PR TITLE
Added additional domain for Grit Academy

### DIFF
--- a/lib/domains/se/gritgames.txt
+++ b/lib/domains/se/gritgames.txt
@@ -1,0 +1,1 @@
+Grit Academy


### PR DESCRIPTION
Grit Academy (gritacademy.se) has started a new 2-yr program for game developers. Students are learning to code in C++ and C# together with Unreal Engine and Unity. These students will be using gritgames.se as their email domain instead of gritacademy.se - but it is still the same school. This is the reason I request to add this domain. 