### PR TITLE
Adding unisal generic domain

### DIFF
--- a/lib/domains/br/unisal/aluno.txt
+++ b/lib/domains/br/unisal/aluno.txt
@@ -1,0 +1,1 @@
+UNISAL - Centro Universitário Salesiano de São Paulo

--- a/lib/domains/br/unisal/aluno.txt
+++ b/lib/domains/br/unisal/aluno.txt
@@ -1,2 +1,1 @@
 UNISAL - Centro Universitário Salesiano de São Paulo
-Centro Universitário Salesiano de São Paulo

--- a/lib/domains/br/unisal/aluno.txt
+++ b/lib/domains/br/unisal/aluno.txt
@@ -1,1 +1,2 @@
 UNISAL - Centro Universitário Salesiano de São Paulo
+Centro Universitário Salesiano de São Paulo


### PR DESCRIPTION
Hello, in 2020 there was an update in Emails from UNISAL (the university I study computer engineering) in Brazil, and accordingly to Brazilian data laws, they need to change from RA@aluno.sj.unisal.br to RA@aluno.unisal.br (removing the .sj). So I've created this domain to match the new pattern of my university email.