### PR TITLE
adding Taradale High School

### DIFF
--- a/lib/domains/nz/school/ths.txt
+++ b/lib/domains/nz/school/ths.txt
@@ -1,0 +1,1 @@
+Taradale High School


### PR DESCRIPTION
adding Taradale High School (high school in Napier, Hawke's Bay, NZ)