### PR TITLE
sau11.org

### DIFF
--- a/lib/domains/org/sau11.txt
+++ b/lib/domains/org/sau11.txt
@@ -1,0 +1,1 @@
+Dover High School

--- a/lib/domains/us/nh/k12/dover.txt
+++ b/lib/domains/us/nh/k12/dover.txt
@@ -1,4 +1,0 @@
-Dover High School
-Dover Regional Tech Center
-https://www.dover.k12.nh.us/
-.group


### PR DESCRIPTION
Moves `dover.k12.nh.us` to `sau11.org`.

[Homepage](https://dover.k12.nh.us)
[IT program](https://ctc.dover.k12.nh.us/apps/pages/index.jsp?uREC_ID=1253507&type=d&pREC_ID=1477636)
[Proof of domain use](https://github.com/user-attachments/assets/51745443-9a8f-4255-af3e-c57c57d9fe14) ([source document](https://4.files.edl.io/2c86/03/11/21/163114-d7a2f5d0-2326-467b-9326-4fec53ba74ee.pdf))
