### PR TITLE
Added Kolehiyo ng Lungsod ng Dasmariñas

### DIFF
--- a/lib/domains/ph/edu/kld.txt
+++ b/lib/domains/ph/edu/kld.txt
@@ -1,0 +1,2 @@
+Kolehiyo ng Lungsod ng Dasmariñas
+College of City of Dasmariñas


### PR DESCRIPTION
Please Add Kolehiyo ng Lungsod ng Dasmariñas (English name: College of City of Dasmariñas)
Official Facebook Link: https://www.facebook.com/KLDOfficialFBPage
Official Website Link: https://www.kld.edu.ph
BS in Information Systems Program Included in the Website: https://www.kld.edu.ph/degree-programs/