### PR TITLE
add Penang Matriculation College

### DIFF
--- a/lib/domains/my/edu/moe-dl.txt
+++ b/lib/domains/my/edu/moe-dl.txt
@@ -1,0 +1,1 @@
+Penang Matriculation College


### PR DESCRIPTION
http://www.kmpp.matrik.edu.my/

Currently on maintenance, but it's an official government matriculation college programme. 

It's under Kolej Matrikulasi Pulau Pinang on Malaysia's Ministry of Education website:
https://www.moe.gov.my/senarai-matrikulasi