### PR TITLE
ZSP im. Jana Pawła II w Czarnem

### DIFF
--- a/lib/domains/pl/org/czluchow.txt
+++ b/lib/domains/pl/org/czluchow.txt
@@ -1,0 +1,2 @@
+Zespół Szkół Ponadpodstawowych im. Jana Pawła II w Czarnem
+Jan Paweł II Secondary School Complex in Czarne


### PR DESCRIPTION
Zespol Szkol Ponadpodstawowych im. Jana Pawła II w Czarnem