### PR TITLE
Add johnruskin.txt

### DIFF
--- a/lib/domains/uk/ac/johnruskin.txt
+++ b/lib/domains/uk/ac/johnruskin.txt
@@ -1,0 +1,1 @@
+John Ruskin College


### PR DESCRIPTION
Address: John Ruskin College, Selsdon Park Road, South Croydon, CR2 8JJ
Website: https://www.johnruskin.ac.uk/
Domain: @johnruskin.ac.uk