### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/ink/gmbh/sbs.txt
+++ b/lib/domains/ink/gmbh/sbs.txt
@@ -1,0 +1,2 @@
+Szkoła Biznesu Snowdon
+Snowdon Business School


### PR DESCRIPTION
Szkoła Biznesu Snowdon, część Polskiego Uniwersytetu Ekonomiczno-Finansowego, to miejsce, gdzie przyszli liderzy biznesu zdobywają niezbędne umiejętności i wiedzę. Nasza szkoła łączy tradycję akademicką z nowoczesnymi metodami nauczania, oferując programy, które przygotowują do globalnych wyzwań biznesowych. Nasi absolwenci są gotowi do kreowania innowacji i liderowania w dynamicznym świecie biznesu.