### PR TITLE
Update stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -620,3 +620,5 @@ oshsu.email
 kuosat.tech
 acu.edu.kg
 ink
+poly.edu.rs
+kun.edu.kg

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -622,3 +622,4 @@ acu.edu.kg
 ink
 poly.edu.rs
 kun.edu.kg
+my.csun.edu


### PR DESCRIPTION
A total of  fake domain names, provided to the github official audit：@poly.edu.rs.  @kun.edu.kg、@my.csun.edu

I am a volunteer of Report Fraud Maintain Fairness, after analyzing the whois record of the submitted domain name to check: kun.edu.kg is a fake qualification university: https://www.cctld.kg/en/whois/result?domain=KUN.EDU.KG

The domain name of poly.edu.rs was registered on January 24th and is also a fake university: https://www.whois.com/whois/poly.edu.rs

The @my.csun.edu domain name has been publicly abused, and it is impossible to determine whether it is a real student, because the university's edu has been unlimitedly publicly registered @my.csun.edu for free. There are many tutorials on the Internet for free registration @my.csun.edu.

Searching the keyword "@my.csun.edu free registration" on Google will yield a large number of free tutorials.