### PR TITLE
Update stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -617,6 +617,5 @@ live
 top
 oshtu.me
 oshsu.email
-kuosat.tech
 acu.edu.kg
 ink


### PR DESCRIPTION
The school domain alias is being abused, but this is indeed the school's domain alias
The old domain alias `kuosat.org` is no longer in use, please delete it.