### PR TITLE
Add Universidad Nacional de Colombia

### DIFF
--- a/lib/domains/co/edu/unal.txt
+++ b/lib/domains/co/edu/unal.txt
@@ -1,0 +1,1 @@
+Universidad Nacional de Colombia


### PR DESCRIPTION
This Pull Request adds the Universidad Nacional de Colombia to the list of educational institutions in the JetBrains/swot repository.

#### Details:
- **Institution Name:** Universidad Nacional de Colombia
- **Institutional Domain:** `unal.edu.co`
- **File Added:** `lib/domains/co/edu/unal.txt`

#### Justification:
The Universidad Nacional de Colombia is a leading public university in Colombia, offering a wide range of undergraduate and postgraduate programs across various fields. The institutional domain (`unal.edu.co`) is used by students and faculty for academic emails and educational services.

Additionally, the **School of Systems and Computing Engineering** uses the same institutional domain (`unal.edu.co`) for its communications.

#### References:
- Official Website: [https://unal.edu.co](https://unal.edu.co)
- School of Systems and Computing Engineering: [https://ingenieria.bogota.unal.edu.co/es/formacion/pregrado/ingenieria-de-sistemas-y-computacion.html](https://ingenieria.bogota.unal.edu.co/es/formacion/pregrado/ingenieria-de-sistemas-y-computacion.html)