### PR TITLE
Added Dept. of Applied Mechanics (Budapest University of Technology and Economics)

### DIFF
--- a/lib/domains/hu/bme/mm.txt
+++ b/lib/domains/hu/bme/mm.txt
@@ -1,0 +1,2 @@
+Budapesti Műszaki és Gazdaságtudományi Egyetem
+Budapest University of Technology and Economics


### PR DESCRIPTION
Domain `mm.bme.hu` is used by teachers of the Dept. of Applied Mechanics in:
Budapest University of Technology and Economics 
(Faculty of Mechanical Engineering)

IT-related courses offered by the university: [Computer Engineering courses (BSC, MSC)](https://www.vik.bme.hu/en/education/programs/)
Programming-related course offered by the faculty: [Mechanical Engineering Modeling MSC](https://www.mm.bme.hu/spec/solidmech)
URL of a page showing that the university recognizes the domain: [mm.bme.hu/contact](https://www.mm.bme.hu/contact)

Thanks for reviewing the PR in advance.