### PR TITLE
Add Hankuk University of Foreign Studies domain

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,1 +1,1 @@
-hufs.ac.kr
+Hankuk University of Foreign Studies

--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,1 @@
+hufs.ac.kr


### PR DESCRIPTION
This PR adds the domain for Hankuk University of Foreign Studies.

- School Name: Hankuk University of Foreign Studies
- School Website: https://www.hufs.ac.kr
- Email Domain: hufs.ac.kr

Please review and merge this PR. Thank you!
