### PR TITLE
Update stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -639,3 +639,4 @@ knau.edu.kg
 tss.edu.kg
 aa.edu.kg
 pccinternational.org
+c5.hk


### PR DESCRIPTION
The real address of Canossa Primary School is https://www.cpswts.edu.hk/

![880b7f53d913b7abbffcc553c12958fd.png](https://i.miji.bid/2025/02/10/880b7f53d913b7abbffcc553c12958fd.png)
![c01f9acfa7d3180207b1a48f8cbe44a7.png](https://i.miji.bid/2025/02/10/c01f9acfa7d3180207b1a48f8cbe44a7.png)

Fake website snapshot query: http://web.archive.org/web/20241123020836/https://c5.hk/