### PR TITLE
Added Atlantic Cape Faculty Email Domain

### DIFF
--- a/lib/domains/edu/atlantic.txt
+++ b/lib/domains/edu/atlantic.txt
@@ -1,0 +1,2 @@
+Atlantic Cape Community College
+Atlantic Cape Community College


### PR DESCRIPTION
Additional information:
University official website URL:
[https://www.atlanticcape.edu](https://www.atlanticcape.edu/)
Faculty  emails are in the form [username@atlantic.edu](mailto:username@atlantic.edu)
Thank you for reviewing this request!