### PR TITLE
Update stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -640,3 +640,6 @@ tss.edu.kg
 aa.edu.kg
 pccinternational.org
 c5.hk
+c5.hk
+uest.edu.kg
+aa.edu.kg


### PR DESCRIPTION
A Chinese is abusing jetBrains’ educational discount loophole and applying to many fake schools, causing fraud and abuse. 
Name: Shi Jia 
iPhone:+8615869170395
Abuse of domain names c5.hk, uest.edu.kg, aa.edu.kg Please sanction it

