### PR TITLE
Add City College of San Francisco

### DIFF
--- a/lib/domains/edu/ccsf/mail.txt
+++ b/lib/domains/edu/ccsf/mail.txt
@@ -1,0 +1,2 @@
+CCSF
+City College of San Francisco


### PR DESCRIPTION
Add `mail.ccsf.edu` to domains. Official website: https://www.ccsf.edu/