### PR TITLE
add kafs university domain

### DIFF
--- a/lib/domains/eg/edu/kfs/agr.txt
+++ b/lib/domains/eg/edu/kfs/agr.txt
@@ -1,0 +1,2 @@
+جامعة كفر الشيخ
+Kafrelsheikh University


### PR DESCRIPTION
This PR to add [Kafrelsheikh Universit](https://kfs.edu.eg/) domain.