### PR TITLE
[ndri.res.in] Added domain for NDRI, Karnal

### DIFF
--- a/lib/domains/in/res/ndri.txt
+++ b/lib/domains/in/res/ndri.txt
@@ -1,0 +1,1 @@
+ICAR - National Dairy Research Institute, Karnal


### PR DESCRIPTION
Added **ICAR-National Dairy Research Institute** (ndri.res.in) in the domain list.

1. University Official Website: https://ndri.res.in/
2. List of Courses requiring IT: https://ndri.res.in/education/admission/
3. The courses namely, Animal Biochemistry, Animal Biotechnology, Animal Genetics & Breeding requires the use of IT related software.
