### PR TITLE
Add Shri Ramswaroop Memorial University to JetBrains swot repository

### DIFF
--- a/file (2)/lib/domains/in/ac/srmu.txt
+++ b/file (2)/lib/domains/in/ac/srmu.txt
@@ -1,0 +1,1 @@
+Shri Ramswaroop Memorial University


### PR DESCRIPTION
University Name: Shri Ramswaroop Memorial University

Domain Added: srmu.ac.in

Reason for Submission:
Shri Ramswaroop Memorial University is a recognized educational institution in India. The university provides academic email addresses (@srmu.ac.in) to students and faculty. Adding this domain to JetBrains' swot repository will allow students to apply for JetBrains' student license.

Official Website: https://www.srmu.ac.in/

Additional Information:

The university offers multiple degree programs in engineering, management, and sciences.
The email domain is actively used by students and faculty for official academic purposes.
Please review and merge this request. Let me know if any additional details are needed.