### PR TITLE
Añadir dominio "sandunga" para la Universidad del Istmo

### DIFF
--- a/lib/domains/mx/edu/unistmo/sandunga.txt
+++ b/lib/domains/mx/edu/unistmo/sandunga.txt
@@ -1,0 +1,1 @@
+Universidad del Istmo campus Tehuantepec


### PR DESCRIPTION
Dentro del repositorio ya existía una entrada para la Universidad del Istmo, específicamente con el dominio bianni. Sin embargo, la universidad utiliza diferentes dominios de correo electrónico para sus distintos campus.
En este caso, se ha agregado un nuevo dominio sandunga, que corresponde a otro campus de la misma universidad.

Gracias por revisar y considerar esta solicitud. Quedo atento a cualquier comentario.