### PR TITLE
Added Pandit Deendayal Energy University

### DIFF
--- a/lib/domains/in/ac/pdpu/sot.txt
+++ b/lib/domains/in/ac/pdpu/sot.txt
@@ -1,0 +1,1 @@
+Pandit Deendayal Energy University - School of Technology


### PR DESCRIPTION
University URL: https://pdeu.ac.in/school-of-technology
Also active: https://sot.pdpu.ac.in/
Courses offered: https://pdeu.ac.in/courses
Note:
University underwent a name change from Pandit Deendayal Petroleum University (PDPU) to Pandit Deendayal Energy University (PDEU)
Emails for students still use pdpu.ac.in but website has been changed to pdeu.ac.in