### PR TITLE
add new IIT domain for Outlook addresses

### DIFF
--- a/lib/domains/edu/illinoistech.txt
+++ b/lib/domains/edu/illinoistech.txt
@@ -1,0 +1,1 @@
+Illinois Institute of Technology


### PR DESCRIPTION
New student addresses for Illinois Institute of Technology use `illnoistech.edu` instead of the "legacy" domain of `iit.edu`. Both domains are valid but students enrolled prior to 2025 have iit addresses and new students have illnoistech addresses.