### PR TITLE
Request to Remove "tukorea.ac.kr" from the Abused List

### DIFF
--- a/lib/domains/kr/ac/tukorea.txt
+++ b/lib/domains/kr/ac/tukorea.txt
@@ -1,0 +1,2 @@
+한국공학대학교
+Tech University of Korea


### PR DESCRIPTION
Our institution, Tech University of Korea, is currently listed on the abused list, preventing our students from accessing JetBrains student licenses. 

Tech University of Korea is a four-year university specializing in IT and technology education. We kindly request a review of our school's email domain and its removal from the abused list so that our students can utilize JetBrains tools for academic purposes.

Thank you for your time and consideration.