### PR TITLE
Add correo.tdea.edu.co domain for Tecnologico de Antioquia

### DIFF
--- a/lib/domains/co/edu/tdea/correo.txt
+++ b/lib/domains/co/edu/tdea/correo.txt
@@ -1,0 +1,1 @@
+Tecnológico de Antioquia


### PR DESCRIPTION
This PR adds the domain tdea.edu.co for Tecnológico de Antioquia – Institución Universitaria, an educational institution in Colombia that offers IT-related courses.

Official website: https://www.tdea.edu.co/
email domain: correo.tdea.edu.co

Thank you for view this request.