### PR TITLE
Added albertparkcollege to domain/au/edu/vic

### DIFF
--- a/lib/domains/au/edu/vic/albertparkcollege.txt
+++ b/lib/domains/au/edu/vic/albertparkcollege.txt
@@ -1,0 +1,1 @@
+Albert Park College


### PR DESCRIPTION
School:
Albert Park College

Website:
https://albertparkcollege.vic.edu.au