### PR TITLE
Add a college that teaches software engineering

### DIFF
--- a/lib/domains/hu/semmelweis/emk.txt
+++ b/lib/domains/hu/semmelweis/emk.txt
@@ -1,0 +1,2 @@
+Semmelweis Egyetem Egészségügyi Menedzserképző Központ
+Health Services Management Training Centre, Semmelweis University

--- a/lib/domains/ua/edu/kitu.txt
+++ b/lib/domains/ua/edu/kitu.txt
@@ -1,0 +1,2 @@
+Фаховий коледж інженерії, управління та землевпорядкування Державного некомерційного підприємства "Державний університет "Київський авіаційний інститут""
+Professional College of Engineering, Management and Land Management of the State Non-Profit Enterprise "State University "Kyiv Aviation Institute"


### PR DESCRIPTION
Professional College of Engineering, Management and Land Management of the State Non-Profit Enterprise "State University "Kyiv Aviation Institute"" can be found as Фаховий коледж інженерії, управління та землевпорядкування Державного некомерційного підприємства "Державний університет "Київський авіаційний інститут""