### PR TITLE
senecapolytechnic.ca

### DIFF
--- a/lib/domains/ca/senecapolytechnic.txt
+++ b/lib/domains/ca/senecapolytechnic.txt
@@ -1,0 +1,2 @@
+Seneca Polytechnic
+Seneca Polytechnic


### PR DESCRIPTION
Adding senecapolytechnic.ca to list of post-secondary institutions in Canada.
Seneca College recently changed its domain from senecacollege.ca to senecapolytechnic.ca