### PR TITLE
ADD alumnos.upm.es domain

### DIFF
--- a/lib/domains/es/upm/alumnos.txt
+++ b/lib/domains/es/upm/alumnos.txt
@@ -1,0 +1,1 @@
+Universidad Politécnica de Madrid


### PR DESCRIPTION
- Universidad Politécnica de Madrid domain is https://www.upm.es/
- Students have the alumnos.upm.es subdomain for their email addresses. 
- https://www.upm.es/Estudiantes/Estudios_Titulaciones/Estudios_Master/Programas contains an exhaustive list of Bachelor, Master and other postgraduate programs that are IT related.
- I am providing below proof that the domain alumnos.upm.es is recognized for the students in Universidad Politecnica de Madrid (upm.es)
![imagen](https://github.com/user-attachments/assets/c9becca2-04a8-44ef-a712-9e09f2574502)
