### PR TITLE
Verify university domain

### DIFF
--- a/rmu.txt
+++ b/rmu.txt
@@ -1,0 +1,1 @@
+Robert Morris University


### PR DESCRIPTION
Request to add Robert Morris University to the list of universities supported for JetBrains educational products.

The domain corresponding to the university's emails is "rmu.edu"

University website: https://www.rmu.edu/