### PR TITLE
Adding Domain for Misaka University

### DIFF
--- a/lib/domains/kg/edu/misaka.txt
+++ b/lib/domains/kg/edu/misaka.txt
@@ -1,0 +1,2 @@
+Мисака университети
+Misaka University


### PR DESCRIPTION
add the domain for Misaka University
The domain corresponding to the university's emails is "misaka.edu.kg"

Official website of the university
https://www.misaka.edu.kg

