### PR TITLE
Add RSG Enkhuizen

### DIFF
--- a/lib/domains/nl/rsgedu.txt
+++ b/lib/domains/nl/rsgedu.txt
@@ -1,0 +1,2 @@
+RSG Enkhuizen
+https://rsg-enkhuizen.nl/


### PR DESCRIPTION
Added domain for school "RSG Enkhuizen" https://rsg-enkhuizen.nl/ with e-mail domain rsgedu.nl
