### PR TITLE
Add Micklefield Church of England Primary Academy, UK

### DIFF
--- a/lib/domains/uk/org/micklefieldprimary.txt
+++ b/lib/domains/uk/org/micklefieldprimary.txt
@@ -1,0 +1,1 @@
+Micklefield Church of England Primary Academy


### PR DESCRIPTION
Address：Great North Road, Micklefield, Leeds, West Yorkshire, LS25 4AQ
Request official permission from GitHub to add the school, which will offer a children's programming development course.