### PR TITLE
Adding Qassim Univ in Saudi Arabia

### DIFF
--- a/lib/domains/sa/edu/qu.txt
+++ b/lib/domains/sa/edu/qu.txt
@@ -1,0 +1,1 @@
+qassim university


### PR DESCRIPTION
Please add Qassim university to be recognized by JetBrains. 

Qassim Univ. website: https://qu.edu.sa/
Computer College website: https://www.qu.edu.sa/faculty_department/453

