### PR TITLE
Add Işık University Student mail domain 

### DIFF
--- a/lib/domains/tr/edu/isik.txt
+++ b/lib/domains/tr/edu/isik.txt
@@ -1,0 +1,2 @@
+Işık Üniversitesi
+Işık University


### PR DESCRIPTION
There is already a domain added for Işık University at the existing repository but that domain(@isikun.edu.tr) is only used for teachers at our school. For students "@isik.edu.tr" is being used. Thus, this domain should be added for students to be able to use free licence properly.