### PR TITLE
Added various NITS departments

### DIFF
--- a/lib/domains/in/ac/nits.txt
+++ b/lib/domains/in/ac/nits.txt
@@ -1,0 +1,1 @@
+National Institute of Technology, Silchar

--- a/lib/domains/in/ac/nits/che.txt
+++ b/lib/domains/in/ac/nits/che.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/civil.txt
+++ b/lib/domains/in/ac/nits/civil.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/cse.txt
+++ b/lib/domains/in/ac/nits/cse.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/ece.txt
+++ b/lib/domains/in/ac/nits/ece.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/ei.txt
+++ b/lib/domains/in/ac/nits/ei.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/hum.txt
+++ b/lib/domains/in/ac/nits/hum.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/math.txt
+++ b/lib/domains/in/ac/nits/math.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/mba.txt
+++ b/lib/domains/in/ac/nits/mba.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/mech.txt
+++ b/lib/domains/in/ac/nits/mech.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar

--- a/lib/domains/in/ac/nits/phy.txt
+++ b/lib/domains/in/ac/nits/phy.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Silchar


### PR DESCRIPTION
## Added  [National Institute of Technology, Silchar (NITS)](https://www.nits.ac.in/) root domain with various schools/departments under NITS

| Institute                        			| eMail Domain		|
|-------------------------------------------	|------------------	|
| National Institute of technology, Silchar       | nits.ac.in 	|

| Department/School                         	| eMail SubDomain  	|
|-------------------------------------------	|------------------	|
| Civil Engineering                         	| civil.nits.ac.in 	|
| Mechanical Engineering                    	| mech.nits.ac.in  	|
| Computer Science & Engineering            	| cse.nits.ac.in   	|
| Electronics & Communication Engineering   	| ece.nits.ac.in   	|
| Electronics & Instrumentation Engineering 	| ei.nits.ac.in    	|
| Physics                                   	| phy.nits.ac.in   	|
| Chemistry                                 	| che.nits.ac.in   	|
| Mathematics                               	| math.nits.ac.in  	|
| Management Studies                        	| mba.nits.ac.in   	|
| Humanities and Social Sciences            	| hum.nits.ac.in   	|