### PR TITLE
add EHU School of Digital Competencies (esdc.lt)

### DIFF
--- a/lib/domains/lt/esdc.txt
+++ b/lib/domains/lt/esdc.txt
@@ -1,0 +1,3 @@
+Viešosios įstaigos "Europos Humanitarinis Universitetas" filialas EPAM skaitmeninės inžinerijos mokykla
+EHU Skaitmeninių kompetencijų mokykla
+EHU School of Digital Competencies


### PR DESCRIPTION
Official website: https://esdc.lt/ (proof of using the domain is closer to the bottom)
Offering: https://esdc.lt/specialization