### PR TITLE
Add Hankuk University of Foreign Studies (hufs.ac.kr) domain

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
Adding Hankuk University of Foreign Studies (hufs.ac.kr) domain for JetBrains student license eligibility.

**The official website of Hankuk University of Foreign Studies is:**   
https://www.hufs.ac.kr

The university provides IT-related courses.
**The university's Computer Science department website URL:**  
https://computer.hufs.ac.kr/computer/index.do

**The university's Industrial management engineering department website URL:**  
https://ime.hufs.ac.kr/ime/index.do

**Students and faculty use email addresses under the domain @hufs.ac.kr.**  
[HUFS Official Email Announcement](https://www.hufs.ac.kr/hufs/11281/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGaHVmcyUyRjIxODAlMkYxMjQ0MDclMkZhcnRjbFZpZXcuZG8lM0ZwYWdlJTNEMSUyNnNyY2hDb2x1bW4lM0RzaiUyNnNyY2hXcmQlM0QlRUIlQTklOTQlRUMlOUQlQkMlMjZiYnNDbFNlcSUzRCUyNmJic09wZW5XcmRTZXElM0QlMjZyZ3NCZ25kZVN0ciUzRCUyNnJnc0VuZGRlU3RyJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2cGFzc3dvcmQlM0QlMjY%3D)

Thank you for your time and consideration!