### PR TITLE
Add Chung-ang University

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+Chung-ang University
+Chung-ang University

--- a/lib/domains/kr/cau.txt
+++ b/lib/domains/kr/cau.txt
@@ -1,0 +1,2 @@
+Chung-ang University
+Chung-ang University


### PR DESCRIPTION
Adding Chung-ang University domain for student license eligibility.
email domain is @cau.ac.kr 