### PR TITLE
Add EHU School of Digital Competencies (esdc.lt)

### DIFF
--- a/lib/domains/lt/esdc.txt
+++ b/lib/domains/lt/esdc.txt
@@ -1,0 +1,3 @@
+Viešosios įstaigos "Europos Humanitarinis Universitetas" filialas EPAM skaitmeninės inžinerijos mokykla
+EHU Skaitmeninių kompetencijų mokykla
+EHU School of Digital Competencies


### PR DESCRIPTION
Official website: https://esdc.lt/ (proof of using the domain is closer to the bottom)
Offering: https://esdc.lt/specialization

[The previous request](https://github.com/JetBrains/swot/pull/27724) was closed due to human error. The domain does exist and has DNS records, [for example MX one](https://dns.google/query?name=esdc.lt&rr_type=MX&ecs=)