### PR TITLE
feat: add Kentucky Country Day School

### DIFF
--- a/lib/domains/org/kcd.txt
+++ b/lib/domains/org/kcd.txt
@@ -1,0 +1,1 @@
+Kentucky Country Day School


### PR DESCRIPTION
as per requested by the README, some info:

Official Website: https://www.kcd.org
IT related courses fall under the STEAM & MAKER education page: 
- https://www.kcd.org/academics/steam--maker-education
- https://kcd-public.rubiconatlas.org/all-public-curriculum/all-courses?subject=2&schoolType=3&ascending=1&orderBy=name&page=1

Specifically, year-long courses like AP Computer Science A/Principles, and multi-year STEAM certificate projects are all IT-related.

Student emails are @student.kcd.org, faculty @kcd.org, and alumni do not have email access.
