### PR TITLE
Add fikr.edu.sa, modify fikrgs.edu.sa

### DIFF
--- a/lib/domains/sa/edu/fikr.txt
+++ b/lib/domains/sa/edu/fikr.txt
@@ -1,0 +1,2 @@
+Dar Alfikr Schools
+Dar Alfikr Schools

--- a/lib/domains/sa/edu/fikrgs.txt
+++ b/lib/domains/sa/edu/fikrgs.txt
@@ -1,2 +1,2 @@
-Dar Alfikr Schools
-Dar Alfikr Schools
+Dar Alfikr Schools for Girls
+Dar Alfikr Schools for Girls


### PR DESCRIPTION
A previous PR (https://github.com/JetBrains/swot/pull/20013) added Dar Alfikr Schools to the repo, but added it under the `fikrgs.edu.sa` domain, which is the domain for the Girls branch. I've added the male branch's domain (`fikr.edu.sa`). and updated the other domain's file to state that it's for the Girls' branch.