### PR TITLE
Create alu.txt

### DIFF
--- a/lib/domains/es/uma/alu.txt
+++ b/lib/domains/es/uma/alu.txt
@@ -1,0 +1,1 @@
+E.T.S.I. de Telecomunicación Universidad de Málaga


### PR DESCRIPTION
Adding the domain alu.uma.es for Escuela Técnica Superior de Ingeniería de Telecomunicación (ETSI Telecomunicación), Universidad de Málaga.

- **Official website**: [https://www.uma.es/etsi-de-telecomunicacion/](https://www.uma.es/etsi-de-telecomunicacion/)
- **IT-related course page**: [https://www.uma.es/etsi-de-telecomunicacion/cms/menu/estudios/grado-en-ingenieria-de-sistemas-de-telecomunicacion/](https://www.uma.es/etsi-de-telecomunicacion/cms/menu/estudios/grado-en-ingenieria-de-sistemas-de-telecomunicacion/)
- **Proof of domain usage**: [https://www.uma.es/servicio-central-de-informatica/info/7656/correo-electronico/](https://www.uma.es/servicio-central-de-informatica/info/7656/correo-electronico/)

The domain `alu.uma.es` is officially used for student email addresses at the University of Málaga, including students from ETSI Telecomunicación.