### PR TITLE
add cis

### DIFF
--- a/lib/domains/eg/edu/asu/cis.txt
+++ b/lib/domains/eg/edu/asu/cis.txt
@@ -1,0 +1,2 @@
+Faculty of computer and information science, ain shams universty
+


### PR DESCRIPTION
university official website URL: https://cis.asu.edu.eg/

URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://cis.asu.edu.eg/page/45


screenshot showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.:
![image](https://github.com/user-attachments/assets/0b1af997-cc4f-4429-b043-73cf2d741bdb)
