### PR TITLE
Add UFA Saint Michel, domain name saintmichelannecy.fr

### DIFF
--- a/lib/domains/fr/saintmichelannecy.txt
+++ b/lib/domains/fr/saintmichelannecy.txt
@@ -1,0 +1,1 @@
+UFA Saint Michel


### PR DESCRIPTION
Email adresses with domain name saintmichelannecy.fr are given to our students.
More information about courses on https://www.st-michel.fr/formations/etablissement-superieur/formations/bachelor-csi-apprentissage