### PR TITLE
Add Walisinghe Harischandra College

### DIFF
--- a/lib/domains/com/walisinghe.txt
+++ b/lib/domains/com/walisinghe.txt
@@ -1,0 +1,1 @@
+Walisinghe Harischandra College


### PR DESCRIPTION
  - Walisinghe Harschandra College, a Sri Lankan government institute of education. 
  - Domain: walisinghe.com
  - Domain ownership proof 
    - GitHub recognizes the domain as institute's official domain
    - Institute's FB pages recognizes: https://www.facebook.com/WHCMU/
    
  