### PR TITLE
The Higher Institute of Applied Techniques (or ISTA)  REQUEST FOR jEATBRAIN FOR STUDENT 

### DIFF
--- a/lib/domains/cd/ista.txt
+++ b/lib/domains/cd/ista.txt
@@ -1,0 +1,2 @@
+Institut Supérieur des Techniques Appliquées (I.S.T.A.), Kinshasa
+Higher Institute of Applied Techniques (I.S.T.A.) ,Kinshasa

--- a/lib/domains/ista.txt
+++ b/lib/domains/ista.txt
@@ -1,0 +1,2 @@
+Institut Supérieur des Techniques Appliquées (I.S.T.A.), Kinshasa
+Higher Institute of Applied Techniques (I.S.T.A.) ,Kinshasa


### PR DESCRIPTION
The Higher Institute of Applied Techniques (or ISTA) is a public institution of the Democratic Republic of the Congo located in Kinshasa in the commune of Barumbu and born from the merger in 1971 of three institutes: the Meteorological Training Center (C.F.M.), the Institute of Civil Aviation (I.A.C.) and the National School of Posts and Telecommunications (E.N.P.T.). Initially called the Institute of Meteorology, Civil Aviation and Telecommunications, the institute took its current name in 19731.