### PR TITLE
Add uca.ac.ma Domain

### DIFF
--- a/lib/domains/ma/ac/uca.txt
+++ b/lib/domains/ma/ac/uca.txt
@@ -1,0 +1,2 @@
+École Nationale des Sciences Appliquées de Safi, Université Cadi Ayyad
+National School of Applied Sciences of Safi, Cadi Ayyad University


### PR DESCRIPTION
the school official website URL : https://ensas.uca.ma/
the school street address, including city and country : Route Sidi Bouzid BP 63, 46000, Safi, Maroc( https://maps.app.goo.gl/oNyDgtqLL8U5HcBA8)
an URL of a page on the official website where the school offers an IT-related long-term (>1 year) course : https://ensas.uca.ma/Home/FormationInitiale
the university official website : https://www.uca.ma/fr