### PR TITLE
Add HCMIU

### DIFF
--- a/lib/domains/vn/hcmiu/hcmiu.txt
+++ b/lib/domains/vn/hcmiu/hcmiu.txt
@@ -1,0 +1,1 @@
+Vietnam National University HCMC - International University


### PR DESCRIPTION
Please add Ho Chi Minh City International University Domain

- The university's official website: https://hcmiu.edu.vn/en/
- The school of IT's official website URL: https://it.hcmiu.edu.vn/
- The university street address, including city and country: Khu phố 6, Linh Trung Ward, Thu Duc District, Ho Chi Minh City, Vietnam (https://maps.app.goo.gl/CJJa7qkJTdTtuXMt8)
- The URL of a page on the official website where the school offers an IT-related long-term (>1 year) course: https://hcmiu.edu.vn/en/schools-and-departments/school-of-computer-science-and-engineering/