### PR TITLE
Added Wrocław University of Science and Technology

### DIFF
--- a/lib/domains/pl/edu/pwr.txt
+++ b/lib/domains/pl/edu/pwr.txt
@@ -1,1 +1,2 @@
-Wrocław University of Technology
+Politechnika Wrocławska
+Wrocław University of Science and Technology

--- a/lib/domains/pl/edu/pwr/student.txt
+++ b/lib/domains/pl/edu/pwr/student.txt
@@ -1,0 +1,2 @@
+Politechnika Wrocławska
+Wrocław University of Science and Technology


### PR DESCRIPTION
- Added subdomain given by Wrocław University of Science and Technology to students (@student.pwr.edu.pl)
- Updated university name in existing entry (@pwr.edu.pl) to current English official name and added official Polish name

Links for verification:
- Main university site: [https://pwr.edu.pl/en/](https://pwr.edu.pl/en/)
- Page saying @student.pwr.edu.pl e-mails are used by students: [https://di.pwr.edu.pl/uslugi/poczta/pierwsze-logowanie](https://di.pwr.edu.pl/uslugi/poczta/pierwsze-logowanie)
- Page related to currently started IT bachelor degree studies: [https://wit.pwr.edu.pl/en/students/programme-of-study/2024-2025-academic-year---1st-level](https://wit.pwr.edu.pl/en/students/programme-of-study/2024-2025-academic-year---1st-level)