### PR TITLE
Add student email and teacher alias email for Sichuan University of Arts and Science

### DIFF
--- a/lib/domains/email/sasu.txt
+++ b/lib/domains/email/sasu.txt
@@ -1,0 +1,2 @@
+四川文理学院
+Sichuan University of Arts and Science


### PR DESCRIPTION
To apply for educational discounts as a student of Sichuan University of Arts and Science, the school's homepage is www.sasu.edu.cn. We have introduced a new student email system, mail.sasu.email. Emails ending with @sasu.edu.cn are for faculty, while students' email addresses are unified as student ID@sasu.email. Additionally, faculty can also set up alias email addresses ending with @sasu.email.
<img width="1275" alt="mail" src="https://github.com/user-attachments/assets/a95477ee-ee6a-4fc9-bb62-9d993e6b43ed" />
<img width="1274" alt="school" src="https://github.com/user-attachments/assets/4519659c-8ba3-4ba8-8857-8ec1aab64ac2" />
