### PR TITLE
Add UPM school file for Jetbrain student licence

### DIFF
--- a/lib/domains/es/upm/alumnnos.txt
+++ b/lib/domains/es/upm/alumnnos.txt
@@ -1,0 +1,1 @@
+Universidad Politecnica de Madrid


### PR DESCRIPTION
A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://emse.fi.upm.es/en/

A screenshot showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: 
<img width="1398" alt="Captura de pantalla 2025-03-17 a las 22 57 01" src="https://github.com/user-attachments/assets/843bb7dc-1dc2-4eeb-a903-8603413f5499" />
