### PR TITLE
Add tukorea.ac.kr domain

### DIFF
--- a/lib/domains/kr/ac/tukorea.txt
+++ b/lib/domains/kr/ac/tukorea.txt
@@ -1,0 +1,2 @@
+한국공학대학교
+TECH UNIVERSITY OF KOREA


### PR DESCRIPTION
Kindly request the inclusion of the domain(tukorea.ac.kr) for Korea University of Technology, a prestigious institution in South Korea known for its excellence in engineering and technology. Thank you for your seamless performance and steadfast dependability.