### PR TITLE
Add RUPP to kh/edu domain

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,2 @@
+Royal University of Phnom Penh
+Royal University of Phnom Penh


### PR DESCRIPTION
University Name: Royal University of Phnom Penh (RUPP)
Domain: rupp.edu.kh
Student Email Format: student@rupp.edu.kh
Website: https://www.rupp.edu.kh/