### PR TITLE
Politechnika Krakowska also known in English as Cracow University of Technology

### DIFF
--- a/lib/domains/pl/cuot.txt
+++ b/lib/domains/pl/cuot.txt
@@ -1,0 +1,2 @@
+Politechnika Krakowska
+Cracow University of Technology


### PR DESCRIPTION
Politechnika Krakowska
Cracow University of Technology
www.cuot.edu.pl