### PR TITLE
Add AIE (US)

### DIFF
--- a/lib/domains/edu/aie.txt
+++ b/lib/domains/edu/aie.txt
@@ -1,0 +1,1 @@
+Academy of Interactive Entertainment


### PR DESCRIPTION
The Academy of Interactive Entertainment operates in the United States with a physical campus in Seattle, WA and Lafayette, LA and uses the `aie.edu` domain.

This addition covers the use of staff/faculty e-mail addresses under `aie.edu` and students under `students.aie.edu`.

- Official Website URL - https://aie.edu/
- Long-term: Seattle offers a [Game Programming](https://aie.edu/program/seattle/advanced-diploma-game-programming/) is a 4 Semester program spanning two years.
- Proof of Usage (excerpt from public-facing IT documentation): 
![image](https://github.com/user-attachments/assets/156f1853-d6e1-4f6d-9240-e5df82624611)


This is related, but distinct from https://github.com/JetBrains/swot/pull/4310 which recognizes `aie.edu.au` e-mail addresses but not `aie.edu`; the `.au` being for the Australian-facing staff and students.