### PR TITLE
Add Hankuk University of Foreign Studies

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
Add Hankuk University of Foreign Studies
Hankuk University of Foreign Studies is located in Seoul, South Korea and uses the domain hufs.ac.kr.


Official Website URL - https://www.hufs.ac.kr/