### PR TITLE
Manarat International University added, established 2001

### DIFF
--- a/lib/domains/bd/ac/manarat.txt
+++ b/lib/domains/bd/ac/manarat.txt
@@ -1,0 +1,1 @@
+Manarat International University


### PR DESCRIPTION
Manarat International University is a private university in Bangladesh, established in 2001. It offers undergraduate and graduate programs in various disciplines, including CSE, EEE, Civil Engineering, Business Administration, Journalism, and English. With two campuses in Dhaka, Bangladesh.

website: https://manarat.ac.bd