### PR TITLE
Add national university of Colombia in the available edu domains

### DIFF
--- a/lib/domains/co/edu/unal.txt
+++ b/lib/domains/co/edu/unal.txt
@@ -1,0 +1,2 @@
+Universidad Nacional de Colombia
+National University of Colombia


### PR DESCRIPTION
This pull request adds support for the National University of Colombia's domain https://unal.edu.co/, unal.edu.co, to the list of recognized .edu domains.