### PR TITLE
Add HUFS to JetBrains student license eligibility

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
### Summary  
Requesting to add **Hankuk University of Foreign Studies (HUFS)** to the JetBrains student license program.  

### Details  
- HUFS is a well-known university in South Korea.  
- Many students at HUFS use JetBrains tools for their programming studies.  
- Adding HUFS to the student license program will benefit many students.  

### Expected Outcome  
Students with **@hufs.ac.kr** email addresses should be eligible for JetBrains student licenses, including PyCharm.  

Thank you for considering this request!