### PR TITLE
Add Universidad Privada del Norte

### DIFF
--- a/lib/domains/pe/upn.txt
+++ b/lib/domains/pe/upn.txt
@@ -1,0 +1,1 @@
+Universidad Privada del Norte


### PR DESCRIPTION
Added domain for Universidad Privada del Norte.

PD: The previous attemp to register the univesity is wrong ([previuos PR](https://github.com/JetBrains/swot/pull/27841)), @jsalazargarate2410 registered @upn.edu.pe. As you can see in the video at the bottom section on this [link](https://www.upn.edu.pe/zona-cachimbo/informacion-del-estudiante), all the students use the domain @upn.pe, only the administrative accounts and teachers use @upn.edu.pe.