### PR TITLE
Add mymdc.edu for Miami Dade College

### DIFF
--- a/lib/domains/edu/mymdc.txt
+++ b/lib/domains/edu/mymdc.txt
@@ -1,0 +1,1 @@
+Miami Dade College


### PR DESCRIPTION
This pull request adds the mymdc.edu domain for Miami Dade College.

🔗 Official website: https://www.mdc.edu  
🔗 IT-related program: https://www.mdc.edu/computerinformation  
🔗 Email domain usage: https://www.mdc.edu/it/email/  

The domain mymdc.edu is used for student email addresses (e.g., student@mymdc.edu).
Please add this domain so Miami Dade College students can access JetBrains student licenses.
