### PR TITLE
Add tukorea.ac.kr domain

### DIFF
--- a/lib/domains/kr/ac/tukorea.txt
+++ b/lib/domains/kr/ac/tukorea.txt
@@ -1,0 +1,1 @@
+Tech University of Korea


### PR DESCRIPTION
Added Korea Tech University (한국공학대학교) domain
Official Website: https://www.tukorea.ac.kr/
IT-related Course Page: https://ce.tukorea.ac.kr/ce/1826/subview.do