### PR TITLE
Fix incorrect Kyonggi University information added in PR #22842

### DIFF
--- a/lib/domains/kr/ac/kgu.txt
+++ b/lib/domains/kr/ac/kgu.txt
@@ -1,2 +1,0 @@
-경기대학교
-university of kyonggi

--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+Kyonggi University


### PR DESCRIPTION
Corrects erroneously added domain information for Kyonggi University introduced in PR #22842:

The domain was incorrectly listed as kgu.ac.kr, which does not exist
The correct domain is kyonggi.ac.kr
University name was improperly formatted as 'university of kyonggi' instead of 'Kyonggi University'

This PR fixes these inaccuracies to ensure the correct domain and proper naming convention for Kyonggi University.