### PR TITLE
Add Universidad Politécnica de Madrid

### DIFF
--- a/lib/domains/es/upm/alumnos.txt
+++ b/lib/domains/es/upm/alumnos.txt
@@ -1,0 +1,1 @@
+Universidad Politécnica de Madrid


### PR DESCRIPTION
Active students get assigned emails in the subdomain `alumnos.upm.es`.