### PR TITLE
Add `clovis.edu`

### DIFF
--- a/lib/domains/edu/clovis.txt
+++ b/lib/domains/edu/clovis.txt
@@ -1,0 +1,1 @@
+Clovis Community College


### PR DESCRIPTION
Official URL:
https://www.clovis.edu/

2-Year Associates Programming related degrees:
https://www.clovis.edu/cis/index.aspx

Overall general (though incomplete list of) Degree Plans and certificates:
https://www.clovis.edu/programs/

The college is physical and has been fully standalone since the 1990's (was a subdivision of a larger University before that, but it outgrew them).

Employee (Faculty, Admin, and other education related staff; contractors and outside people do not get emails) emails end with @clovis.edu
Student (recently active only, after 100 days at end of term students lose email access, they do not gain access to an email until they have registered and been admitted to a course and will immediately lose it if they drop their courses for any reason) emails end with @st.clovis.edu

Can confirm employee emails ending with @clovis.edu on any division 'owned' page, such as the programming related degree link above having one on the bottom left sidebar.
