### PR TITLE
Add hhbkde.txt

### DIFF
--- a/lib/domains/com/onmicrosoft/hhbkde.txt
+++ b/lib/domains/com/onmicrosoft/hhbkde.txt
@@ -1,0 +1,1 @@
+Heinrich-Hertz-Berufskolleg Düsseldorf


### PR DESCRIPTION
Add Domain hhbkde.onmicrosoft.com for Heinrich-Hertz-Berufskolleg in Düsseldorf Germany

Official Website is https://hhbk.de
Internal Suport Website is https://hhbk.support 

There are the personal o365 email 

![Bildschirmfoto 2025-03-27 um 20 04 01](https://github.com/user-attachments/assets/901d67c2-11cb-470d-ae7a-44dcbd084838)
