### PR TITLE
Add iuh.edu.vn domain for Industrial University of Ho Chi Minh City

### DIFF
--- a/lib/domains/vn/edu/iuh/iuh.txt
+++ b/lib/domains/vn/edu/iuh/iuh.txt
@@ -1,0 +1,2 @@
+Đại học Công nghiệp Thành phố Hồ Chí Minh
+Industrial University of Ho Chi Minh City


### PR DESCRIPTION
This pull request adds the domain iuh.edu.vn to the SWoT repository for academic email verification.

Details:

- University Name: Industrial University of Ho Chi Minh City (IUH)

- Official Website: https://iuh.edu.vn/

- Email Pattern: @iuh.edu.vn

Reason for Addition:

- This domain is used by students and faculty for academic purposes.

- The university is a well-recognized institution in Vietnam.

Adding this domain will allow students to access educational resources and benefits provided by JetBrains.