### PR TITLE
Added rii.edu.kz to JetBrains/swot student license eligibility

### DIFF
--- a/lib/domains/kz/edu/rii.txt
+++ b/lib/domains/kz/edu/rii.txt
@@ -1,0 +1,2 @@
+rii.edu.kz
+


### PR DESCRIPTION
Added rii.edu.kz (Рудненский индустриальный университет) as a university email domain for JetBrains student licenses.
Official university website: https://www.rii.edu.kz/