### PR TITLE
Add uca.ac.ma.json for École Supérieure de Technologie - Safi

### DIFF
--- a/uca.ac.ma.json
+++ b/uca.ac.ma.json
@@ -1,0 +1,2 @@
+École Supérieure de Technologie Safi
+Graduate School of Technology of Safi


### PR DESCRIPTION
Adding the domain uca.ac.ma for student license validation.