### PR TITLE
Add Lichtenberg Oberstufen Gymnasium

### DIFF
--- a/lib/domains/de/log-web.txt
+++ b/lib/domains/de/log-web.txt
@@ -1,0 +1,1 @@
+Lichtenberg-Oberstufen-Gymnasium Bruchköbel


### PR DESCRIPTION
Adds the Lichtenberg-Oberstufen-Gymnasium (Bruchköbel, Hesse, Germany) to the list of known schools.
Domain: https://log-web.de.

It is a German High School, which also provides a course in IT (https://log-web.de/informatik/).