### PR TITLE
Add Instituto Cibertec 

### DIFF
--- a/lib/domains/pe/edu/cibertec.txt
+++ b/lib/domains/pe/edu/cibertec.txt
@@ -1,0 +1,2 @@
+Instituto Cibertec
+Cybertec Institute, Peru


### PR DESCRIPTION
official website URL : https://www.cibertec.edu.pe/
URL of a page on the official website where a long-term : https://www.cibertec.edu.pe/carreras-profesionales/computacion-e-informatica/