### PR TITLE
Add seoultech.ac.kr to JetBrains swot

### DIFF
--- a/lib/domains/kr/ac/seoultech.txt
+++ b/lib/domains/kr/ac/seoultech.txt
@@ -1,0 +1,2 @@
+서울과학기술대학교
+Seoul National University of Science and Technology


### PR DESCRIPTION
Hello JetBrains team,

Please add `seoultech.ac.kr` to the list of supported educational domains.

- 🎓 Official website: https://www.seoultech.ac.kr
- 💻 IT-related long-term course: https://cs.seoultech.ac.kr/index.do (Computer Science and Engineering Department, 4-year program)
- 📧 Students receive emails ending with `@seoultech.ac.kr` — proof available at https://portal.seoultech.ac.kr or by request.

Thank you very much!
