### PR TITLE
Please add PSM

### DIFF
--- a/lib/domains/ve/edu/psm.txt
+++ b/lib/domains/ve/edu/psm.txt
@@ -1,0 +1,1 @@
+Instituto Universitario Politecnico Santiago Mariño


### PR DESCRIPTION
PSM is short name for Politecnico Santiago Mariño, an institute located in Maracay where i live.