### PR TITLE
Add Louisiana Universities Marine Consortium

### DIFF
--- a/lib/domains/edu/lumcon.txt
+++ b/lib/domains/edu/lumcon.txt
@@ -1,0 +1,1 @@
+Louisiana Universities Marine Consortium


### PR DESCRIPTION
Add Louisiana Universities Marine Consortium to edu domain.