### PR TITLE
Camp Rav Tov

### DIFF
--- a/lib/domains/org/machneravtov.txt
+++ b/lib/domains/org/machneravtov.txt
@@ -1,0 +1,1 @@
+ Camp Rav Tov


### PR DESCRIPTION
Machne (Camp) Rav Tov D'Satmar

#### Instiution/School Website
{[Website URL](https://machneravtov.org/)}

#### Email Users

*Please place an x between the square brackets if yes*
- [ x] Students
- [x ] Academic/Teaching Staff
- [x ] Other/Support Staff
- [x] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [x] Post-graduate research
- [x ] Community College or equivalent
- [x ] High School or equivalent
- [x ] Elementary School or equivalent

Machne Rav Tov is a network of five summer camps located in upstate New York, providing year-round educational continuity for children.

