### PR TITLE
Adicionando domínio da Unibras para acesso educacional

### DIFF
--- a/lib/domains/br/com/soubraseducacional.txt
+++ b/lib/domains/br/com/soubraseducacional.txt
@@ -1,0 +1,1 @@
+soubraseducacional.com.br


### PR DESCRIPTION
Adicionando o domínio "soubraseducacional.com.br" para permitir que alunos e professores da Unibras solicitem licenças educacionais da JetBrains.
https://faculdadeunibras.com.br/nortegoiano/