### PR TITLE
Add Fu Jen Catholic University

### DIFF
--- a/lib/domains/tw/edu/fju/m365.txt
+++ b/lib/domains/tw/edu/fju/m365.txt
@@ -1,0 +1,2 @@
+天主教輔仁大學
+Fu Jen Catholic University


### PR DESCRIPTION
Fu Jen Catholic University (FJU, FJCU or Fu Jen) is a private Catholic university in Xinzhuang, New Taipei City, Taiwan.