### PR TITLE
Added Bal Bharati Public School, Ganga ram Hospital Marg, New Delhi, India

### DIFF
--- a/lib/domains/balbharati/gr.txt
+++ b/lib/domains/balbharati/gr.txt
@@ -1,0 +1,1 @@
+Bal Bharati Public School


### PR DESCRIPTION
Added school Bal Bharati Public School, GRH marg, in New Delhi.
Full address: `3, BAL BHARATI PUBLIC SCHOOL-OLD RAJINDER NAGAR, B/4, Sir Ganga Ram Hospital Marg, Old Rajinder Nagar, New Rajinder Nagar, New Delhi, Delhi, 110060`


