### PR TITLE
Adding empa.edu.ar domain for supporting its users

### DIFF
--- a/lib/domains/ar/edu/empa.txt
+++ b/lib/domains/ar/edu/empa.txt
@@ -1,0 +1,2 @@
+Escuela de Musica Popular de Avellaneda
+Public Avellaneda Music School


### PR DESCRIPTION
Adding domain support for EMPA: Avellaneda Public University School 

1. Official site: https://www.empa.edu.ar/
2. Long duration careers could be seen at homepage https://www.empa.edu.ar/ "Carreras" section with 4+ years careers being shown
3. The University domain is the same as email domain