### PR TITLE
add Vietnam National University txt

### DIFF
--- a/lib/domains/vn/edu/vnu.txt
+++ b/lib/domains/vn/edu/vnu.txt
@@ -1,0 +1,1 @@
+Vietnam National University


### PR DESCRIPTION
Adding Vietnam National University (VNU) to the list of recognized universities. VNU is one of the top public universities in Vietnam, offering a wide range of academic programs and research initiatives.