### PR TITLE
Add Hellenic Open University (eap.gr)

### DIFF
--- a/lib/domains/gr/eap/ac.txt
+++ b/lib/domains/gr/eap/ac.txt
@@ -1,0 +1,2 @@
+Ελληνικό Ανοικτό Πανεπιστήμιο
+Hellenic Open University


### PR DESCRIPTION
The student emails are in the form of @ac.eap.gr , that's what I added.
The main page is here: www.eap.gr
The page about computer science degree: https://www.eap.gr/en/undergraduate/computer-science/
Hope that helps.