### PR TITLE
Add Universidad Blas Pascal (ubp.edu.ar)

### DIFF
--- a/lib/domains/ar/edu/ubp.txt
+++ b/lib/domains/ar/edu/ubp.txt
@@ -1,0 +1,2 @@
+Universidad Blas Pascal
+Blas Pascal University


### PR DESCRIPTION
Adding Universidad Blas Pascal (ubp.edu.ar) to the list of academic domains.

This institution offers long-term educational programs eligible for JetBrains educational licenses.
Website: https://www.ubp.edu.ar/