### PR TITLE
Add kkumail.com domain for student license

### DIFF
--- a/lib/domains/com/kkumail.txt
+++ b/lib/domains/com/kkumail.txt
@@ -1,0 +1,2 @@
+มหาวิทยาลัยขอนแก่น
+Khon Kaen University


### PR DESCRIPTION
Add `kkumail.com` domain, which belongs to **Khon Kaen University**, a public university in Thailand, specifically for student email addresses.

This domain is used for official student email addresses, e.g., `@kkumail.com`.

Official website: https://www.kku.ac.th