### PR TITLE
Add İzmir Demokrasi Üniversitesi

### DIFF
--- a/lib/domains/tr/edu/idu/std.txt
+++ b/lib/domains/tr/edu/idu/std.txt
@@ -1,0 +1,2 @@
+İzmir Demokrasi Üniversitesi
+Izmir Democracy University


### PR DESCRIPTION
Add İzmir Demokrasi Üniversitesi located in Türkiye to request student license.