### PR TITLE
Create cabrillo.txt

### DIFF
--- a/lib/domains/edu/cabrillo.txt
+++ b/lib/domains/edu/cabrillo.txt
@@ -1,0 +1,1 @@
+Cabrillo College


### PR DESCRIPTION
See the course catalogs for Cabrillo College at https://www.cabrillo.edu/college-catalog/

Unfortunately we use a third-party to host actual catalog/curriculum info, e.g. here is one of the Python programming courses I teach: https://cabrillo.elumenapp.com/catalog/2024-2025/course,cs20p#mainContent

We don't advertise it publicly so I can't show you a URL describing it, but our Google enterprise account does include Gmail accounts for all students via studentid@cabrillo.edu.

I also maintain my own email forwarding, so any student in my current CS 20P class has an address available via username@jeff.cis.cabrillo.edu.

Thanks!