### PR TITLE
Adding edu.hanbat.ac.kr domain for Hanbat National University.

### DIFF
--- a/lib/domains/kr/ac/anu/edu.txt
+++ b/lib/domains/kr/ac/anu/edu.txt
@@ -1,0 +1,1 @@
+한밭대학교/ Hanbat National University

--- a/lib/domains/kr/ac/anu/edu.txt
+++ b/lib/domains/kr/ac/anu/edu.txt
@@ -1,1 +1,0 @@
-한밭대학교/ Hanbat National University

--- a/lib/domains/kr/ac/hanbat/edu.txt
+++ b/lib/domains/kr/ac/hanbat/edu.txt
@@ -1,0 +1,2 @@
+한밭대학교
+Hanbat National University


### PR DESCRIPTION
Here's the commit message in English:
"Adding edu.hanbat.ac.kr domain for Hanbat National University.
This PR adds the domain for Hanbat National University (한밭대학교) students. At our university, student email addresses follow the format [studentID]@edu.hanbat.ac.kr.
Official university website: https://www.hanbat.ac.kr/
My student email is [20238030@edu.hanbat.ac.kr](mailto:20238030@edu.hanbat.ac.kr), which confirms that edu.hanbat.ac.kr is the official student email domain for our university."
File path: lib/domains/kr/ac/hanbat/edu.txt
File content:
한밭대학교
Hanbat National University