### PR TITLE
Add Chung-Ang University (cau.ac.kr)

### DIFF
--- a/cau.txt
+++ b/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University

--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
School official website: https://www.cau.ac.kr  
IT-related long-term program: https://cse.cau.ac.kr  
Proof of student email domain: https://www.cau.ac.kr (students receive @cau.ac.kr email addresses)