### PR TITLE
Add kyonggi.ac.kr domain

### DIFF
--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,1 @@
+Kyonggi University


### PR DESCRIPTION
### School Domain Addition Request

**University Name:** Kyonggi University  
**Official Website:** https://www.kyonggi.ac.kr  
**IT-related Long-term Course URL:** https://computer.kyonggi.ac.kr  
**Email Domain Proof:** https://www.kyonggi.ac.kr/webService.kgu?pgcode=kr102

Kyonggi University is a well-established university in South Korea offering various long-term (over 1 year) IT-related programs, including Computer Science and Engineering.  
The university issues official student email addresses under the domain `kyonggi.ac.kr`.  
We kindly request you to add this domain to the JetBrains educational domain list for student license eligibility.
