### PR TITLE
Add New Jersey Institute of Technlogy to the list of educational domains

### DIFF
--- a/lib/domains/edu/njit.txt
+++ b/lib/domains/edu/njit.txt
@@ -1,0 +1,2 @@
+New Jersey Institute of Technology
+New Jersey Institute of Technology


### PR DESCRIPTION
Added [njit.edu](http://njit.edu/) under lib/domains/edu with file: njit.txt