### PR TITLE
Add Hanbat National University

### DIFF
--- a/lib/domains/kr/ac/hanbat/edu.txt
+++ b/lib/domains/kr/ac/hanbat/edu.txt
@@ -1,0 +1,2 @@
+한밭대학교
+Hanbat National University

--- a/lib/domains/kr/ac/hanbat/o365.txt
+++ b/lib/domains/kr/ac/hanbat/o365.txt
@@ -1,0 +1,2 @@
+한밭대학교
+Hanbat National University


### PR DESCRIPTION
Dear JetBrains Team,

I hope this message finds you well.

I'm writing to kindly request that the email domains @edu.hanbat.ac.kr and @o365.hanbat.ac.kr, which are used by both faculty and undergraduate students at Hanbat National University in South Korea, be added to your list of approved domains for educational licenses—particularly those that grant access to tools such as IntelliJ IDEA Ultimate.

Hanbat National University is a leading institution in engineering, science, and technology education. Providing access to JetBrains' professional tools would greatly enhance both teaching and learning experiences across the university.

University Website: https://www.hanbat.ac.kr/

Requested Domains: @edu.hanbat.ac.kr, @o365.hanbat.ac.kr

Thank you for considering this request, and for your continued support of education and software development around the world.

Best regards.