### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,4 @@
+"경기대학교" lib/domains/kr/ac/kyonggi.txt
+Kyonggi University
+https://www.kyonggi.ac.kr/www/index.do
+https://www.kyonggi.ac.kr/u_computer/index.do


### PR DESCRIPTION
Add Kyonggi University to the list of educational institutions

Our university, Kyonggi University (경기대학교), was missing from the educational institutions list.  
I have added the necessary information to include it.

Please review and merge this request.

Thank you!