### PR TITLE
Add fci.kfs.edu.eg for Kafr El-Sheikh University

### DIFF
--- a/lib/domains/eg/edu/fci.txt
+++ b/lib/domains/eg/edu/fci.txt
@@ -1,0 +1,2 @@
+كلية الحاسبات و المعلومات كفرالشيخ
+faculty of computer and information kafr el-sheikh


### PR DESCRIPTION
Added fci.txt to support Faculty of Computer and Information, Kafr El-Sheikh University (كلية الحاسبات والمعلومات كفرالشيخ)