### PR TITLE
Add stu.helwan.edu.eg domain for Helwan University

### DIFF
--- a/lib/domains/education/file/lib/domains/eg/edu/helwan/fci.txt
+++ b/lib/domains/education/file/lib/domains/eg/edu/helwan/fci.txt
@@ -1,0 +1,2 @@
+كلية الحاسبات و الذكاء الاصطناعي جامعة حلوان
+Computer science and artificial intelligence

--- a/lib/domains/education/lib/domains/eg/edu/stu/helwan.txt
+++ b/lib/domains/education/lib/domains/eg/edu/stu/helwan.txt
@@ -1,0 +1,1 @@
+Helwan University


### PR DESCRIPTION
Adding the official email domain of Faculty of Computers and Artificial Intelligence, Helwan University: fci.helwan.edu.eg
