### PR TITLE
Daejeon Institute of Science and Technology

### DIFF
--- a/lib/domains/kr/ac/dst/i.txt
+++ b/lib/domains/kr/ac/dst/i.txt
@@ -1,0 +1,2 @@
+대전과학기술대학교
+Daejeon Institute of Science and Technology


### PR DESCRIPTION
adding i.dst.ac.kr from https://www.dst.ac.kr