### PR TITLE
feat: add new university domain

### DIFF
--- a/lib/domains/ec/edu/uce.txt
+++ b/lib/domains/ec/edu/uce.txt
@@ -1,0 +1,2 @@
+Universidad Central del Ecuador
+Central University of Ecuador


### PR DESCRIPTION
- Add Central University of Ecuador domain, uce.edu.ec.

University web:
[Web](https://www.uce.edu.ec/)

Address:
Av. Universitaria, Quito 170129, Ecuador.

IT course information in related University:
[Information](https://www.uce.edu.ec/web/fing)
![Screenshot 2025-04-15 123645](https://github.com/user-attachments/assets/703b0f1d-b295-4100-b852-72008530bd49)


Proof that mentioned domain is recognized by university:
![Screenshot 2025-04-15 122703](https://github.com/user-attachments/assets/9b2baa60-32c5-43fb-8d9c-0a0df70b189b)
The domain uce.edu.ec is used by all members in Central University of Ecuador, the image shows authorities emails that use mentioned domain. 
