### PR TITLE
Add Vietnam National University (VNU).

### DIFF
--- a/lib/domains/vn/edu/vnu.txt
+++ b/lib/domains/vn/edu/vnu.txt
@@ -1,0 +1,2 @@
+Đại học Quốc gia Hà Nội
+Vietnam National University


### PR DESCRIPTION
Since all VNU now all migrated to vnu.edu.vn email, please approve VNU domain to JetBrains