### PR TITLE
ADD kyonggi.ac.kr

### DIFF
--- a/lib/domains/ac/kyonggi.txt
+++ b/lib/domains/ac/kyonggi.txt
@@ -1,2 +1,0 @@
-경기대학교
-Kyonggi univercity

--- a/lib/domains/ac/kyonggi.txt
+++ b/lib/domains/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+Kyonggi univercity

--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+Kyonggi univercity


### PR DESCRIPTION
Add Kyonggi University (kyonggi.ac.kr)

Kyonggi University is a certified institution in Korea offering computer science and software engineering courses.
Official student email domain is kyonggi.ac.kr.
Website : https://www.kyonggi.ac.kr/