### PR TITLE
Add subu.edu.tr domain for Sakarya Uygulamalı Bilimler Üniversitesi

### DIFF
--- a/lib/domains/tr/edu/subu.txt
+++ b/lib/domains/tr/edu/subu.txt
@@ -1,0 +1,2 @@
+Sakarya Uygulamalı Bilimler Üniversitesi
+Sakarya University of Applied Sciences


### PR DESCRIPTION
Added Sakarya Uygulamalı Bilimler Üniversitesi (subu.edu.tr) domain to support free JetBrains license eligibility.
Website: https://www.subu.edu.tr