### PR TITLE
Add UTP University

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+UTP
+Universidad Tecnológica del Perú


### PR DESCRIPTION
This pull request adds Universidad Tecnológica del Perú (UTP) to the list of recognized educational institutions. UTP is a private university located in Peru, offering a variety of undergraduate and graduate programs in engineering, business, and technology. The addition of this domain will allow UTP students to access JetBrains products through the student license program.