### PR TITLE
Add PUCE (Pontificia Universidad Católica del Ecuador) domain for Jet…

### DIFF
--- a/lib/domains/ec/edu/puce.txt
+++ b/lib/domains/ec/edu/puce.txt
@@ -1,0 +1,1 @@
+Pontificia Universidad Católica del Ecuador


### PR DESCRIPTION
Adding domain `puce.edu.ec` for the Pontificia Universidad Católica del Ecuador (PUCE), a private university based in Quito, Ecuador.

This domain is used by students and staff for institutional emails. Requesting inclusion to support JetBrains student licenses.