### PR TITLE
Add Universidad Tecnológica del Perú (utp.edu.pe)

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+Technological University of Peru


### PR DESCRIPTION
Added domain utp.edu.pe for Universidad Tecnológica del Perú.
Official website: https://www.utp.edu.pe
