### PR TITLE
Create duoduc.txt

### DIFF
--- a/lib/domains/cl/duoduc.txt
+++ b/lib/domains/cl/duoduc.txt
@@ -1,0 +1,1 @@
+Fundación Instituto Profesional Duoc UC


### PR DESCRIPTION
This PR adds `duocuc.cl`, the email domain used by students of Duoc UC, a recognized higher education institution in Chile.

Although the official website operates under `duoc.cl`, all students are assigned institutional email addresses with the domain `@duocuc.cl`. This is confirmed by the institution itself in the following official page:

- https://www.duoc.cl/alumnos/servicios-digitales/correo-institucional/

> "Toda la información oficial [...] será enviada a tu correo @duocuc.cl..."

Here is a screenshot from the official page for additional confirmation:

![image](https://github.com/user-attachments/assets/03d415fa-8614-4d4f-aa24-1c728df53dd5)

Thank you for your time and consideration!
