### PR TITLE
Add Kyungsung University

### DIFF
--- a/lib/domains/kr/ac/ks.txt
+++ b/lib/domains/kr/ac/ks.txt
@@ -1,0 +1,2 @@
+경성대학교
+Kyungsung University


### PR DESCRIPTION
Add Kyungsung University from South Korea.
Offical website is https://kscms.ks.ac.kr/kor/Main.do.
And Kyungsung University is in "swot/lib/domains/abusted.txt" file, can you allow our university?

Hope this will be consider to help the review process.
Thank you :)