### PR TITLE
Create duocuc.txt

### DIFF
--- a/lib/domains/cl/duocuc.txt
+++ b/lib/domains/cl/duocuc.txt
@@ -1,0 +1,1 @@
+Fundación Instituto Profesional Duoc UC


### PR DESCRIPTION
This PR adds `duocuc.cl`, the email domain used by students of Duoc UC, a recognized higher education institution in Chile.

Although the official website operates under `duoc.cl`, all students are assigned institutional email addresses with the domain `@duocuc.cl`. This is confirmed by the institution itself in the following official page:

- https://www.duoc.cl/alumnos/servicios-digitales/correo-institucional/

> "Toda la información oficial [...] será enviada a tu correo @duocuc.cl..."

Here is a screenshot from the official page for additional confirmation:

![IMG_20250423_094814](https://github.com/user-attachments/assets/9ec52f18-f4dc-49a3-a78d-a7863811519f)


Thank you for your time and consideration!