### PR TITLE
to add dtdl.edu.vn

### DIFF
--- a/lib/domains/vn/edu/dtdl.txt
+++ b/lib/domains/vn/edu/dtdl.txt
@@ -1,0 +1,2 @@
+Trường Cao Đẳng Điện Tử - Điện Lạnh Hà Nội
+HaNoi College of Electronic and Electro - Refrigeratory Technics


### PR DESCRIPTION
University official website URL:
https://dtdl.edu.vn

URL of the website providing long-term IT courses (>1 year):
https://dtdl.edu.vn/khoa-hoc/cong-nghe-thong-tin-trinh-do-trung-cap

Proof of university recognition of student email domain:
https://dtdl.edu.vn/lien-he