### PR TITLE
Add hufs.ac.kr

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign studies


### PR DESCRIPTION
	•	Official website: https://www.hufs.ac.kr
	•	IT program page: https://www.hufs.ac.kr/hufs/11262/subview.do
	•	Email domain usage proof: https://sites.google.com/hufs-gsuite.kr/g-suite