### PR TITLE
Add Anabuki Computer College to JetBrains Educational License Program

### DIFF
--- a/lib/domains/jp/anabuki-college/c.txt
+++ b/lib/domains/jp/anabuki-college/c.txt
@@ -1,0 +1,2 @@
+穴吹コンピュータカレッジ
+Anabuki Computer College

--- a/lib/domains/jp/anabuki-college/c.txt
+++ b/lib/domains/jp/anabuki-college/c.txt
@@ -1,2 +1,0 @@
-穴吹コンピュータカレッジ
-Anabuki Computer College

--- a/lib/domains/net/anabuki-college/c.txt
+++ b/lib/domains/net/anabuki-college/c.txt
@@ -1,0 +1,2 @@
+穴吹コンピュータカレッジ
+Anabuki Computer College


### PR DESCRIPTION
This pull request adds Anabuki Computer College to the list of supported educational institutions.
Anabuki Computer College is a recognized educational institution that meets the eligibility criteria for the JetBrains Educational License Program.
Thank you for considering this addition!

https://web.anabuki-college.net/