### PR TITLE
Add KMITL domain (kmitl.ac.th) for JetBrains Educational License

### DIFF
--- a/kmitl.txt
+++ b/kmitl.txt
@@ -1,0 +1,2 @@
+สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง
+King Mongkut's Institute of Technology Ladkrabang


### PR DESCRIPTION
Added "kmitl.ac.th" domain to support students from King Mongkut's Institute of Technology Ladkrabang (KMITL) for applying to the JetBrains Student License Program.

Example email: 65010260@kmitl.ac.th
