### PR TITLE
Added Széchenyi István Technical School of Engineering

### DIFF
--- a/lib/domains/hu/gr-szechenyi.txt
+++ b/lib/domains/hu/gr-szechenyi.txt
@@ -1,0 +1,2 @@
+Székesfehérvári SZC Széchenyi István Műszaki Technikum 
+Székesfehérvár Vocational Training Center Széchenyi István Technical School of Engineering


### PR DESCRIPTION
1. [The domain ](https://gr-szechenyi.hu/) used in the email system redirects to a domain that hosts mostly websites of technical high schools all around Hungary: [https://szek-szechenyi.www.intezmeny.edir.hu/](https://szek-szechenyi.www.intezmeny.edir.hu/)
2. Example of a [5 year long course](https://szek-szechenyi.www.intezmeny.edir.hu/kepzeseink/technikum-szakkepzo) about software development:
![image](https://github.com/user-attachments/assets/e0fcc25d-ea9a-4f66-917b-3e4bac6eda15)
3. The domain used in email addresses for the school's teachers and selected students (note that not every student gets a personal email address automatically) is listed as the main way of contacting the institution.
![image](https://github.com/user-attachments/assets/885bf179-4674-4e8b-b084-e1b40d224844)

