### PR TITLE
Add wbsedu.de domain for WBS TRAINING AG

### DIFF
--- a/lib/domains/de/wbsedu.txt
+++ b/lib/domains/de/wbsedu.txt
@@ -1,1 +1,1 @@
-Add wbsedu.de domain for WBS TRAINING AG
+WBS TRAINING AG

--- a/lib/domains/de/wbsedu.txt
+++ b/lib/domains/de/wbsedu.txt
@@ -1,0 +1,1 @@
+Add wbsedu.de domain for WBS TRAINING AG


### PR DESCRIPTION
This pull request adds the domain `wbsedu.de`, which is used by WBS TRAINING AG, a recognized educational institution in Germany.

- Official website: https://www.wbstraining.de/
- Official name (in native language): WBS TRAINING AG
- Email domain used by students: @wbsedu.de

WBS TRAINING AG provides certified educational programs and vocational training, and students receive institutional email addresses under the `wbsedu.de` domain.

Please note: This PR corrects a previous mistake that referred to a non-existent `.edu.ng` domain. This version uses the correct `.de` domain for Germany.

Thank you for reviewing!