### PR TITLE
Add oi.edu.eg domain for Obour Higher Institute of Management, Computers and Information Systems

### DIFF
--- a/lib/domains/eg/edu/oi.txt
+++ b/lib/domains/eg/edu/oi.txt
@@ -1,2 +1,1 @@
-Obour Higher Institute of Management, Computers and Information Systems
-obour inistitutes
+oi.edu.eg

--- a/lib/domains/eg/edu/oi.txt
+++ b/lib/domains/eg/edu/oi.txt
@@ -1,0 +1,2 @@
+Obour Higher Institute of Management, Computers and Information Systems
+obour inistitutes


### PR DESCRIPTION
Requesting to add student domain oi.edu.eg for license eligibility.

