### PR TITLE
Adding 15° ΓΕΛ Αθηνών

### DIFF
--- a/lib/domains/gr/sch.txt
+++ b/lib/domains/gr/sch.txt
@@ -1,0 +1,2 @@
+15° ΓΕΛ Αθηνών
+15th high school of athens


### PR DESCRIPTION
Adding 15° ΓΕΛ Αθηνών/15th general high school of athens