### PR TITLE
Request to Add Universidad Nacional de Colombia (unal.edu.co) to Educational Domain List

### DIFF
--- a/lib/domains/co/edu/unal.txt
+++ b/lib/domains/co/edu/unal.txt
@@ -1,0 +1,1 @@
+Universidad Nacional de Colombia


### PR DESCRIPTION
Dear JetBrains team,

I am writing to request the inclusion of the domain unal.edu.co in your list of recognized academic institutions. This domain belongs to the Universidad Nacional de Colombia, the largest and most prestigious public university in the country, with a long-standing tradition in academic excellence and research.

As a part-time lecturer (docente ocasional) at this institution, I can confirm that access to JetBrains’ educational licenses would significantly benefit both faculty and students in their teaching, learning, and development activities.

If any form of institutional verification is required, I would be happy to provide it privately.

Thank you for your time and consideration.

Best regards,
Yeison Nolberto Cardona Alvarez
Part-Time Lecturer – Universidad Nacional de Colombia
