### PR TITLE
Add Wellington High School

### DIFF
--- a/lib/domains/nz/school/whs.txt
+++ b/lib/domains/nz/school/whs.txt
@@ -1,0 +1,1 @@
+Wellington High School


### PR DESCRIPTION
Add Wellington High School, Wellington, New Zealand https://www.whs.school.nz