### PR TITLE
Add cau university

### DIFF
--- a/lib/domains/kr/ac/cau/cau.txt
+++ b/lib/domains/kr/ac/cau/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+CHUNG-ANG UNIVERSITY


### PR DESCRIPTION
## 📌 Introduction to Chung-Ang University (CAU)

[Chung-Ang University (CAU)](https://www.cau.ac.kr) is one of South Korea’s leading private universities, established in 1918. It operates two campuses: the main campus in Seoul (Heukseok-dong) and a secondary campus in Anseong.

With over a century of academic excellence, CAU has played a pivotal role in fostering talented individuals across various fields including arts, sciences, engineering, business, and the humanities. The university is also actively expanding its global presence and interdisciplinary education in response to the Fourth Industrial Revolution.

### Key Highlights
- 🎓 Over 100 years of academic tradition and innovation  
- 🏫 Dual campuses in Seoul and Anseong  
- 💻 Strong programs in AI, software, business, design, and performing arts  
- 🌍 Active in global partnerships and industry-academic collaboration  

📎 For more information, please visit the [official CAU website](https://www.cau.ac.kr).
