### PR TITLE
Add Al-Ahram Canadian University (ACU) in Cairo, Egypt

### DIFF
--- a/lib/domains/eg/edu/acu.txt
+++ b/lib/domains/eg/edu/acu.txt
@@ -1,0 +1,1 @@
+Al-Ahram Canadian University


### PR DESCRIPTION
This pull request adds Al-Ahram Canadian University (ACU) to the JetBrains educational institutions list.

Details:
- Name: Al-Ahram Canadian University
- Website: https://www.acu.edu.eg
- City: Giza
- Country: Egypt
- Email domain: acu.edu.eg

The file has been added under the correct directory structure: _education/Egypt/Cairo/

Thank you for reviewing this request.
