### PR TITLE
Add www.uniajc.edu.co to support educational license

### DIFF
--- a/lib/domains/co/edu/uniajc.txt
+++ b/lib/domains/co/edu/uniajc.txt
@@ -1,0 +1,1 @@
+Institución Universitaria Antonio José Camacho


### PR DESCRIPTION
Adding support for www.uniajc.edu.co to request educational license for students.

Details:

Name: Institución Universitaria Antonio José Camach
Website: https://www.uniajc.edu.co
City: Cali
Country: Colombia
Email domain: uniajc.edu.co

Thank you for reviewing this request.