### PR TITLE
Adding www.middlesexcollege.edu previously called www.middlesexcc.edu…

### DIFF
--- a/lib/domains/edu/middlesexcc.txt
+++ b/lib/domains/edu/middlesexcc.txt
@@ -1,0 +1,1 @@
+Middlesex County College

--- a/lib/domains/edu/middlesexcollege.txt
+++ b/lib/domains/edu/middlesexcollege.txt
@@ -1,0 +1,2 @@
+Middlesex College
+Middlesex County College

--- a/lib/domains/edu/middlesexcollege.txt
+++ b/lib/domains/edu/middlesexcollege.txt
@@ -1,2 +1,1 @@
 Middlesex College
-Middlesex County College


### PR DESCRIPTION
Adding www.middlesexcollege.edu to the edu list.  The college was recently rename from www.middlesexcc.edu

Middlesex County College to Middlesex College.