### PR TITLE
Add Royal University of Phnom Penh (rupp.edu.kh)

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,4 @@
+Royal University of Phnom Penh
+សាកលវិទ្យាល័យភូមិន្ទភ្នំពេញ
+https://rupp.edu.kh
+https://www.fe.rupp.edu.kh/program/7


### PR DESCRIPTION
Hello JetBrains team,

I am submitting a request to add the Royal University of Phnom Penh (rupp.edu.kh) to the list of recognized educational domains.
 • Official website: https://rupp.edu.kh (https://rupp.edu.kh/)
 • School email domain: @rupp.edu.kh
 • I have attached a PDF screenshot from the official student portal showing that student email addresses use this domain.
 • Attachment: [Student_login.pdf](https://github.com/user-attachments/files/20024456/Student_login.pdf)

This domain is used by students for official academic communication and registration. I am requesting its addition so students can access JetBrains tools for educational purposes.

Thank you for your support and for providing access to these valuable educational tools.