### PR TITLE
Add songeui.ac.kr

### DIFF
--- a/lib/domains/kr/ac/songeui.txt
+++ b/lib/domains/kr/ac/songeui.txt
@@ -1,0 +1,2 @@
+가톨릭대학교 성의교정
+The Catholic University of Korea - Songeui Campus


### PR DESCRIPTION
가톨릭대학교 성의교정
The Catholic University of Korea - Songeui Campus

Songeui Campus has two domains:
 - songeui.catholic.ac.kr (Web)
 - songeui.ac.kr (Email) 
