### PR TITLE
Add sv.sgu.edu.vn to educational domains

### DIFF
--- a/lib/domains/vn/edu/sgu/sv.txt
+++ b/lib/domains/vn/edu/sgu/sv.txt
@@ -1,0 +1,2 @@
+Trường Đại học Sài Gòn
+Sai Gon University


### PR DESCRIPTION
This pull request adds two entries to the `lib/domains/vn/edu/sgu/sv.txt` file to include the full name and English translation of Sai Gon University.
