### PR TITLE
Add Chung-Ang University cau.ac.kr

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
This pull request adds two entries to the lib/domains/kr/ac/cau.txt file to include the full name and English translation of Chung-Ang University.

The university official website: [cau.ac.kr](https://www.cau.ac.kr)