### PR TITLE
Add domain for Nile University of Science and Technology (Add domain file for nu.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/nu.txt
+++ b/lib/domains/eg/edu/nu.txt
@@ -1,0 +1,2 @@
+جامعة النيل
+Nile University


### PR DESCRIPTION
This pull request adds the domain nu.edu.eg for Nile University.

- Created file at: lib/domains/eg/edu/nu.txt
- Official school name added as the first line of the file.
- Domain is used for academic/student email addresses.

Thank you!
