### PR TITLE
Universidad Iberoamericana (UNIBE) added.

### DIFF
--- a/lib/domains/do/edu/unibe/est.txt
+++ b/lib/domains/do/edu/unibe/est.txt
@@ -1,0 +1,1 @@
+Universidad Iberoamericana (UNIBE)


### PR DESCRIPTION
This pull request adds Universidad Iberoamericana (UNIBE) from the Dominican Republic to the JetBrains educational domain list.

- University Name: Universidad Iberoamericana (UNIBE)
- Official Website: https://www.unibe.edu.do/
- Email Domain: est.unibe.edu.do (used by students)
- Example Email: jpaulino@est.unibe.edu.do (personal institutional email used for verification)

UNIBE is a recognized academic institution in the Dominican Republic. Students use email addresses under the domain est.unibe.edu.do for academic purposes. This addition would allow UNIBE students and staff to benefit from JetBrains educational licenses.