### PR TITLE
Request to Add School Domain for JetBrains Educational Access (Add Hanbyeol Elementary School by goedu.kr)

### DIFF
--- a/lib/domains/kr/ac/goedu.txt
+++ b/lib/domains/kr/ac/goedu.txt
@@ -1,0 +1,2 @@
+한별초등학교
+Hanbyeol Elementary School


### PR DESCRIPTION
Hello,

In elementary, middle, and high schools located in Gyeonggi-do, South Korea, email domains are issued through a centralized cloud system. As a result, the domain used is unified as goedu.kr rather than being specific to each individual school.

Please take this into consideration when registering our domain.

Thank you very much.