### PR TITLE
Add colegiulunirea.ro to the list of academic domains

### DIFF
--- a/lib/domains/ro/colegiulunirea.txt
+++ b/lib/domains/ro/colegiulunirea.txt
@@ -1,0 +1,2 @@
+Colegiul National "Unirea", Târgu Mureș
+"Unirea" National college, Târgu Mureș


### PR DESCRIPTION
Added colegiulunirea.ro for Colegiul Național "Unirea" in Târgu Mureș, Romania. This domain is used for the school's official website and email addresses issued to students and staff.