### PR TITLE
Add University of Houston-Downtown (uhd.edu)

### DIFF
--- a/lib/domains/edu/uhd/uhd.txt
+++ b/lib/domains/edu/uhd/uhd.txt
@@ -1,0 +1,1 @@
+University of Houston-Downtown


### PR DESCRIPTION
Adding University of Houston-Downtown.

- Official Website: https://www.uhd.edu/
- IT-related long-term course (>1 year) example: MS in Artificial Intelligence - https://www.uhd.edu/academics/sciences/msai.aspx
- Proof of domain usage for students (e.g., student services, email info): The "Getting Started" page for business students mentions @uhd.edu email context - https://www.uhd.edu/academics/business/new-students/getting-started.aspx

Please let me know if any further information is needed.