### PR TITLE
Add Green University of Bangladesh - .ac domain

### DIFF
--- a/lib/domains/bd/ac/green/student.txt
+++ b/lib/domains/bd/ac/green/student.txt
@@ -1,0 +1,1 @@
+Green University of Bangladesh


### PR DESCRIPTION
This pull request adds support for the .ac domain of Green University of Bangladesh (GUB). Although GUB is listed in the SWOT database with a .edu domain, students are not provided access to that domain. Therefore, I am requesting the inclusion of the .ac domain on behalf of GUB students to enable their access.

Thank You.