### PR TITLE
add domain:m365.fju.edu.tw

### DIFF
--- a/lib/domains/tw/edu/fju/m365.txt
+++ b/lib/domains/tw/edu/fju/m365.txt
@@ -1,0 +1,2 @@
+天主教輔仁大學
+Fu Jen Catholic University


### PR DESCRIPTION
天主教輔仁大學
Fu Jen Catholic University

domain: m365.fju.edu.tw