### PR TITLE
Rafisa Informatik GmbH offers vocational education for authistic students

### DIFF
--- a/lib/domains/ch/rafisa.txt
+++ b/lib/domains/ch/rafisa.txt
@@ -1,0 +1,1 @@
+Rafisa Informatik GmbH


### PR DESCRIPTION
Rafisa Informatik GmbH offers vocational education for authistic pers…ons in the IT industry at seven different locations in Switzerland. rafisa.ch is used as the Email domain for the students as well as for the trainers. See https://rafisa.ch/en/  for details