### PR TITLE
Add Fu Jen Catholic University domain (fju.edu.tw)

### DIFF
--- a/lib/domains/tw/edu/fju/m365.txt
+++ b/lib/domains/tw/edu/fju/m365.txt
@@ -1,0 +1,2 @@
+天主教輔仁大學
+FuJen Catholic University


### PR DESCRIPTION
Adds the domain for Fu Jen Catholic University (輔仁大學) in Taiwan according to contribution guidelines.
