### PR TITLE
Add tukorea.ac.kr domain for Tech University of Korea

### DIFF
--- a/lib/domains/kr/ac/tukorea.txt
+++ b/lib/domains/kr/ac/tukorea.txt
@@ -1,0 +1,2 @@
+한국공학대학교
+Tech University of Korea


### PR DESCRIPTION
Request to add the academic domain tukorea.ac.kr for Tech University of Korea (한국공학대학교) to the JetBrains student license whitelist.

This file was generated using the official form provided by JetBrains.
