### PR TITLE
Add Rheinische Hochschule Köln to known universities

### DIFF
--- a/lib/domains/de/rh-koeln/ext.txt
+++ b/lib/domains/de/rh-koeln/ext.txt
@@ -1,0 +1,1 @@
+Rheinische Hochschule Köln


### PR DESCRIPTION
In this pull request, I want to add the Rheinische Hochschule Köln (formerly known as Rheinische Fachhochschule Köln) to known universities. 

https://rh-koeln.de/