### PR TITLE
Add domain binus.ac.id

### DIFF
--- a/lib/domains/ac/id/binus.txt
+++ b/lib/domains/ac/id/binus.txt
@@ -1,0 +1,2 @@
+Universitas Bina Nusantara
+Binus University


### PR DESCRIPTION
BINUS UNIVERSITY is a leading private university in Indonesia with a strong emphasis on international education and technology

Official Site: `https://binus.ac.id`
Mail Domain: `@binus.ac.id`