### PR TITLE
Add Anyang University

### DIFF
--- a/lib/domains/kr/gs/anyang.txt
+++ b/lib/domains/kr/gs/anyang.txt
@@ -1,0 +1,2 @@
+안양대학교
+Anyang University


### PR DESCRIPTION
Adding 안양대학교 (Anyang University) for domain gs.anyang.ac.kr to support student educational licenses.
