### PR TITLE
Add Hankuk University Of Foreign Studies(hufs.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University Of Foreign Studies


### PR DESCRIPTION
I ask JetBrains to add my university domain

University name: Hankuk University Of Foreign Studies(Seoul,Korea)
University Domain: @hufs.ac.kr
University URL: https://www.hufs.ac.kr/sites/hufs/index.do

Hankuk University of Foreign Studies is a university that teaches not only foreign languages but also various fields.
I am working on software ai as a double major in this school.

Please review, an if everything looks good, merge please
Thankyou :)
(email: choi991117@hufs.ac.kr)