### PR TITLE
Add Anyang University (gs.anyang.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/anyang/gs.txt
+++ b/lib/domains/kr/ac/anyang/gs.txt
@@ -1,0 +1,2 @@
+안양대학교
+Anyang University


### PR DESCRIPTION
This PR adds Anyang University (gs.anyang.ac.kr) to the list of educational domains for JetBrains Student License.
The file was generated using JetBrains' official domain request form.
Thank you!