### PR TITLE
Update the proper official name of NURE university

### DIFF
--- a/lib/domains/ua/nure.txt
+++ b/lib/domains/ua/nure.txt
@@ -1,1 +1,1 @@
-Kharkiv National University Radioelectronics, Ukraine
+Kharkiv National University of Radio Electronics, Ukraine


### PR DESCRIPTION
Hi, this small MR aims to update the correct name of the NURE university, Ukraine.

Official website: https://nure.ua/en/