### PR TITLE
Add Seoyeong Univerisity in South Korea

### DIFF
--- a/lib/domains/kr/ac/sou.txt
+++ b/lib/domains/kr/ac/sou.txt
@@ -1,0 +1,2 @@
+서영대학교
+SEOYEONG University


### PR DESCRIPTION
It's for add Seoyeong Univerisity in South Korea
Domain is : [ID].sou.ac.kr

please review, and if have any problem, Merge please

I'll be eagerly waiting for it to be approved.
Please take care of it quickly.
Thank you :) 