### PR TITLE
added kyonggi

### DIFF
--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+Kyonggi University


### PR DESCRIPTION
Add Kyonggi University (kyonggi.ac.kr)

This PR adds Kyonggi University to the list of educational institutions eligible for JetBrains free licenses.

- **Official Website:** [Kyonggi University](https://www.kyonggi.ac.kr/www/index.do)
- **IT Related Department:** [Computer Science Department](http://cs.kyonggi.ac.kr:8080/Index)

The university offers long-term courses related to IT, and the domain kyonggi.ac.kr is used as the official email domain for enrolled students.

Please review and merge this PR. Thank you!