### PR TITLE
Add Yeungnam University (yu.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/yu.txt
+++ b/lib/domains/kr/ac/yu.txt
@@ -1,0 +1,1 @@
+Yeungnam University


### PR DESCRIPTION
## **1. School Official Website URL**  
- https://www.yu.ac.kr/

----

## **2. School Address**  
- 280, Daehak-ro, Gyeongsan-si, Gyeongsangbuk-do, Republic of Korea
----

## **3. Proof of Domain Usage (@yu.ac.kr)**  
- Official source: https://sites.google.com/yu.ac.kr/help  

Based on the contents of the official site
#### 4. 특기 사항
- **가. @ynu.ac.kr(@yumail.ac.kr) 주소는 현재와 동일한 방법으로 서비스를 제공하며, 신규 가입은 받지 않습니다.**  
  → This confirms that `@ynu.ac.kr` is the **previously used domain** and is no longer available for new registrations.

#### 1. 웹메일 시스템 교체 (Google Gmail 사용)
- **가. 웹메일 시스템 전환: 기존 웹메일 시스템(@yu.ac.kr 주소) → 구글 Gmail 시스템 전환**
- **- Gmail 시스템을 통하여 교내 @yu.ac.kr 메일 서비스를 제공합니다.**  
  → This clearly indicates that `@yu.ac.kr` is the **currently active domain**, officially used through the Gmail system.

Therefore, please consider adding `@yu.ac.kr` to the list of accepted educational domains.

Thank you very much!
