### PR TITLE
Request to Add yu.ac.kr as a Verified Academic Domain for License Authentication

### DIFF
--- a/lib/domains/kr/ac/yu.txt
+++ b/lib/domains/kr/ac/yu.txt
@@ -1,0 +1,2 @@
+영남대학교
+Yeungnam University


### PR DESCRIPTION
Dear JetBrains,

I hope this message finds you well.

I am an undergraduate student at Yeungnam University in South Korea, majoring in Computer Engineering.

I am reaching out regarding the academic license verification process. Currently, our university issues student email accounts using the domain `yu.ac.kr`. However, I have noticed that your system only recognizes `ynu.ac.kr` as the official domain for Yeungnam University.

While `ynu.ac.kr` may have been used in the past, it is no longer active for student emails. As a result, many students, including myself, are currently unable to verify our academic status to access your educational license.

Would it be possible to add `yu.ac.kr` as a verified domain for Yeungnam University?

Your support on this matter would be greatly appreciated.  
Thank you for your time and consideration.

Best regards,  
Undergraduate Student  
Department of Computer Engineering  
Yeungnam University
