### PR TITLE
Create fab.txt

### DIFF
--- a/lib/domains/br/mil/fab.txt
+++ b/lib/domains/br/mil/fab.txt
@@ -1,0 +1,1 @@
+Escola de Especialistas de Aeronáutica (EEAR) - Força Aérea Brasileira (FAB)


### PR DESCRIPTION
Adds the fab.mil.br domain related to the Escola de Especialistas de Aeronáutica (EEAR), https://www2.fab.mil.br/eear/, Military Organization responsible for the training of Aeronautics Specialists in training courses - ecognized by the Ministry of Education (MEC) - and improvement (https://www2.fab.mil.br/eear/index.php/2015-06-02-14-12-40), of the Brazilian Air Force (FAB).