### PR TITLE
Add My School - mdc.edu

### DIFF
--- a/lib/domains/net/mymdc.txt
+++ b/lib/domains/net/mymdc.txt
@@ -1,0 +1,1 @@
+Miami Dade College


### PR DESCRIPTION
Hello,
My school is Miami Dade College. all students emails domain is mymdc.net. Only professors and school staff use .edu as email domain.
![image](https://github.com/user-attachments/assets/a3e473a7-6ea9-4fb8-9a67-c37392f8bf78)
