### PR TITLE
Add university domain for kmitl.ac.th

### DIFF
--- a/lib/domains/th/ac/kmitl.txt
+++ b/lib/domains/th/ac/kmitl.txt
@@ -1,0 +1,1 @@
+King Mongkut's Institute of Technology Ladkrabang


### PR DESCRIPTION
Add official domain for my university to enable JetBrains student license.