### PR TITLE
Add yu.ac.kr (Yeungnam University)

### DIFF
--- a/lib/domains/ac/kr/yu.txt
+++ b/lib/domains/ac/kr/yu.txt
@@ -1,0 +1,2 @@
+영남대학교
+Yeungnam University

--- a/lib/domains/ac/kr/yu.txt
+++ b/lib/domains/ac/kr/yu.txt
@@ -1,2 +1,2 @@
-영남대학교
-Yeungnam University
+yu.ac.kr
+


### PR DESCRIPTION
Adding yu.ac.kr domain for Yeungnam University student email verification.
This domain is used by enrolled students in South Korea.