### PR TITLE
Add TAEJAE UNIVERSITY (taejae.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/taejae.txt
+++ b/lib/domains/kr/ac/taejae.txt
@@ -1,0 +1,2 @@
+태재대학교
+TAEJAE University


### PR DESCRIPTION
This pull request adds TAEJAE UNIVERSITY to the JetBrains/swot repository.

- University Name: TAEJAE UNIVERSITY
- Website: https://www.taejae.ac.kr
- Student Portal: https://portal.taejae.ac.kr
- Email Domain: taejae.ac.kr

### Proof of educational domain usage:
- The official student and faculty email addresses use the domain `taejae.ac.kr`.
- Here is a screenshot showing the email login page or portal (attached or linked):
 ![taejae ac kr](https://github.com/user-attachments/assets/02ff1d39-417d-42af-8c64-8734b9de5dd2)

The university is an accredited higher education institution in South Korea, offering degree programs to undergraduate and graduate students.

Thank you for reviewing this request.
