### PR TITLE
Add yu domain

### DIFF
--- a/lib/domains/kr/ac/yu.txt
+++ b/lib/domains/kr/ac/yu.txt
@@ -1,0 +1,2 @@
+영남대학교
+Yeungnam University

--- a/lib/domains/kr/ac/yu.txt
+++ b/lib/domains/kr/ac/yu.txt
@@ -1,2 +1,2 @@
 영남대학교
-Yeungnam University
+Yeungnam university


### PR DESCRIPTION
please add yu domain for yeungnam university students

Yeungnam university is located in south Korea and refer to the below link
https://www.yu.ac.kr/english/index.do

Address and telephone numbers :
280 Daehak-Ro, Gyeongsan, Gyeongbuk 38541, Republic of Korea (38541 Korea)
170 Hyeonchung-ro, Nam-gu, Daegu 42415, Republic of Korea (42415 Korea)
TEL [053-810-2114](tel:053-810-2114) / FAX 053-810-2036