### PR TITLE
Add Elektronik Radom

### DIFF
--- a/lib/domains/pl/edu/elektronik.txt
+++ b/lib/domains/pl/edu/elektronik.txt
@@ -1,0 +1,2 @@
+Zespół Szkół Elektronicznych im. Bohaterów Westerplatte w Radomiu
+Westerplatte Heroes Electronic Schools Complex, Radom

--- a/lib/domains/pl/elektronikonline.txt
+++ b/lib/domains/pl/elektronikonline.txt
@@ -1,0 +1,2 @@
+Zespół Szkół Elektronicznych im. Bohaterów Westerplatte w Radomiu
+Westerplatte Heroes Electronic Schools Complex, Radom


### PR DESCRIPTION
School official website: https://elektronik.edu.pl
A list of available courses of study at the school: https://elektronik.edu.pl/index.php/2015-05-15-10-49-45/kierunki-ksztalcenia-w-roku-szkolnym-2025-2026

E-mails for teachers are contained in the domain @elektronik.edu.pl
Mail for students is contained in the domain @elektronikonline.pl