### PR TITLE
Add cau.ac.kr for Chung-Ang University

### DIFF
--- a/lib/domains/kr/cau.txt
+++ b/lib/domains/kr/cau.txt
@@ -1,1 +1,2 @@
+중앙대학교
 Chung-Ang University


### PR DESCRIPTION
This pull request adds the domain `cau.ac.kr` for Chung-Ang University (Seoul, South Korea).

- 🔗 Official website: https://www.cau.ac.kr
- 💻 IT-related course: https://cse.cau.ac.kr
- 📧 Student email usage proof: https://mail.cau.ac.kr

Students of the university use `@cau.ac.kr` email addresses, which qualifies them for educational licenses under JetBrains policy.

Thank you!