### PR TITLE
Add binus.ac.id to support JetBrains student license

### DIFF
--- a/lib/domains/id/ac/binus.txt
+++ b/lib/domains/id/ac/binus.txt
@@ -1,0 +1,2 @@
+Universitas Bina Nusantara
+Binus University


### PR DESCRIPTION
This pull request adds the domain binus.ac.id for BINUS University (Jakarta, Indonesia).

🔗 Official website: https://www.binus.ac.id  
💻 IT-related course: https://computer-science.binus.ac.id  
📧 Student email usage proof: https://student.binus.ac.id  

Students of the university use @binus.ac.id email addresses, which qualifies them for educational licenses under JetBrains policy.

Thank you!