### PR TITLE
Add bme.buet.ac.bd domain

### DIFF
--- a/lib/domains/bd/ac/buet/bme.txt
+++ b/lib/domains/bd/ac/buet/bme.txt
@@ -1,0 +1,2 @@
+Department of Biomedical Engineering, BUET
+Bangladesh University of Engineering and Technology


### PR DESCRIPTION
This pull request adds the domain bme.buet.ac.bd, used by students of the Department of Biomedical Engineering, Bangladesh University of Engineering and Technology (BUET).

- Official University Website: https://www.buet.ac.bd
- IT-related Course Page: https://bme.buet.ac.bd/undergraduate-program/
- Email domain format: student@bme.buet.ac.bd