### PR TITLE
South Puget Sound Community College

### DIFF
--- a/lib/domains/us/spscc.txt
+++ b/lib/domains/us/spscc.txt
@@ -1,0 +1,1 @@
+South Puget Sound Community College


### PR DESCRIPTION
Adding South Puget Sound Community College domain spscc.edu to the master branch.