### PR TITLE
add uts.edu.co

### DIFF
--- a/lib/domains/co/edu/uts.txt
+++ b/lib/domains/co/edu/uts.txt
@@ -1,0 +1,2 @@
+Unidades Tecnológicas de Santander
+Santander Technology Units


### PR DESCRIPTION
The domain of the university "Unidades Tecnológicas de Santander" of Colombia is added, so that students can use educational licenses.