### PR TITLE
Add Royal University of Phnom Penh (rupp.edu.kh) domain file

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,2 @@
+Royal University of Phnom Penh
+Royal University of Phnom Penh


### PR DESCRIPTION
Adding metadata for Royal University of Phnom Penh to request free JetBrains licenses for students.