### PR TITLE
Add roquegonzalez.org domain

### DIFF
--- a/lib/domains/org/roquegonzalez.txt
+++ b/lib/domains/org/roquegonzalez.txt
@@ -1,0 +1,1 @@
+Instituto Superior Roque Gonzalez


### PR DESCRIPTION
The domain roquegonzalez.org is used by Instituto Superior Roque González, an educational institution located in Argentina. This domain is used for official email communication with students and staff.

Website for verification: https://www.roquegonzalez.com.ar
