### PR TITLE
Adding AIU to JetBrains academic licenses

### DIFF
--- a/lib/domains/eg/edu/aiu.txt
+++ b/lib/domains/eg/edu/aiu.txt
@@ -1,0 +1,2 @@
+Alamein International University
+Alamein International University


### PR DESCRIPTION
This pull request adds Alamein International University (AIU) to the list of recognized academic institutions.
Its official domain: aiu.edu.eg. This change will help identify students and staff from AIU when applying for JetBrains academic licenses, enabling them to receive appropriate educational discounts.