### PR TITLE
University of Málaga

### DIFF
--- a/lib/domains/es/uma.txt
+++ b/lib/domains/es/uma.txt
@@ -1,0 +1,2 @@
+Universidad de Málaga
+University of Málaga


### PR DESCRIPTION
Adds `University of Málaga` domain.

https://www.uma.es/