### PR TITLE
Add University of Technology of Peru

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica del Perú


### PR DESCRIPTION
University website: https://www.utp.edu.pe/

Added utp.txt file for Universidad Tecnológica del Perú under lib/domains/pe/edu.
This will allow students with **@utp.edu.pe** email addresses to request JetBrains student licenses.