### PR TITLE
Add University of Science and Technology

### DIFF
--- a/lib/domains/kr/ac/ust.txt
+++ b/lib/domains/kr/ac/ust.txt
@@ -1,0 +1,2 @@
+University of Science and Technology
+과학기술연합대학원대학교


### PR DESCRIPTION
Add University of Science and Technology in R.O.K.

1. the university official website URL, if it is different from the domain you are submitting
It's same (https://www.ust.ac.kr/)
2. a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
History tab in https://ust.ac.kr/prog/major/eng/sub03_03_02/all/view.do?majorNo=70
3. a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.
![스크린샷 2025-06-04 101731](https://github.com/user-attachments/assets/2855abb6-d480-4124-9d9e-5fe7d7130dc2)

