### PR TITLE
Add UABJO - Facultad de Idiomas de Oaxaca

### DIFF
--- a/lib/domains/mx/edu/f-idiomas.txt
+++ b/lib/domains/mx/edu/f-idiomas.txt
@@ -1,0 +1,2 @@
+UABJO
+Facultad de idiomas sede Burgoa


### PR DESCRIPTION
This pull request adds the domain for Universidad Autónoma "Benito Juárez" de Oaxaca (UABJO) to the JetBrains/swot repository. UABJO is a public university located in Oaxaca, Mexico, and offers a variety of undergraduate and postgraduate programs, including Computer Science and related fields.