### PR TITLE
Added Boston University

### DIFF
--- a/lib/domains/edu/bu.txt
+++ b/lib/domains/edu/bu.txt
@@ -1,0 +1,1 @@
+Boston University


### PR DESCRIPTION
- the university official website URL, if it is different from the domain you are submitting
www.bu.edu

- a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
www.bu.edu/cs

- a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.
https://www.bu.edu/cs/profiles/john-w-byers/

(See email at very bottom)


