### PR TITLE
Control Data Training GmbH - second email domain

### DIFF
--- a/lib/domains/com/onmicrosoft/cdtnue.txt
+++ b/lib/domains/com/onmicrosoft/cdtnue.txt
@@ -1,0 +1,2 @@
+Control Data Training GmbH
+Control Data Training GmbH


### PR DESCRIPTION
This is the second email domain for our organization Control Data Training GmbH. This email domain @cdtnue.onmicrosoft.com is used by students.

Information about the main domain
Control Data Training GmbH - Adding a new educational institution to the list for obtaining licenses. a URL of a page on the official Website
https://cdt-nue.de/

a URL of a page on the official website where a long-term (>1 year). IT related course is offered by the University It states here that the programs last a minimum of 2 years. https://cdt-nue.de/umschulungen/
https://cdt-nue.de/weiterbildungspraemie/

Program for IT specialist application development CDT (2 years) https://cdt-nue.de/weiterbildung/fachinformatikerfachinformatikerin-anwendungsentwicklung-cdt/

Program for IT specialist system integration CDT (2 years) https://cdt-nue.de/weiterbildung/fachinformatikerfachinformatikerin-systemintegration-cdt/

On this page in the contacts section there is an email with the official domain ( info@cdt-nue.de ) https://cdt-nue.de/kontakt/