### PR TITLE
Add Fu Jen Catholic University to m365.txt

### DIFF
--- a/lib/domains/tw/edu/fju/m365.txt
+++ b/lib/domains/tw/edu/fju/m365.txt
@@ -1,0 +1,1 @@
+Fu Jen Catholic University


### PR DESCRIPTION
The school official website URL: https://www.fju.edu.tw/indexEN.jsp
The school street address, including city and country: No. 510, Zhongzheng Rd, Xinzhuang District, New Taipei City, Taiwan 242
URL of a page on the official website where the school offers an IT-related long-term (>1 year) course : https://csie2.fju.edu.tw/webPage/39