### PR TITLE
Add a college SKIT, Bengaluru to the list of educational institutes.

### DIFF
--- a/lib/domains/in/org/skit.txt
+++ b/lib/domains/in/org/skit.txt
@@ -1,0 +1,1 @@
+Sri Krishna Institute of Technology, Bengaluru


### PR DESCRIPTION
Adding Sri Krishna Institute of Technology, Bengaluru to the list of Jetbrains supported educational institutes.