### PR TITLE
adding coloradomesa.edu domain

### DIFF
--- a/lib/domains/edu/coloradomesa.txt
+++ b/lib/domains/edu/coloradomesa.txt
@@ -1,0 +1,1 @@
+Colorado Mesa University


### PR DESCRIPTION
Adding coloradomesa.edu domain. We have two email domains, @coloradomesa.edu for staff/faculty and @mavs.coloradomesa.edu for students.

https://www.coloradomesa.edu/information-technology/how-to.html under Synchronizing CMU Mail