### PR TITLE
Add hufs.ac.kr (Hankuk University of Foreign Studies)

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
학교 공식 웹사이트: https://www.hufs.ac.kr