### PR TITLE
Add student.anyang.ac.kr domain for Anyang University

### DIFF
--- a/lib/domains/kr/ac/anyang/student.txt
+++ b/lib/domains/kr/ac/anyang/student.txt
@@ -1,0 +1,3 @@
+안양대학교
+Anyang University
+student.anyang.ac.kr


### PR DESCRIPTION
This PR adds the student.anyang.ac.kr domain for Anyang University in South Korea.
