### PR TITLE
Add office.hsc.ac.kr domain from Hallym Polytechnic University

### DIFF
--- a/lib/domains/kr/ac/hsc/office.txt
+++ b/lib/domains/kr/ac/hsc/office.txt
@@ -1,0 +1,2 @@
+한림성심대학교
+Hallym Polytechnic University


### PR DESCRIPTION
This pull request adds the domain `office.hsc.ac.kr` for Hallym Polytechnic University.

- Official university website: [http://www.hsc.ac.kr](http://www.hsc.ac.kr) (Note: 'www.' is required for access)
- Domain to be added: `office.hsc.ac.kr`
- The domain is used by Hallym Polytechnic University (한림성심대학교) for internal and academic purposes.

Thank you!