### PR TITLE
Add Universidad Tecnológica del Perú (utp.edu.pe)

### DIFF
--- a/lib/domains/pe/utp.txt
+++ b/lib/domains/pe/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+Technological University of Peru


### PR DESCRIPTION
Adding support for the domain `utp.edu.pe` so that students from Universidad Tecnológica del Perú can apply for a JetBrains student license.

Website: https://www.utp.edu.pe