### PR TITLE
Added Clemens August Gymnasium Cloppenburg

### DIFF
--- a/lib/domains/eu/c-a-g.txt
+++ b/lib/domains/eu/c-a-g.txt
@@ -1,0 +1,1 @@
+Clemens-August-Gymnasium Cloppenburg


### PR DESCRIPTION
# Clemens-August-Gymnasium

## Address 
Bahnhofstraße 53
49661 Cloppenburg

## Website
https://c-a-g.de/ (Homepage)
https://c-a-g.eu/ (IServ - **mail**, files, tasks, etc.)

## Further information
The domain for mail is `c-a-g.eu` instead of `c-a-g.de` because IServ runs on `c-a-g.eu`.

### Places where `c-a-g.eu` is linked on `c-a-g.de`
https://c-a-g.de/index.php/unterricht
https://c-a-g.de/index.php/startseite/kontakt