### PR TITLE
Create bu.txt

### DIFF
--- a/lib/domains/edu/bu.txt
+++ b/lib/domains/edu/bu.txt
@@ -1,0 +1,1 @@
+Boston University


### PR DESCRIPTION
Add Boston University (bu.edu)

**Official University Website:**  
https://www.bu.edu

**IT-related Long-term Course (More than 1 year):**  
https://www.bu.edu/met/programs/information-technology/

This PR adds `bu.edu` to the list of educational domains. The official site confirms use of this domain for student emails.
