### PR TITLE
Add Bangladesh University of Engineering and Technology grad students

### DIFF
--- a/lib/domains/bd/ac/buet/cse/grad.txt
+++ b/lib/domains/bd/ac/buet/cse/grad.txt
@@ -1,0 +1,1 @@
+Bangladesh University of Engineering and Technology


### PR DESCRIPTION
Currently, only the undergrad students are eligible, as their domain starts with **_ugrad_**, where as the graduate(masters) students' domain start with **_grad_**
Please approve the grad students as well.