### PR TITLE
Add "Duale Hochschule Sachsen" domain

### DIFF
--- a/lib/domains/de/dhsn/edu.txt
+++ b/lib/domains/de/dhsn/edu.txt
@@ -1,0 +1,2 @@
+Duale Hochschule Sachsen
+Berufsakademie Sachsen


### PR DESCRIPTION
This PR adds the _Duale Hochschuule Sachen_ E-Mail domain used by students, `edu.dhsn.de`.

The institution was previously called _Berufsakademie Sachsen_. This name is included in the `edu.txt`.

In the interest of getting the domain added quicker:

> the university official website URL, if it is different from the domain you are submitting

- Homepage of the institution: https://www.dhsn.de/ (Unfortunately only available in German)
  - Note that the previous name is mentioned on this Homepage ("_Berufsakademie Sachsen is now called..._")

> a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university

- For example: https://www.dhsn.de/studienangebot/detail/medieninformatik

> a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.

- I can't really find a page detailing this. I have a (not great quality) screenshot of an inbox:

![image](https://github.com/user-attachments/assets/eeed4faf-2726-45b0-972f-aa3ac397991f)

The only other student E-Mail I have found is on the following (external) website: https://www.kc-sachsen.de/kennenlernen/inklusion/ansprechpartnerinnen (search for `edu.dhsn.de`, links to a page of the University).

Should these not suffice I will try to find an E-Mail or something similar containing this information. 