### PR TITLE
Add student email domain for NWU China

### DIFF
--- a/lib/domains/cn/edu/nwu/stumail.txt
+++ b/lib/domains/cn/edu/nwu/stumail.txt
@@ -1,0 +1,2 @@
+西北大学
+Northwest University (Xi'an, China)


### PR DESCRIPTION
Added the student-specific email domain"西北大学 (Northwest University (Xi'an, China)".