### PR TITLE
Add Baekseok University

### DIFF
--- a/lib/domains/kr/ac/bu.txt
+++ b/lib/domains/kr/ac/bu.txt
@@ -1,0 +1,2 @@
+백석대학교
+Baekseok University


### PR DESCRIPTION
### University Name
백석대학교 (Baekseok University)

### Domain
bu.ac.kr

### Official Website
https://www.bu.ac.kr/

### IT-related Long-term Course
https://community.bu.ac.kr/info/1767/subview.do