### PR TITLE
Add "Gymnasium Eckental"

### DIFF
--- a/lib/domains/com/onmicrosoft/eckegym.txt
+++ b/lib/domains/com/onmicrosoft/eckegym.txt
@@ -1,0 +1,1 @@
+Gymnasium Eckental


### PR DESCRIPTION
Add domain used by students of "Gymnasium Eckental" (Germany).

- Official Website:
https://gymnasium-eckental.de/
- Proof of long-term IT-related Course: 
https://gymnasium-eckental.de/wp-content/uploads/2021/03/Information-Zweigwahl-G9-7.-Klassen.pdf
(See section "Stundentafel G9" -> "Informatik (NTG)")
- Proof that the submitted domain is used for student emails:
https://gymnasium-eckental.de/wp-content/uploads/2023/09/Elternbrief-Office365-fuer-Schueler.pdf
(Confirms use of domain for students' Microsoft 365 accounts)