### PR TITLE
Add DSATM

### DIFF
--- a/lib/domains/in/edu/dsatm.txt
+++ b/lib/domains/in/edu/dsatm.txt
@@ -1,0 +1,1 @@
+Dayananda Sagar Academy of Technology and Management, Bengaluru


### PR DESCRIPTION
- Official University Website: https://dsatm.edu.in
- Link for UG course (4 years) provided by the university: https://dsatm.edu.in/academics/ug/computer-science
- The official link itself recognises the specified domain: https://dsatm.edu.in