### PR TITLE
Add Universidad Nacional Federico Villarreal (unfv.edu.pe)

### DIFF
--- a/lib/domains/pe/edu/unfv.txt
+++ b/lib/domains/pe/edu/unfv.txt
@@ -1,0 +1,1 @@
+Universidad Nacional Federico Villarreal


### PR DESCRIPTION
This commit adds the domain `unfv.edu.pe` for Universidad Nacional Federico Villarreal in Peru.

Official website: https://www.unfv.edu.pe
Proof of academic affiliation available if needed.