### PR TITLE
Added TSI AUCA

### DIFF
--- a/lib/domains/kg/tsiauca.txt
+++ b/lib/domains/kg/tsiauca.txt
@@ -1,0 +1,1 @@
+Technical School of Innovation AUCA


### PR DESCRIPTION
Hi, Add TSI AUCA, please
the university official website URL:  https://tsiauca.kg/

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
description:
https://tsiauca.kg/software_engineering_and_social_transformations

courses:
https://ecourse.auca.kg/enrol/index.php?id=6706
https://ecourse.auca.kg/enrol/index.php?id=6704
https://ecourse.auca.kg/enrol/index.php?id=6683
https://ecourse.auca.kg/enrol/index.php?id=6752
https://ecourse.auca.kg/enrol/index.php?id=6707
https://ecourse.auca.kg/enrol/index.php?id=6737
https://ecourse.auca.kg/enrol/index.php?id=6741
https://ecourse.auca.kg/enrol/index.php?id=6742

but you cannot to see full course, because you need enrollment key and of NDA issues