### PR TITLE
Add Berufskolleg fuer Gestaltung und Technik Aachen

### DIFF
--- a/lib/domains/de/schueler-bkgut.txt
+++ b/lib/domains/de/schueler-bkgut.txt
@@ -1,3 +1,3 @@
 Berufskolleg für Gestaltung und Technik Aachen
 Vocational college for design and engineering, Aachen
-Student accounts
+Student Accounts


### PR DESCRIPTION
This commit adds the domain schueler-bkgut.de,
which is used for the student accounts of the institution "Berufskolleg fuer Gestaltung und Technik Aachen". The schools website can be reached at bkgut.de

Move to correct position