### PR TITLE
Add itb.edu.ec domain for Instituto Tecnológico Bolivariano de Ecuador

### DIFF
--- a/lib/domains/ec/edu/itb.txt
+++ b/lib/domains/ec/edu/itb.txt
@@ -1,0 +1,1 @@
+Instituto Tecnológico Bolivariano

--- a/lib/domains/ec/edu/itb.txt
+++ b/lib/domains/ec/edu/itb.txt
@@ -1,1 +1,3 @@
 Instituto Tecnológico Bolivariano
+
+Domain: @itb.edu.ec

--- a/lib/domains/ec/edu/itb.txt
+++ b/lib/domains/ec/edu/itb.txt
@@ -1,1 +1,0 @@
-Instituto Tecnológico Bolivariano


### PR DESCRIPTION
Añadido el dominio itb.edu.ec para el Instituto Tecnológico Bolivariano de Ecuador. Esto permitirá a los estudiantes acceder a las licencias educativas de JetBrains.