### PR TITLE
Add Chung-Ang University (cau.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
This pull request adds support for Chung-Ang University (중앙대학교) in South Korea.

- Domain: cau.ac.kr
- File path: lib/domains/kr/ac/cau.txt

The file follows the required structure for academic domain submissions as per JetBrains SWOT repository guidelines. Chung-Ang University is a recognized university offering undergraduate and graduate programs in Computer Science and related fields.

Thank you for reviewing this request.