### PR TITLE
Agregar dominio ucsm.edu.pe

### DIFF
--- a/lib/domains/pe/edu/UCSM.txt
+++ b/lib/domains/pe/edu/UCSM.txt
@@ -1,0 +1,1 @@
+Universidad Católica de Santa Maria

--- a/lib/domains/pe/edu/UCSM.txt
+++ b/lib/domains/pe/edu/UCSM.txt
@@ -1,1 +1,0 @@
-Universidad Católica de Santa Maria

--- a/lib/domains/pe/edu/ucsm.txt
+++ b/lib/domains/pe/edu/ucsm.txt
@@ -1,0 +1,1 @@
+Universidad Católica de Santa Maria


### PR DESCRIPTION
Este Pull Request agrega el dominio institucional "ucsm.edu.pe" correspondiente a la "Universidad Católica de Santa María" en Perú, para permitir que sus estudiantes y docentes puedan acceder a licencias educativas gratuitas de los productos JetBrains.

Información incluida en el archivo `lib/domains/pe/edu/ucsm.txt`:

- Nombre oficial: Universidad Católica de Santa María
- Nombre alternativo: UCSM
- Nombre en inglés: Catholic University of Santa María

Gracias por considerar esta solicitud.
