### PR TITLE
Add Karpagam Academy of Higher Education (kahedu.edu.in)

### DIFF
--- a/lib/domains/in/edu/kahedu.txt
+++ b/lib/domains/in/edu/kahedu.txt
@@ -1,0 +1,2 @@
+Karpagam Academy Of Higher Education
+Karpagam Academy Of Higher Education


### PR DESCRIPTION
Added the domain file for Karpagam Academy of Higher Education to support JetBrains student license.
