### PR TITLE
Añadir dominio cibertec.edu.pe para licencias educativas

### DIFF
--- a/lib/domains/pe/edu/cibertec.txt
+++ b/lib/domains/pe/edu/cibertec.txt
@@ -1,0 +1,2 @@
+IES CIBERTEC
+Cybertec Institute, Peru.


### PR DESCRIPTION
Este archivo añade el dominio de Cibertec para que los estudiantes puedan acceder a las licencias gratuitas de JetBrains.