### PR TITLE
Add domain aluno.educacao.sp.gov.br for educational license verification

### DIFF
--- a/file/lib/domains/br/gov/sp/educacao/aluno.txt
+++ b/file/lib/domains/br/gov/sp/educacao/aluno.txt
@@ -1,0 +1,1 @@
+E.E Amadeu Amaral


### PR DESCRIPTION
Adding the domain `aluno.educacao.sp.gov.br` to support students from public schools in São Paulo, Brazil, requesting JetBrains educational licenses.