### PR TITLE
 Add University of Ghana domain: stud.ug.edu.ghstud.txt

### DIFF
--- a/lib/domains/gh/edu/ug/stud.txt
+++ b/lib/domains/gh/edu/ug/stud.txt
@@ -1,0 +1,1 @@
+stud.ug.edu.gh


### PR DESCRIPTION
This adds the domain stud.ug.edu.gh for students of the University of Ghana to access JetBrains student licenses.
