### PR TITLE
Add dima.ac.kr (Dong-Ah Institute of Media and Arts)

### DIFF
--- a/lib/domains/kr/ac/dima.txt
+++ b/lib/domains/kr/ac/dima.txt
@@ -1,0 +1,3 @@
+동아방송예술대학교  
+https://www.dima.ac.kr  
+South Korea


### PR DESCRIPTION
동아방송예술대학교(dima.ac.kr)를 JetBrains 교육용 프로그램에 등록 요청합니다.
학교 도메인 기준에 따라 파일을 추가하였습니다.
감사합니다.