### PR TITLE
Add kyonggi university to the SWOT list

### DIFF
--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+kyonggi university


### PR DESCRIPTION

Hello.

Kyonggi University is not currently listed in the SWOT repository, which is used for verifying student status for JetBrains student licenses. To resolve this, I have added 'kyonggi.txt' to the repository.

Thank you for maintaining this useful resource!

- University: Kyonggi University (경기대학교)
- Domain: @kyonggi.ac.kr
- Added file: swot/lib/domains/ac/kr/kyonggi.txt