### PR TITLE
Add korea.ac.kr domain for Korea University Graduate School of Convergence Science and Technology

### DIFF
--- a/lib/domains/kr/ac/lib/domains/kr/ac/korea.txt
+++ b/lib/domains/kr/ac/lib/domains/kr/ac/korea.txt
@@ -1,0 +1,1 @@
+Korea University Graduate School of Convergence Science and Technology


### PR DESCRIPTION
Adding domain korea.ac.kr for Korea University Graduate School of Convergence Science and Technology

Official Website: https://gscst.korea.ac.kr

Proof: https://gscst.korea.ac.kr → Shows usage of korea.ac.kr email domain
