### PR TITLE
Add korea.ac.kr domain for Korea University Graduate School of Convergence Science and Technology

### DIFF
--- a/lib/domains/kr/ac/korea.txt
+++ b/lib/domains/kr/ac/korea.txt
@@ -1,1 +1,0 @@
-Korea University

--- a/lib/domains/kr/ac/korea.txt
+++ b/lib/domains/kr/ac/korea.txt
@@ -1,0 +1,1 @@
+Korea University Graduate School of Convergence Science and Technology

--- a/lib/domains/kr/ac/lib/domains/kr/ac/korea.txt
+++ b/lib/domains/kr/ac/lib/domains/kr/ac/korea.txt
@@ -1,1 +1,0 @@
-Korea University Graduate School of Convergence Science and Technology

--- a/lib/domains/kr/ac/lib/domains/kr/ac/korea.txt
+++ b/lib/domains/kr/ac/lib/domains/kr/ac/korea.txt
@@ -1,0 +1,1 @@
+Korea University Graduate School of Convergence Science and Technology


### PR DESCRIPTION
This PR adds the korea.ac.kr domain used by Korea University Graduate School of Convergence Science and Technology.

Official website: https://gscst.korea.ac.kr  
Email domain: korea.ac.kr
