### PR TITLE
Add eng.rizvi.edu.in domain for Rizvi College of Engineering, Mumbai

### DIFF
--- a/lib/domains/in/edu/rizvi/eng.txt
+++ b/lib/domains/in/edu/rizvi/eng.txt
@@ -1,0 +1,1 @@
+eng.rizvi.edu.in


### PR DESCRIPTION
This PR adds the domain `eng.rizvi.edu.in` for Rizvi College of Engineering, Mumbai (India). Students use this domain for their academic email accounts.

Official Website: https://eng.rizvi.edu.in/