### PR TITLE
Add gt/edu/url.txt for Universidad Rafael Landívar

### DIFF
--- a/lib/domains/gt/edu/url.txt
+++ b/lib/domains/gt/edu/url.txt
@@ -1,0 +1,2 @@
+Universidad Rafael Landívar
+URL


### PR DESCRIPTION
Domain: correo.url.edu.gt  
Official website:  https://principal.url.edu.gt/
Proof: https://principal.url.edu.gt/vriu/becas/
![proof](https://github.com/user-attachments/assets/cc2f9b75-d17b-47ef-8ec0-f1ae0dc1ac5c)