### PR TITLE
Add hufs.ac.kr (한국외국어대학교)

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk university of foreign studies


### PR DESCRIPTION
Adding Hankuk University of Foreign Studies to support JetBrains student license.
Domain: hufs.ac.kr