### PR TITLE
Add Universitas Mercu Buana (id/ac/mercubuana)

### DIFF
--- a/lib/domains/id/ac/mercubuana/student.txt
+++ b/lib/domains/id/ac/mercubuana/student.txt
@@ -1,0 +1,1 @@
+Universitas Mercubuana


### PR DESCRIPTION
* Add `lib/domains/id/ac/mercubuana/student.txt` with the line     “Universitas Mercubuana” to register the university’s student‑email   domain for the JetBrains Educational Pack. * Official site: https://www.mercubuana.ac.id     Student addresses follow the pattern `@student.mercubuana.ac.id`. * Universitas Mercu Buana is an accredited Indonesian university   (DIKTI BAN‑PT), so this addition meets the repository’s eligibility   requirements.