### PR TITLE
Add EICC community colleges to the list - live.eicc.edu

### DIFF
--- a/lib/domains/edu/eicc/live.txt
+++ b/lib/domains/edu/eicc/live.txt
@@ -1,0 +1,1 @@
+Eastern Iowa Community Colleges


### PR DESCRIPTION
This fork is to allow Eastern Iowa Community Colleges to the list comprising the @live.eicc.edu domain for student email addresses.

Official Website: https://eicc.edu
IT Courses: https://eicc.edu/classes-programs/pathway/information-solutions/programming/
Email Domain Information:  There isn't a good screenshot on any specific page to show the live.eicc.edu domain, but you can see in the email section that they are using Microsoft Live 365 which is why the sub-domain is live.eicc.edu.  More information here:  https://eicc.edu/eicc-for/current-students/accessing-eicc-accounts.aspx