### PR TITLE
Create ucsy.txt

### DIFF
--- a/lib/domains/ng/edu/ucsy.txt
+++ b/lib/domains/ng/edu/ucsy.txt
@@ -1,0 +1,1 @@
+University of Computer Studies, Yangon


### PR DESCRIPTION
Adds University of Computer Studies, Yangon (UCSY)

University official website: https://ucsy.edu.mm/

Proof of long-term IT-related course:
https://ucsy.edu.mm/page316.do

Proof that ucsy.edu.mm is the official student email domain:
Attached is a screenshot of an official email from the UCSY Training Affairs Office sent to my student address (banyaroo@ucsy.edu.mm).

The email format for students is: name@ucsy.edu.mm

Thank you!