### PR TITLE
Create ucsy.txt

### DIFF
--- a/lib/domains/mm/edu/ucsy.txt
+++ b/lib/domains/mm/edu/ucsy.txt
@@ -1,0 +1,1 @@
+University of Computer Studies, Yangon


### PR DESCRIPTION
Adds University of Computer Studies, Yangon (UCSY)

University official website: https://ucsy.edu.mm/

Proof of long-term IT-related course:
https://ucsy.edu.mm/page316.do

Proof that ucsy.edu.mm is the official student email domain:
Attached is a screenshot of an official email from the UCSY Training Affairs Office sent to my student address (banyaroo@ucsy.edu.mm).

![Screenshot_20250629-081516](https://github.com/user-attachments/assets/c7510e29-5acf-4d81-8369-4dbea920b53b)

The email format for students is: name@ucsy.edu.mm

Thank you!