### PR TITLE
Create biochem.txt

### DIFF
--- a/lib/domains/de/mpg/biochem.txt
+++ b/lib/domains/de/mpg/biochem.txt
@@ -1,0 +1,1 @@
+Max Planck Institute for Biochemistry


### PR DESCRIPTION
This is a request to add the domain biochem.mpg.de to the list. The Max Planck Institute for Biochemistry is located in Martinsreid outside Munich.
https://www.biochem.mpg.de/en
The institute hosts 20 research groups, each hosting between 2-20 PhD students. Enrolled students are assigned an email address with the format name@biochem.mpg.de. You can read more on the bottom of the institute IT page here: https://it.biochem.mpg.de/mail-video-conferencing/-/IT/service?tab=Mail