### PR TITLE
Add ENSIAS domain (um5.ac.ma)

### DIFF
--- a/lib/domains/ma/ac/um5.txt
+++ b/lib/domains/ma/ac/um5.txt
@@ -1,0 +1,2 @@
+École Nationale Supérieure d'Informatique et d'Analyse des Systèmes
+National School of Computer Science and Systems Analysis


### PR DESCRIPTION
Adding ENSIAS (École Nationale Supérieure d’Informatique et d’Analyse des Systèmes) domain for student license eligibility.