### PR TITLE
Add Cambridge College to JetBrains education institutions list

### DIFF
--- a/lib/domains/edu/cambridgecollege/go.txt
+++ b/lib/domains/edu/cambridgecollege/go.txt
@@ -1,0 +1,2 @@
+Cambridge College
+Cambridge College


### PR DESCRIPTION
Added Cambridge College educational institution according to JetBrains guidelines.