### PR TITLE
Add BFW Hamm to the respository

### DIFF
--- a/lib/domains/de/bfw-hamm.txt
+++ b/lib/domains/de/bfw-hamm.txt
@@ -1,0 +1,3 @@
+Berufsförderungswerk Hamm GmbH
+Berufsförderungswerk Hamm
+BFW Hamm

--- a/lib/domains/org/bfw-hamm.txt
+++ b/lib/domains/org/bfw-hamm.txt
@@ -1,0 +1,3 @@
+Berufsförderungswerk Hamm GmbH
+Berufsförderungswerk Hamm
+BFW Hamm


### PR DESCRIPTION
We kindly ask via this request to add our Berufsförderungswerk Hamm GmbH to the list of recognised domains.
There are already other German BFWs on this list like BFW Dortmund, Köln and Oberhausen.

Translated from our official web page:
"Berufsfoerderungswerke were established to support employees who can no longer continue their previous professional activities due to health reasons, helping them return to work. These health reasons can be physical or psychological, arising from illness or accident consequences. The Social Code IX provides "services for participation in working life" for these individuals, aiming to reintegrate them into work through close support and requalification, such as retraining.

Our retraining programs are conducted in an inter-company format, combining theoretical and practical training at our facility, supplemented by practical learning phases in a company of your choice. Alternatively, a company-based retraining is possible, allowing you to train in a local company in your desired profession."

Please see: https://bfw-hamm.de for further information.
Please see this page for our courses including the "IT-Systemelektroniker" (two year retraining):  https://bfw-hamm.de/umschulung

The two domains are registered to us and are both linked to our website and to corresponding mail services (.de for staff members and .org for students and staff members including teachers).