### PR TITLE
Add Chung-Ang University

### DIFF
--- a/lib/domains/kr/ac/cau/student.txt
+++ b/lib/domains/kr/ac/cau/student.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
- the university official website URL: https://neweng.cau.ac.kr/index.do
- IT related course URL: https://neweng.cau.ac.kr/cms/FR_CON/index.do?MENU_ID=990 & https://neweng.cau.ac.kr/cms/FR_CON/index.do?MENU_ID=770
- official email domain URL: https://neweng.cau.ac.kr/cms/FR_CON/index.do?MENU_ID=500