### PR TITLE
Add uca.ac.ma domainCreate uca.txt

### DIFF
--- a/lib/domains/ma/ac/uca.txt
+++ b/lib/domains/ma/ac/uca.txt
@@ -1,0 +1,1 @@
+uca.ac.ma


### PR DESCRIPTION
Adding Université Cadi Ayyad domain (uca.ac.ma) to support JetBrains student license requests.
