### PR TITLE
Add VKU email domain (vku.udn.vn)

### DIFF
--- a/lib/domains/vn/udn/vku/vku.txt
+++ b/lib/domains/vn/udn/vku/vku.txt
@@ -1,0 +1,2 @@
+Trường Đại học CNTT & Truyền thông Việt – Hàn - Đại học Đà Nẵng
+Vietnam - Korea University of Information and Communication Technology - The University of Danang


### PR DESCRIPTION
This pull request adds the email domain `vku.udn.vn` for VKU - Vietnam-Korea University of Information and Communication Technology, under the University of Danang (UDN), Vietnam.

The file `lib/domains/vn/udn/vku.txt` contains the full name of the university to support domain verification for JetBrains Student Pack and other education services.

Thank you for your consideration.
