### PR TITLE
Added King Mongkut's Institute of Technology Ladkrabang (kmitl.ac.th)

### DIFF
--- a/lib/domains/th/ac/kmitl.txt
+++ b/lib/domains/th/ac/kmitl.txt
@@ -1,0 +1,2 @@
+สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง
+King Mongkut's Institute of Technology Ladkrabang


### PR DESCRIPTION
## University Information
**Domain:** kmitl.ac.th
**University:** King Mongkut's Institute of Technology Ladkrabang (KMITL) **Country:** Thailand
**Official Website:** https://www.kmitl.ac.th/

## IT-Related Programs Offered (Bachelor's Degree - 4 years) KMITL offers numerous IT-related engineering and science programs:

### Engineering Programs:
- **Software Engineering** - https://se.kmitl.ac.th/
- **Computer Engineering** - https://cei.kmitl.ac.th/
- **Biomedical Engineering** with IT components
- **AI Engineering and Entrepreneurship**
- **Electrical Engineering** - http://www.ee.kmitl.ac.th/
- **Robotics and Artificial Intelligence Engineering**

### Science Programs:
- **Digital Technology and Integrated Innovation** - https://inter.science.kmitl.ac.th/

### International Programs:
- **Software Engineering International Program** (partnership with University of Glasgow)
- **Computer Engineering International Program**

## International Partnerships
- **University of Glasgow (UK)** - Double degree program in Software Engineering
- **Carnegie Mellon University (USA)** - CMKL collaboration for graduate programs

## Domain Usage Proof
- Student email format: [student_id]@kmitl.ac.th (e.g., 65010260@kmitl.ac.th)
- Faculty email format: [name]@kmitl.ac.th
- Official contact: pr.kmitl@kmitl.ac.th
- IT Department: undergrad@it.kmitl.ac.th

## Additional Information
- KMITL is a public institute under the Thai Ministry of Higher Education
- Established institution with strong reputation in engineering and technology
- Offers both Thai and English-taught programs
- The domain kmitl.ac.th is exclusively used for enrolled students, faculty, and staff

All programs mentioned are accredited 4-year degree programs that meet the repository's requirements for IT-related education. not fraud  