### PR TITLE
Add University of Nigeria, Nsukka (unn.edu.ng)

### DIFF
--- a/lib/domains/ng/edu/unn.txt
+++ b/lib/domains/ng/edu/unn.txt
@@ -1,0 +1,2 @@
+University of Nigeria, Nsukka
+University of Nigeria, Nsukka


### PR DESCRIPTION
This pull request adds the domain unn.edu.ng for University of Nigeria, Nsukka to the list of academic institutions.
Email used: chukwuma.ohadoma.242261@unn.edu.ng