### PR TITLE
Add Uniwersytet Opolski domain (pl/opole/uni/cs)

### DIFF
--- a/lib/domains/pl/opole/uni/cs/student.txt
+++ b/lib/domains/pl/opole/uni/cs/student.txt
@@ -1,0 +1,1 @@
+Uniwersytet Opolski


### PR DESCRIPTION
This pull request adds the domain of Uniwersytet Opolski (Department of Computer Science) to the JetBrains educational institutions list. I am a student of Informatics at Uniwersytet Opolski and would like to apply for a free JetBrains student license.

The domain structure is: pl/opole/uni/cs/student.txt 
(student.uni.opole.pl)

