### PR TITLE
Add rupp.edu.kh (Royal University of Phnom Penh)

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,2 @@
+សាកលវិទ្យាល័យភូមិន្ទភ្នំពេញ
+Royal University of Phnom Penh (RUPP)


### PR DESCRIPTION
Added rupp.txt file under lib/domains/kh/edu based on JetBrains instructions
to support student email domain of Royal University of Phnom Penh.
