### PR TITLE
Add rupp domain for Royal university of phnom penh

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,1 @@
+Royal university of phnom penh


### PR DESCRIPTION
Hello JetBrains Team,

I would like to request the addition of Royal University of Phnom Penh (RUPP) to your list of recognized institutions for the JetBrains Student Pack.

University Name: Royal University of Phnom Penh
Official Website: https://www.rupp.edu.kh/
Country: Cambodia

RUPP is the oldest and largest public university in Cambodia, offering a wide range of undergraduate and postgraduate programs in science, technology, education, and the humanities. Many students and developers at RUPP are actively involved in software engineering and IT, and access to JetBrains tools would greatly support their learning and development.

Thank you for considering this request!

Best regards,
**SOKHORN KHY**