### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/ch/kbz-zug.txt
+++ b/lib/domains/ch/kbz-zug.txt
@@ -1,0 +1,2 @@
+Kaufmännisches Bildungszentrum Zug
+KBZ Zug


### PR DESCRIPTION
Add kbz-zug.ch as official educational domain
Domain submitted: kbz-zug.ch

Official school name:
- Kaufmännisches Bildungszentrum Zug (KBZ Zug)

Official website:
- https://www.kbz-zug.ch

IT-related long-term program (min. 1 year):
- https://www.kbz-zug.ch/bildungsangebot/berufsbildung/ict-fachmann-frau-efz/

Proof that students use the domain kbz-zug.ch:
- Student email addresses follow the format: vorname.nachname@365.kbz-zug.ch
- Email usage is internally confirmed by the school

Thank you for reviewing this request!
