### PR TITLE
Add paf-iast.edu.pk domain for Pak-Austria Fachhochschule Institute o…

### DIFF
--- a/lib/domains/pk/edu/paf-iast/paf-iast.txt
+++ b/lib/domains/pk/edu/paf-iast/paf-iast.txt
@@ -1,0 +1,1 @@
+Pak-Austria Fachhochschule Institute of Applied Sciences and Technology


### PR DESCRIPTION
…f Applied Sciences and Technology

University: Pak-Austria Fachhochschule Institute of Applied Sciences and Technology (PAF-IAST)

Official website: https://www.paf-iast.edu.pk/

Proof of long-term IT-related course:
https://www.paf-iast.edu.pk/software-engineering/


This domain is used by enrolled students and staff, and the university offers accredited degree programs in computer science and software engineering that span more than one year.

Thank you for reviewing this request!