### PR TITLE
Add Unirios

### DIFF
--- a/lib/domains/com/uniriosead.txt
+++ b/lib/domains/com/uniriosead.txt
@@ -1,0 +1,1 @@
+Centro Universitário do Rio São Francisco, UNIRIOS


### PR DESCRIPTION
Adding Brazilian university, from the interior of northeastern Brazil. Verify on site www.unirios.edu.br