### PR TITLE
Add alumnos.ui1.com domain for Universidad Isabel I

### DIFF
--- a/lib/domains/com/ui1/alumnos.txt
+++ b/lib/domains/com/ui1/alumnos.txt
@@ -1,0 +1,1 @@
+Universidad Isabel I


### PR DESCRIPTION
This PR adds the domain `alumnos.ui1.com` used by students of Universidad Isabel I (UI1) to request free educational licenses for JetBrains products.

- ✅ Official university website: https://www.ui1.es
- ✅ Domain used for student emails: `nombre.apellido@alumnos.ui1.com`
- ✅ File generated using the JetBrains Student Verification ZIP tool.

###  Proof of domain usage


![image](https://github.com/user-attachments/assets/f0909702-d6db-4aff-aa39-07109c77bfe3)



---

Thank you for considering this request. Please let me know if additional information is required.