### PR TITLE
Create BAU.txt

### DIFF
--- a/lib/domains/jo/edu/BAU.txt
+++ b/lib/domains/jo/edu/BAU.txt
@@ -1,0 +1,1 @@
+AL-Balqa Applied University


### PR DESCRIPTION
AL-Balqa Applied University
AL-Balqa Applied University

Official school name:

    AL-Balqa Applied University

Official website:

    https://bau.edu.jo

IT-related long-term program (min. 1 year):

    https://www.bau.edu.jo/bauar/Colleges/IT/Home.aspx

Proof that students use the domain https://bau.edu.jo:
	Teacher email adresses follow the format : name@bau.edu.jo
    Student email addresses follow the format: std_id_number@std.bau.edu.jo
    Email usage is internally confirmed by the school