### PR TITLE
Add Edubridge International School domain

### DIFF
--- a/lib/domains/org/edubridgeschool.txt
+++ b/lib/domains/org/edubridgeschool.txt
@@ -1,0 +1,1 @@
+Edubridge International School


### PR DESCRIPTION
This pull request adds `edubridgeschool.org` to the JetBrains SWoT repository.

- School name: Edubridge International School
- Website: https://edubridgeschool.org
- Email domain proof: edubridgeschool.org (provided via JetBrains school file)