### PR TITLE
feat: add domain for AUST university in Lebanon

### DIFF
--- a/lib/domains/lb/edu/aust/students.txt
+++ b/lib/domains/lb/edu/aust/students.txt
@@ -1,0 +1,2 @@
+American University of Science and Technology
+American University of Science and Technology


### PR DESCRIPTION
This PR adds the email domain name for the "American University of Science and Technology" (AUST) located in Lebanon.

**Official website:** https://www.aust.edu.lb/
**University email sample:** <fullname_initials><digits>@students.aust.edu.lb

Please let me know if you require additional information.