### PR TITLE
Add ifts24.edu.ar to JetBrains educational domains

### DIFF
--- a/lib/domains/ar/edu/ifts24.txt
+++ b/lib/domains/ar/edu/ifts24.txt
@@ -1,0 +1,1 @@
+Instituto de Formación Técnica Superior N° 24


### PR DESCRIPTION
This pull request adds the domain `ifts24.edu.ar` to the list of recognized educational institutions.

**Institution name:** Instituto de Formación Técnica Superior N.º 24  
**Website:** https://www.ifts24.edu.ar  
**Official domain used by students and staff:** ifts24.edu.ar  

**Justification:**
- IFTS N.º 24 is a public higher education institution located in Buenos Aires, Argentina.
- Students and teachers use email addresses under the `@ifts24.edu.ar` domain.
- You can verify the institution’s official website at https://www.ifts24.edu.ar.
- Contact emails such as `bedelia@ifts24.edu.ar` or `soportecampus@ifts24.edu.ar` are visible on the site.

This addition will allow students from IFTS N.º 24 to apply for free JetBrains educational licenses.