### PR TITLE
Add Kyonggi University

### DIFF
--- a/lib/domains/kr/ac/kyonggi.txt
+++ b/lib/domains/kr/ac/kyonggi.txt
@@ -1,0 +1,2 @@
+경기대학교
+Kyonggi University


### PR DESCRIPTION
Dear JetBrains Team,

Please add Kyonggi University (South Korea) to your educational institutions list for student licensing.

- Name: Kyonggi University
- Domain: kyonggi.ac.kr
- Official website: https://www.kyonggi.ac.kr
- IT course: https://www.kyonggi.ac.kr/u_computer/index.do (Computer Science Department)
- Email domain proof: https://sites.google.com/kyonggi.ac.kr/help#:~:text=@kyonggi.ac.kr

This will help our students access JetBrains educational licenses for their studies.
Thanks!