### PR TITLE
Add UTP domain

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+UTP


### PR DESCRIPTION
- Example of domain name used by Universidad Tecnológica del Perú (UTP): studentcode@utp.edu.pe
- University website link: https://www.utp.edu.pe/

**Evidence:**

1. **Screenshot from UTP website:**
<img width="1919" height="918" alt="Captura de pantalla 2025-07-10 214636" src="https://github.com/user-attachments/assets/2e369215-d9c0-40d7-9062-6f4ed0f0bad9" />

2. **My A2 MCER - UTP certificate as a Software Engineer student:**
[Certificado Inglés A2 MCER - UTP.pdf](https://github.com/user-attachments/files/21174105/Certificado.Ingles.A2.MCER.-.UTP.pdf)
