### PR TITLE
Add Sungkyunkwan University

### DIFF
--- a/lib/domains/edu/skku.txt
+++ b/lib/domains/edu/skku.txt
@@ -1,0 +1,2 @@
+성균관대학교
+Sungkyunkwan University


### PR DESCRIPTION
### University/School Name
Sungkyunkwan University

### Domain
skku.edu

### Official Website
https://www.skku.edu

### Email Proof
An email address using the `@skku.edu` domain is issued to all enrolled students at Sungkyunkwan University.  
Example: `s2025xxxx@skku.edu`

### Additional Information
Sungkyunkwan University is one of the oldest and most prestigious universities in South Korea.  
Adding the `skku.edu` domain will allow its students to access JetBrains Student Pack benefits.

### Reference
If required, I can provide proof of enrollment or screenshots of a student email inbox.
