### PR TITLE
Adding ITI Faccio Vercelli - Italy

### DIFF
--- a/lib/domains/it/itisvc.txt
+++ b/lib/domains/it/itisvc.txt
@@ -1,0 +1,1 @@
+ITI G.C. FACCIO


### PR DESCRIPTION
Adding ITI Faccio from Vercelli - Italy
School web site https://nuke.itisvc.it