### PR TITLE
Add Techspire College

### DIFF
--- a/lib/domains/np/edu/cps.txt
+++ b/lib/domains/np/edu/cps.txt
@@ -1,0 +1,1 @@
+Techspire College


### PR DESCRIPTION
1. University URL: https://www.apu.edu.my/
2. College URL: https://techspire.edu.np
3. URL to course: https://techspire.edu.np/BscCsit-program

Note: Previously the college name was College for Professional Studies which was later acquired by new team renaming and branding it to Techspire college which resulted in the difference of domain name and college name. For verification please visit URL: https://cps.edu.np, which will redirect to college URL i.e., https://techspire.edu.np