### PR TITLE
Add Daejin University Korean name

### DIFF
--- a/lib/domains/kr/ac/daejin.txt
+++ b/lib/domains/kr/ac/daejin.txt
@@ -1,0 +1,2 @@
+대진대학교
+Daejin University


### PR DESCRIPTION
Hi,

This pull request adds the Korean name of Daejin University to the corresponding domain file.
- File modified: `lib/domains/kr/ac/daejin.txt`
- Added line: 대진대학교

This helps JetBrains products display the university name correctly in localized environments.

Thank you for your great work maintaining this project!
