### PR TITLE
Add my university

### DIFF
--- a/lib/domains/eg/edu/bu/fci.txt
+++ b/lib/domains/eg/edu/bu/fci.txt
@@ -1,0 +1,2 @@
+كلية الحاسبات و الذكاء الاصطناعي جامعة بنها - computer science and artificial intelligence at banha university
+Faculty of Computers and Artificial Intelligence, Benha University


### PR DESCRIPTION
This pull request adds support for the student email domain `fci.bu.edu.eg`, which belongs to the Faculty of Computers and Information at Benha University in Egypt.

The added file follows the required domain structure:
`lib/domains/eg/edu/bu/fci.txt`

This domain is used for student email addresses, and adding it will allow students from this faculty to apply for free educational licenses for JetBrains products.

Thank you for your consideration.
