### PR TITLE
Add Universidad Tecnológica del Perú (utp.edu.pe)

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica del Perú


### PR DESCRIPTION
This pull request adds support for the Universidad Tecnológica del Perú by including its domain (`utp.edu.pe`) under the `lib/domains/pe/edu/` directory.

- File added: `lib/domains/pe/edu/utp.txt`
- Purpose: To allow students and staff from UTP to apply for JetBrains educational licenses.

Please let me know if any additional information or verification is needed.

Thank you!
