### PR TITLE
Add domain sejong.ac.kr for Sejong University

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+sejong university


### PR DESCRIPTION
1) university homepage : 
https://www.sejong.ac.kr/kor/index.do

2)URL proving a long-term (1+ year) IT-related academic program :
https://www.sejong.ac.kr/kor/college/college-of-software-convergence.do

3) image
<img width="1456" height="908" alt="Screenshot 2025-07-15 at 9 49 46 AM" src="https://github.com/user-attachments/assets/9d41e62b-2278-416b-8ca1-9a784142fd23" />

