### PR TITLE
Add INSEA (Morocco)

### DIFF
--- a/lib/domains/ac/lib/domains/ma/ac/insea/insea.txt
+++ b/lib/domains/ac/lib/domains/ma/ac/insea/insea.txt
@@ -1,0 +1,1 @@
+insea.ac.ma


### PR DESCRIPTION
Added the domain insea.ac.ma for Institut National de Statistique et d'Économie Appliquée (INSEA), Morocco, to support JetBrains Student License Program.
