### PR TITLE
Add eng.asu.edu.eg domain for Ain Shams University

### DIFF
--- a/lib/domains/eg/edu/asu/eng.txt
+++ b/lib/domains/eg/edu/asu/eng.txt
@@ -1,0 +1,1 @@
+Faculty of Engineering – Ain Shams University


### PR DESCRIPTION
This pull request adds `eng.asu.edu.eg` for Ain Shams University.

- Official website: https://eng.asu.edu.eg/

<img width="902" height="440" alt="image" src="https://github.com/user-attachments/assets/e36730c6-4115-49e9-8c0b-b9f77b96c095" />
