### PR TITLE
Move tsinglan.txt to org

### DIFF
--- a/lib/domains/cn/tsinglan.txt
+++ b/lib/domains/cn/tsinglan.txt
@@ -1,2 +1,0 @@
-清阑山学校
-Tsinglan School

--- a/lib/domains/org/tsinglan.txt
+++ b/lib/domains/org/tsinglan.txt
@@ -1,0 +1,2 @@
+清澜山学校
+Tsinglan Schol


### PR DESCRIPTION
Tsinglan School recently changed its official email domain to tsinglan.org.

Official Website URL: https://www.tsinglan.cn/
other proof:
<img width="1800" height="993" alt="Screenshot 2025-07-16 at 23 34 24" src="https://github.com/user-attachments/assets/8c1a1098-fc98-4e3b-b45f-376389286169" />
The ‘Email' on the bottom navigator has already switched to @tsinglan.org, and all the contact emails on the website have already changed.