### PR TITLE
Add ICTU - Thai Nguyen University (ictu.edu.vn)

### DIFF
--- a/lib/domains/edu/vn/ictu.txt
+++ b/lib/domains/edu/vn/ictu.txt
@@ -1,0 +1,1 @@
+ictu.edu.vn

--- a/lib/domains/vn/edu/ictu.txt
+++ b/lib/domains/vn/edu/ictu.txt
@@ -1,0 +1,2 @@
+Trường Đại học Công nghệ Thông tin và Truyền thông – Đại học Thái Nguyên
+University of Information and Communication Technology – Thai Nguyen University


### PR DESCRIPTION
This PR adds the domain ictu.edu.vn for Thai Nguyen University of Information and Communication Technology (ICTU) to the list of recognized academic institutions.
