### PR TITLE
Add kssem.edu.in (K.S. School of Engineering and Management)

### DIFF
--- a/lib/domains/in/edu/kssem.txt
+++ b/lib/domains/in/edu/kssem.txt
@@ -1,0 +1,1 @@
+K S School of Engineering and Management


### PR DESCRIPTION
Institution Name: K.S. School of Engineering and Management
Domain: kssem.edu.in

This domain is used by students and faculty of K.S. School of Engineering and Management, Bengaluru, India.

Official website: https://kssem.edu.in/
Proof: https://kssem.edu.in/contact — shows faculty email using @kssem.edu.in domain (e.g., principal@kssem.edu.in)

Please consider adding this domain to the JetBrains student email whitelist. Thank you!