### PR TITLE
Add o365.chsu.ac.kr domain for Chungbuk Health & Science University

### DIFF
--- a/lib/domains/kr/ac/chsu/o365.txt
+++ b/lib/domains/kr/ac/chsu/o365.txt
@@ -1,0 +1,2 @@
+충북보건과학대학교북보건과학대학교
+Chungbuk Health & Science University


### PR DESCRIPTION
This commit adds the domain o365.chsu.ac.kr to support student email addresses for Chungbuk Health & Science University (충북보건과학대학교).

The files were generated via the JetBrains school domain request form.
