### PR TITLE
add domain for BAEKSEOK University 

### DIFF
--- a/lib/domains/kr/ac/bu.txt
+++ b/lib/domains/kr/ac/bu.txt
@@ -1,0 +1,2 @@
+백석대학교
+BAEKSEOK UNIVERSITY


### PR DESCRIPTION
This commit adds the domain bu.ac.kr to support student email addresses for BAEKSEOK University (백석대학교).

The files were generated via the JetBrains school domain request form.