### PR TITLE
Add rupp.edu.kh domain for Royal University of Phnom Penh

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,1 @@
+Royal University of Phnom Penh


### PR DESCRIPTION
This PR adds the rupp.edu.kh domain to the swot repository to support students from Royal University of Phnom Penh.
