### PR TITLE
DKTE Society's Textile and Engineering Institute

### DIFF
--- a/lib/domains/in/dkte.txt
+++ b/lib/domains/in/dkte.txt
@@ -1,0 +1,1 @@
+DKTE Society's Textile and Engineering Institute


### PR DESCRIPTION
PR for adding dkte.in domain
Official URL of university: https://www.dkte.ac.in/
URL of IT and CS related department: https://www.dkte.ac.in/under-graduate/engineering-department