### PR TITLE
Add aabu.edu.jo for Al al-Bayt University

### DIFF
--- a/lib/domains/jo/edu/aabu.txt
+++ b/lib/domains/jo/edu/aabu.txt
@@ -1,0 +1,2 @@
+الجامعة آل البيت
+Al al-Bayt University


### PR DESCRIPTION
This pull request adds Al al-Bayt University (aabu.edu.jo) to the list of recognized educational domains for JetBrains student and teacher licenses.