### PR TITLE
Add Royal University of Phnom Penh

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,1 @@
+Royal University of Phnom Penh


### PR DESCRIPTION
PR for adding Royal University of Phnom Penh
Official URL of university: https://www.rupp.edu.kh/