### PR TITLE
Add Erasmus Universiteit Rotterdam (eur.nl) domain

### DIFF
--- a/lib/domains/nl/eur.txt
+++ b/lib/domains/nl/eur.txt
@@ -1,0 +1,2 @@
+Erasmus Universiteit Rotterdam
+Erasmus University Rotterdam


### PR DESCRIPTION
Add domain for Erasmus Universiteit Rotterdam (eur.nl)

- **University official website:** https://www.eur.nl/
- **Example IT-related course:** https://www.eur.nl/ese/onderwijs/master/msc-business-analytics-management
- **Proof of student email domain:** https://www.eur.nl/en/campus/ict-education/email  
  (see "All students get a personal EUR email address, ending in @eur.nl")

The domain eur.nl is the official email domain for all students enrolled at Erasmus Universiteit Rotterdam.
