### PR TITLE
Add BINUS University Domain

### DIFF
--- a/lib/domains/id/ac/binus.txt
+++ b/lib/domains/id/ac/binus.txt
@@ -1,0 +1,2 @@
+BINUS University
+BINUS University


### PR DESCRIPTION
Binus University has more than one domain.
It's has:
@binusian.org and @binus.ac.id

Website: https://binus.ac.id/