### PR TITLE
Adding Bharati Vidyapeeth (Deemed to Be University), Pune to the list

### DIFF
--- a/lib/domains/in/edu/bvp.txt
+++ b/lib/domains/in/edu/bvp.txt
@@ -1,0 +1,1 @@
+Bharati Vidyapeeth (Deemed to Be University), Pune


### PR DESCRIPTION
Please add Bharati Vidyapeeth (Deemed to Be University), Pune to the list of educational institutes to provide the learning opportunities.