### PR TITLE
Add Tiga Serangkai University (tsu.ac.id)

### DIFF
--- a/lib/domains/id/ac/tsu.txt
+++ b/lib/domains/id/ac/tsu.txt
@@ -1,0 +1,2 @@
+Tiga Serangkai University
+Tiga Serangkai University


### PR DESCRIPTION
Pull request to include Tiga Serangkai University education email with domain `tsu.ac.id` by adding the required file to the `JetBrains/swot` repositories for free JetBrains education licenses. Additional information to expedite the process:
- Official website => https://tsu.ac.id/
- Official website page for IT programs => https://tsu.ac.id/fakultas-teknik/
- Screenshot of Tiga Serangkai University education email:
<img width="497" height="465" alt="image" src="https://github.com/user-attachments/assets/0f6882dd-3525-4736-bdfd-c4a4ac864dec" />
