### PR TITLE
Add Université Cheikh Anta Diop de Dakar (ucad.edu.sn)

### DIFF
--- a/lib/domains/sn/edu/ucad.txt
+++ b/lib/domains/sn/edu/ucad.txt
@@ -1,0 +1,2 @@
+Université Cheikh Anta Diop de Dakar
+Cheikh Anta Diop University of Dakar


### PR DESCRIPTION
Institution: Université Cheikh Anta Diop de Dakar
Official website: https://www.ucad.sn

The institution provides long-term courses in IT and computer science programs.
Students and staff use email addresses under the domain: ucad.edu.sn

Proof:
- Official website: https://www.ucad.sn
- Example of email domain usage: ucad.edu.sn (used for institutional emails)

Please add this domain to the JetBrains educational program whitelist.