### PR TITLE
Adding udc.edu.ar

### DIFF
--- a/lib/domains/ar/edu/udc.txt
+++ b/lib/domains/ar/edu/udc.txt
@@ -1,0 +1,1 @@
+Universidad del Chubut


### PR DESCRIPTION
Agregar dominio `udc.edu.ar` correspondiente a la Universidad del Chubut.

- 🌐 Sitio web oficial: https://udc.edu.ar/
- 📚 Curso relacionado con IT: Tecnicatura Universitaria en Desarrollo de Software
  - https://udc.edu.ar/carreras/desarrollo-de-software/
- 📧 Confirmación del dominio: El sitio oficial usa el dominio `udc.edu.ar` y los correos institucionales también (ej: contacto@udc.edu.ar)

Nombre en el archivo: Universidad del Chubut