### PR TITLE
Add domain cibertec.edu.pe for JetBrains student license

### DIFF
--- a/lib/domains/pe/edu/cibertec/cibertec.txt
+++ b/lib/domains/pe/edu/cibertec/cibertec.txt
@@ -1,0 +1,2 @@
+Cibertec
+Cibertec Institute of Technology

--- a/lib/domains/pe/edu/cibertec/placeholder.txt
+++ b/lib/domains/pe/edu/cibertec/placeholder.txt
@@ -1,0 +1,1 @@
+Este archivo es solo para crear la ruta de carpetas.


### PR DESCRIPTION
This pull request adds the domain cibertec.edu.pe for students of Cibertec to be eligible for the JetBrains student license.
