### PR TITLE
Add Universidad Pedagógica y Tecnológica de Colombia (uptc.edu.co)

### DIFF
--- a/lib/domains/co/edu/uptc.txt
+++ b/lib/domains/co/edu/uptc.txt
@@ -1,0 +1,1 @@
+Universidad Pedagógica y Tecnológica de Colombia


### PR DESCRIPTION
Add Pedagogical and Technological University of Colombia to the JetBrains/swot domains list

This change registers the institutional domain `uptc.edu.co`, enabling UPTC students to automatically qualify for the JetBrains Educational license.

- Added domain: uptc.edu.co  
- Official website: https://www.uptc.edu.co/ 
