### PR TITLE
Add Te Wananga o Aotearoa (akonga.twoa.ac.nz)

### DIFF
--- a/lib/domains/nz/ac/twoa/akonga.txt
+++ b/lib/domains/nz/ac/twoa/akonga.txt
@@ -1,0 +1,1 @@
+Te Wananga o Aotearoa


### PR DESCRIPTION
Added akonga.txt file to support student domain of Te Wananga o Aotearoa.
