### PR TITLE
feat: add usal.es domain

### DIFF
--- a/lib/domains/es/usal.txt
+++ b/lib/domains/es/usal.txt
@@ -1,0 +1,2 @@
+Universidad de Salamanca
+University of Salamanca


### PR DESCRIPTION
This pull request adds entries to the `lib/domains/es/usal.txt` file to include the names of the University of Salamanca in both Spanish and English.

* [`lib/domains/es/usal.txt`](diffhunk://#diff-fecc33e061749a2532796c2238b0da3f682e4438f59d71ddadad8e4a2e75e68fR1-R2): Added "Universidad de Salamanca" and "University of Salamanca" to the file.