### PR TITLE
Add Sekolah Tinggi Ilmu Komputer Yos Sudarso

### DIFF
--- a/lib/domains/id/ac/stikomyos/student.txt
+++ b/lib/domains/id/ac/stikomyos/student.txt
@@ -1,0 +1,1 @@
+Sekolah Tinggi Ilmu Komputer Yos Sudarso


### PR DESCRIPTION
Menambahkan domain stikomyos.ac.id ke dalam daftar institusi pendidikan untuk mendukung permintaan lisensi pelajar JetBrains.