### PR TITLE
Add BCCIS (bccis.ca) for JetBrains educational license

### DIFF
--- a/lib/domains/ca/bccis.txt
+++ b/lib/domains/ca/bccis.txt
@@ -1,0 +1,2 @@
+(BCCIS) British Columbia Canadian International School
+British Columbia Canadian International School


### PR DESCRIPTION
Added bccis.txt to support British Columbia Canadian International School's domain.
