### PR TITLE
Add g.skku.edu domain for Sungkyunkwan University

### DIFF
--- a/lib/domains/edu/skku/g.txt
+++ b/lib/domains/edu/skku/g.txt
@@ -1,0 +1,1 @@
+Sungkyunkwan University, Republic of Korea


### PR DESCRIPTION
University: Sungkyunkwan University (성균관대학교)
Domain: g.skku.edu
Official website: https://www.skku.edu/eng/
student email: [jg000065@g.skku.edu](mailto:jg000065@g.skku.edu)