### PR TITLE
Add Noida Institute of Engineering and Technology

### DIFF
--- a/lib/domains/in/co/niet.txt
+++ b/lib/domains/in/co/niet.txt
@@ -1,0 +1,1 @@
+Noida Institute of Engineering and Technology


### PR DESCRIPTION
This commit adds NIET (Noida Institute of Engineering and Technology) to the JetBrains swot repository for academic email domain verification.

Domain: niet.co.in  
Used for: student email addresses like 0231cys014@niet.co.in  
Purpose: To enable students to access free JetBrains educational licenses.