### PR TITLE
Added singimail domain

### DIFF
--- a/lib/domains/rs/singimail.txt
+++ b/lib/domains/rs/singimail.txt
@@ -1,0 +1,1 @@
+Univerzitet Singidunum


### PR DESCRIPTION
I see that the singimail.rs domain was removed in the following [commit (ad8f7b7)](https://github.com/JetBrains/swot/commit/ad8f7b7da1a0d755862ed053ee301aa279a98962). However, this is still a valid domain actively used by students of Singidunum University - I personally received this email address from the university and continue to use it