### PR TITLE
university of bologna unibo.it domain

### DIFF
--- a/lib/domains/it/unibo.txt
+++ b/lib/domains/it/unibo.txt
@@ -1,0 +1,2 @@
+Università di Bologna - Italy
+University of Bologna - Italy


### PR DESCRIPTION
add unibo.it domain (University of Bologna - italy)