### PR TITLE
 Add alunos.escolasobidos.net domain for JetBrains student licenses

### DIFF
--- a/lib/domains/net/escolasobidos/alunos.txt
+++ b/lib/domains/net/escolasobidos/alunos.txt
@@ -1,0 +1,2 @@
+Escola Basica e Secundaria Josefa de Obidos
+Basic and Secondary School Josefa de Óbidos


### PR DESCRIPTION
Adding the domain alunos.escolasobidos.net for Escola Básica e Secundária Josefa de Óbidos.

- Official website: https://escolasdobidos.com/website/
- The school offers long-term courses including IT-related subjects.
- The domain is used officially for student emails.

Thank you for reviewing!
