### PR TITLE
Add Sejong University

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
I hope this message finds you well.

I am writing to request the addition of my university, Sejong University, to the list of recognized institutions for JetBrains student verification.

- University Name: Sejong University
- Official Website: https://www.sejong.ac.kr/
- Student Email Domain: @sju.ac.kr

Sejong University is a fully accredited higher education institution in South Korea. Our university provides official student email addresses and student ID cards, meeting the eligibility requirements for the JetBrains Student License Program.

Many students at Sejong University actively use JetBrains tools for learning and development, and official support would greatly enhance our academic experience.

Please let me know if you need any additional documentation or confirmation.

Thank you for your time and consideration.