### PR TITLE
Add Universidad Nacional de Colombia (unal.edu.co)

### DIFF
--- a/lib/domains/co/edu/unal.txt
+++ b/lib/domains/co/edu/unal.txt
@@ -1,0 +1,1 @@
+Universidad Nacional de Colombia


### PR DESCRIPTION
# University Official URL:
[https://unal.edu.co/](https://unal.edu.co/)

## IT Major Long Term URL:
Computer Science / Ingeniería de Sistemas y Computación

## Proof that shows that the University recognizes the domain:
You can verify that the domain `unal.edu.co` is officially used by the Universidad Nacional de Colombia by visiting their homepage:  
➡️ [https://unal.edu.co](https://unal.edu.co)

Additionally, their email addresses for students and staff follow this format: `usuario@unal.edu.co`, as shown in various official pages such as:

- [https://correo.unal.edu.co/](https://correo.unal.edu.co/)
- [https://oferta.unal.edu.co/](https://oferta.unal.edu.co/)
- [https://admisiones.unal.edu.co/](https://admisiones.unal.edu.co/)

<img width="1722" height="871" alt="image" src="https://github.com/user-attachments/assets/db10c7eb-56cb-467f-b1ac-c4fa6105202a" />
