### PR TITLE
Ajouter le domaine ucad.edu.sn pour l'UCAD de Dakar

### DIFF
--- a/lib/domains/sn/edu/ucad.txt
+++ b/lib/domains/sn/edu/ucad.txt
@@ -1,0 +1,1 @@
+Université Cheikh Anta Diop de Dakar


### PR DESCRIPTION
Ceci est une demande d'ajout du domaine de mon école pour bénéficier de la licence éducative. 
Domaine concerné : ucad.edu.sn. Merci.
