### PR TITLE
Add Sejong University

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
Sejong University currently has two domain emails:

xxxxx@sju.ac.kr (for students)
xxxxx@sejong.ac.kr (for professors and employees.)

It appears that the student domain (sju.ac.kr) has not been included in the student license agreement.

If all criteria are satisfied , kindly merge or add the student domain (sju.ac.kr) to the student license.

Thank you :D