### PR TITLE
Add @edu.zh.ch

### DIFF
--- a/lib/domains/ch/zh/edu.txt
+++ b/lib/domains/ch/zh/edu.txt
@@ -1,0 +1,2 @@
+Kantonsschule Zürich Nord
+Zurich North Cantonal School


### PR DESCRIPTION
The @stud.edu.zh.ch domain, which is assigned to our students, is already in your list of domains. The present commit adds the domains without "stud", which are used by educators, see https://www.kzn.ch/personen/lehrpersonen

