### PR TITLE
Agrego dominio usonsonate.edu.sv (Universidad de Sonsonate)

### DIFF
--- a/lib/domains/sv/edu/usonsonate.txt
+++ b/lib/domains/sv/edu/usonsonate.txt
@@ -1,0 +1,1 @@
+Universidad de Sonsonate


### PR DESCRIPTION
this PR adds the domain `usonsonate.edu.sv ` for Universidad de Sonsonate.