### PR TITLE
add Tzu Chi Senior High School Affiliated with Tzu Chi University

### DIFF
--- a/lib/domains/edu/hlc/tcsh.txt
+++ b/lib/domains/edu/hlc/tcsh.txt
@@ -1,0 +1,2 @@
+慈濟大學附屬高級中學
+Tzu Chi Senior High School Affiliated with Tzu Chi University


### PR DESCRIPTION
This PR adds the email domain `@tcsh.hlc.edu.tw` for Tzu Chi University Affiliated Senior High School by adding the corresponding entry in lib/domains/tw/edu/hlc/tcsh.txt.

The file contains the official school name in Chinese and English, allowing students with this email domain to verify their student status for JetBrains student licens