### PR TITLE
Add rupp.edu.kh – Royal University of Phnom Penh

### DIFF
--- a/lib/domains/edu/kh/rupp.txt
+++ b/lib/domains/edu/kh/rupp.txt
@@ -1,0 +1,1 @@
+Royal University of Phnom Penh


### PR DESCRIPTION
Add rupp.edu.kh – Royal University of Phnom Penh

Official website: https://www.rupp.edu.kh