### PR TITLE
Add dgu.ac.kr

### DIFF
--- a/lib/domains/kr/ac/dgu.txt
+++ b/lib/domains/kr/ac/dgu.txt
@@ -1,0 +1,2 @@
+동국대학교
+Dongguk University


### PR DESCRIPTION
Add dgu.ac.kr to support student license

homepage :
https://www.dongguk.edu/main
https://www.dongguk.edu/eng/main