### PR TITLE
Add domain ce.pucmm.edu.do for Pontificia Universidad Católica Madre y Maestra

### DIFF
--- a/lib/domains/do/edu/pucmm/pucmm.txt
+++ b/lib/domains/do/edu/pucmm/pucmm.txt
@@ -1,0 +1,2 @@
+Pontificia Universidad Católica Madre y Maestra
+Pontifical Catholic University Mother and Teacher


### PR DESCRIPTION
Adding the domain **ce.pucmm.edu.do** so students can apply for the JetBrains Student License.

University:
Pontificia Universidad Católica Madre y Maestra (PUCMM) 

Official Website:
https://pucmm.edu.do/

IT-related Degree:
https://www.pucmm.edu.do/ingenierias/ciencias-computacion

Proof of Domain Use by Students:
<img width="1462" height="235" alt="outlook-screenshot" src="https://github.com/user-attachments/assets/b9793ba8-d77d-4015-ada2-64a5f592b6b0" />
