### PR TITLE
Add rupp.edu.kh for Royal University of Phnom Penh

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,2 @@
+Royal University of Phnom Penh
+សាកលវិទ្យាល័យភូមិន្ទភ្នំពេញ


### PR DESCRIPTION
Add rupp.edu.kh – Royal University of Phnom Penh

Official website: https://www.rupp.edu.kh/