### PR TITLE
Add um5.ac.ma to JetBrains educational domain list

### DIFF
--- a/lib/domains/ma/ac/um5.txt
+++ b/lib/domains/ma/ac/um5.txt
@@ -1,0 +1,2 @@
+Université Mohammed V de Rabat
+Mohammed V University in Rabat


### PR DESCRIPTION
**Official Website**: https://www.um5.ac.ma

**IT Program Page**: https://www.um5.ac.ma/um5/ecole-superieure-de-technologie-de-sale  
(This page lists a long-term IT-related program)