### PR TITLE
Add EELU domain for student license request

### DIFF
--- a/lib/domains/eg/edu/eelu/student.txt
+++ b/lib/domains/eg/edu/eelu/student.txt
@@ -1,0 +1,2 @@
+The Egyptian E-learning University
+The Egyptian E-learning University


### PR DESCRIPTION
This adds the domain eelu.edu.eg for Egyptian E-Learning University students requesting educational licenses.