### PR TITLE
adding iduff domain for UFF Universidade Federal Fluminenese 

### DIFF
--- a/lib/domains/br/iduff.txt
+++ b/lib/domains/br/iduff.txt
@@ -1,0 +1,2 @@
+Universidade Federal Fluminense
+Fluminense Federal University


### PR DESCRIPTION
Requet to add iduff.br, the email domain for students to the list of approved domains.