### PR TITLE
Add Le Quy Don High School for the Gifted Students

### DIFF
--- a/lib/domains/vn/edu/lqd.txt
+++ b/lib/domains/vn/edu/lqd.txt
@@ -1,0 +1,2 @@
+Trường THPT Chuyên Lê Quý Đôn
+Le Quy Don High School For The Gifted Students


### PR DESCRIPTION
Our school, Le Quy Don High School for the Gifted Students in Vietnam, uses the custom domain "@lqd.email" to assign emails to students and staff. This file includes the official name of the school in both Vietnamese and English.