### PR TITLE
Add lqd.email domain for Le Quy Don High School for the Gifted Students

### DIFF
--- a/lib/domains/email/lqd.txt
+++ b/lib/domains/email/lqd.txt
@@ -1,0 +1,2 @@
+Trường THPT Chuyên Lê Quý Đôn
+Le Quy Don High School For The Gifted Students


### PR DESCRIPTION
This pull request adds the domain `lqd.email` to the JetBrains swot repository.

Our school, Le Quy Don High School for the Gifted Students (Vietnam), uses the custom domain `@lqd.email` to assign email addresses to students and staff.

Although the domain does not end with `.edu`, it is exclusively used by our school for educational purposes. We kindly request JetBrains to accept this domain for educational license verification.

Thank you for your consideration!