### PR TITLE
Add Royal University Of Phnom Penh files/diretories

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,1 @@
+Royal University Of Phnom Penh


### PR DESCRIPTION
Royal University of Phnom Penh (RUPP) is Cambodia’s largest and oldest public university, founded in 1960. Located in Phnom Penh, it offers Bachelor’s, Master’s, and PhD programs across faculties like Science, Engineering, Social Sciences, Development Studies, Education, and Foreign Languages. Known for its competitive Institute of Foreign Languages (IFL) and strong research in environmental studies and education, RUPP provides scholarships, diverse student clubs, and a vibrant campus life, producing graduates who contribute significantly to Cambodia’s development.