### PR TITLE
Add Universidad Estatal Península de Santa Elena (UPSE) to eligible domains.

### DIFF
--- a/lib/domains/ec/edu/upse.txt
+++ b/lib/domains/ec/edu/upse.txt
@@ -1,0 +1,2 @@
+Universidad Estatal Península de Santa Elena
+UPSE


### PR DESCRIPTION
I am submitting the Universidad Estatal Península de Santa Elena (UPSE) for inclusion in the JetBrains free student license program. Below is the requested information:

- **Official university website URL**: https://www.upse.edu.ec
- **URL of a page on the official website with a long-term (>1 year) IT-related course**: https://www.upse.edu.ec/index.php?option=com_sppagebuilder&view=page&id=8&Itemid=183
- **Proof that the university recognizes the domain `upse.edu.ec` as an official email domain for students**: 
- https://www.upse.edu.ec/images/2019/Agosto/manuales/Sistema_Servicios_Estudiantes.pdf : Page 4 shows a student email with the `@upse.edu.ec` domain.
  - https://www.upse.edu.ec/index.php?option=com_content&view=article&id=881:revista-cientifica-tecnologica-de-la-upse-indexada-a-scielo-ecuador&catid=10&Itemid=178 : Shows that the UPSE's Scientific and Technological journal is: revista_upse@upse.edu.ec
  - https://www.upse.edu.ec/index.php?option=com_sppagebuilder&view=page&id=8&Itemid=183 : Shows that careers oficial emails domain is: upse.edu.ec

Thank you for considering this request!