### PR TITLE
itparral.edu.mx domain

### DIFF
--- a/lib/domains/mx/edu/itparral.txt
+++ b/lib/domains/mx/edu/itparral.txt
@@ -1,0 +1,1 @@
+Instituto Tecnológico de Parral

--- a/lib/domains/mx/tecnm/parral.txt
+++ b/lib/domains/mx/tecnm/parral.txt
@@ -1,0 +1,1 @@
+TecNM Instituto Tecnológico de Parral

--- a/lib/domains/mx/tecnm/parral.txt
+++ b/lib/domains/mx/tecnm/parral.txt
@@ -1,1 +1,0 @@
-TecNM Instituto Tecnológico de Parral


### PR DESCRIPTION
Hello, In my previous request, I was informed that the domain parral.tecnm.mx had been removed from the trusted list due to past abuse, and that technical details about the vulnerability could be shared only with authorized university representatives so it could be resolved.

I am an authorized technical representative of a TecNM campus Parral. Although I have limited local control over parral.tecnm.mx, I do manage the domain itparral.edu.mx directly. We are currently working on enabling parral.tecnm.mx alongside itparral.edu.mx, but the process for parral.tecnm.mx is handled at a higher, non-local level.

To ensure our students can continue to benefit from JetBrains educational licenses while the main domain issue is addressed, would it be possible to register itparral.edu.mx as a trusted domain?

Thank you for your assistance, and I look forward to your guidance on how we can proceed.

Best regards.