### PR TITLE
Add domain sithyd.siu.edu.in for Symbiosis Institute of Technology, Hyderabad

### DIFF
--- a/lib/domains/in/edu/siu/sithyd.txt
+++ b/lib/domains/in/edu/siu/sithyd.txt
@@ -1,0 +1,1 @@
+sithyd.siu.edu.in


### PR DESCRIPTION
Adding the domain sithyd.siu.edu.in used by Symbiosis Institute of Technology, Hyderabad, for student email addresses.
This will enable students to apply for JetBrains educational licenses using their institutional email accounts.
