### PR TITLE
Add Chung-Ang University (cau.ac.kr) domain

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University

--- a/lib/domains/kr/ac/cau/cau.txt
+++ b/lib/domains/kr/ac/cau/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
### Summary
Adding Chung-Ang University (cau.ac.kr) to the JetBrains/swot repository for student license verification.

### School Details
- **School Name (Korean):** 중앙대학교
- **School Name (English):** Chung-Ang University
- **Official Website:** https://www.cau.ac.kr
- **Email Domain:** cau.ac.kr

### Proof of Eligibility
- 통합로그인 통합 ID 신청 페이지: https://www.cau.ac.kr/cms/FR_CON/BoardView.do?MENU_ID=100&CONTENTS_NO=2&BOARD_SEQ=4&BBS_SEQ=28569
  (통합로그인을 통해 cau.ac.kr 이메일이 발급됨을 안내)
- The email domain `@cau.ac.kr` is issued to students, faculty, and staff.
- (Optional) Screenshot of the portal signup flow can be attached here.

### Notes
This addition will allow Chung-Ang University students to verify their status when applying for JetBrains Student Licenses.