### PR TITLE
Adding unadvirtual.edu.co domain.

### DIFF
--- a/lib/domains/co/edu/unadvirtual.txt
+++ b/lib/domains/co/edu/unadvirtual.txt
@@ -1,0 +1,1 @@
+Universidad Nacional Abierta y a Distancia


### PR DESCRIPTION
Official Site:
https://www.unad.edu.co

unadvirtual.edu.co is a domain from "Universidad Nacional Abierta y a Distancia" for the students. 