### PR TITLE
Add professores.epbjc.pt domain

### DIFF
--- a/lib/domains/pt/epbjc/professores.txt
+++ b/lib/domains/pt/epbjc/professores.txt
@@ -1,0 +1,1 @@
+Escola Profissional Bento de Jesus Caraça


### PR DESCRIPTION
Adding the professores.epbjc.pt domain for JetBrains educational license verification.