### PR TITLE
Add horus.edu.eg domain for Horus University

### DIFF
--- a/lib/domains/eg/edu/horus/horus.txt
+++ b/lib/domains/eg/edu/horus/horus.txt
@@ -1,0 +1,1 @@
+Horus University – Private university in New Damietta, Egypt (horus.edu.eg)


### PR DESCRIPTION
This pull request adds the domain horus.edu.eg to the JetBrains SWOT repository under lib/domains/eg/edu/horus/horus.txt.
Horus University is a private university located in New Damietta, Egypt. Adding this domain will enable students with university emails from this domain to verify their student status and access JetBrains educational licenses.