### PR TITLE
Add Senati, an institute from Peru.

### DIFF
--- a/lib/domains/pe/senati.txt
+++ b/lib/domains/pe/senati.txt
@@ -1,0 +1,2 @@
+SENATI
+SENATI


### PR DESCRIPTION
Adding SENATI (Peru) to the JetBrains educational institutions list.
