### PR TITLE
Add tulas.edu.in

### DIFF
--- a/lib/domains/in/edu/tulas.txt
+++ b/lib/domains/in/edu/tulas.txt
@@ -1,0 +1,1 @@
+tulas.edu.in


### PR DESCRIPTION
Adding Tula's Institute, Dehradun, Uttarakhand, India to the JetBrains/swot repository.  
This will allow students with the domain tulas.edu.in to apply for JetBrains Student licenses.

Institution website: https://tulas.edu.in