### PR TITLE
Add Instituto de Educación Superior Privado Cibertec S.A.C (cibertec.edu.pe)

### DIFF
--- a/lib/domains/pe/edu/cibertec.txt
+++ b/lib/domains/pe/edu/cibertec.txt
@@ -1,0 +1,2 @@
+Instituto de Educación Superior Privado Cibertec S.A.C
+CIBERTEC


### PR DESCRIPTION
Domain: cibertec.edu.pe
School: Instituto de Educación Superior Privado Cibertec S.A.C (CIBERTEC)
Reason: Add domain for student licenses. Example student email: i202200351@cibertec.edu.pe
Official website: https://www.cibertec.edu.pe/
