### PR TITLE
Add Ubbo-Emmius-Gymnasium

### DIFF
--- a/lib/domains/net/ueg-leer.txt
+++ b/lib/domains/net/ueg-leer.txt
@@ -1,0 +1,1 @@
+Ubbo-Emmius-Gymnasium


### PR DESCRIPTION
The school's website can be accessed at www.ueg-leer.de. The email addresses of students and teachers are under the domain ueg-leer.net, as the school platform “IServ” is operated under this domain.