### PR TITLE
Add Ubbo-Emmius-Gymnasium

### DIFF
--- a/lib/domains/net/ueg-leer.txt
+++ b/lib/domains/net/ueg-leer.txt
@@ -1,0 +1,1 @@
+Ubbo-Emmius-Gymnasium


### PR DESCRIPTION
The school's website can be accessed at [www.ueg-leer.de](http://www.ueg-leer.de/). The email addresses of students and teachers are under the domain ueg-leer.net, as the school platform “IServ” is operated under this domain.
Here is proof (in German) that the domain ueg-leer.net is used by the school: https://www.ueg-leer.de/?view=article&id=1613:fragen-zu-iserv&catid=117