### PR TITLE
Adding KMIT domain

### DIFF
--- a/lib/domains/in/edu/kmit.txt
+++ b/lib/domains/in/edu/kmit.txt
@@ -1,0 +1,1 @@
+Keshav Memorial Institute of Technology


### PR DESCRIPTION
My college's name was not a part of the JetBrains' education doamins. So here I am adding the domain for my college ending with **kmit.edu.in**