### PR TITLE
Update huttoisd.txt to add HHS and .group

### DIFF
--- a/lib/domains/org/huttoisd.txt
+++ b/lib/domains/org/huttoisd.txt
@@ -1,1 +1,3 @@
 Hutto Middle School
+Hutto High School
+.group


### PR DESCRIPTION
Hello there.
The official URL of Hutto ISD is https://www.hipponation.org/. Specifically, Hutto High School's URL is https://hhs.hipponation.org/. For the pathway about computer science, the PDF file containing info is located at https://resources.finalsite.net/images/v1712741697/hipponationorg/xwsvgpnaibgeaglzsjmi/Programming_and_Software_Development.pdf, but this URL might change, so a stable URL is https://www.hipponation.org/career-technical-education/programs-of-study-2024-2025. The file is located under Programming and Software Development.