### PR TITLE
Add Sejong University (sju.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
Add Sejong University (sju.ac.kr)

Hello JetBrains team,

Please add Sejong University (세종대학교) student email domain for the educational license verification.

- University Name: Sejong University
- Student Email Domain: sju.ac.kr
- (Optional) Reference page proving student email domain: <링크>

Thank you!