### PR TITLE
Add Hankuk University of Foreign Studies (hufs.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
- Official website: https://www.hufs.ac.kr
- IT-related courses: https://computer.hufs.ac.kr
- Proof of email domain: https://mail.hufs.ac.kr 