### PR TITLE
Add Sumy Secondary School No. 15

### DIFF
--- a/lib/domains/ua/sumy/zosh15.txt
+++ b/lib/domains/ua/sumy/zosh15.txt
@@ -1,0 +1,1 @@
+Sumy Institution of General Secondary Education I–III Degrees No. 15 of the Sumy City Council


### PR DESCRIPTION
Adding the zosh15.sumy.ua domain for JetBrains educational license verification.