### PR TITLE
Added Rio Hondo College, Whitter CA

### DIFF
--- a/lib/domains/edu/riohondo/my.txt
+++ b/lib/domains/edu/riohondo/my.txt
@@ -1,0 +1,2 @@
+Rio Hondo College
+Rio Hondo College


### PR DESCRIPTION
Rio Hondo College address - 3600 Workman Mill Rd, Whittier, CA 90601, United States