### PR TITLE
Add Universidad Tecnológica del Perú (utp.edu.pe)

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+Technological University of Peru


### PR DESCRIPTION
Adding domain for Universidad Tecnológica del Perú to support JetBrains student licenses.