### PR TITLE
Add utp.edu.pe domain (Universidad Tecnológica del Perú)

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica del Perú


### PR DESCRIPTION
This commit adds support for the utp.edu.pe domain to recognize email addresses from Universidad Tecnológica del Perú.