### PR TITLE
Add usms.ac.ma - École nationale des sciences appliquées de Khouribga

### DIFF
--- a/lib/domains/ma/ac/usms.txt
+++ b/lib/domains/ma/ac/usms.txt
@@ -1,0 +1,2 @@
+École Nationale des Sciences Appliquées de Khouribga
+National School of Applied Sciences of Khouribga


### PR DESCRIPTION
Adding the domain `usms.ac.ma` for ENSA Khouribga (École nationale des sciences appliquées de Khouribga), a public engineering school in Morocco offering 5-year IT-related programs.

- Official website: http://ensak.usms.ac.ma/ensak/
- IT program: http://ensak.usms.ac.ma/ensak/formation-initiale/
- Proof of email domain usage: Students are assigned @usms.ac.ma emails upon enrollment.