### PR TITLE
Add the `sjsu.edu` domain for San Jose State University 

### DIFF
--- a/lib/domains/edu/sjsu.txt
+++ b/lib/domains/edu/sjsu.txt
@@ -1,0 +1,2 @@
+San José State University
+San Jose State University


### PR DESCRIPTION
Please add the domain `sjsu.edu` used by San Jose State University

Official Website: https://www.sjsu.edu/

Computer Science Program: https://www.sjsu.edu/cs/

Proof of Student Email Domain: https://one.sjsu.edu/task/all/my-email
(Students are able to access their @sjsu.edu emails through the portal via this link.)

Thank You!