### PR TITLE
Add Baekseok University

### DIFF
--- a/lib/domains/kr/ac/bu.txt
+++ b/lib/domains/kr/ac/bu.txt
@@ -1,0 +1,2 @@
+백석대학교
+Baekseok University


### PR DESCRIPTION
University official website URL:
https://www.bu.ac.kr/web/index.do

A URL of a page on the official website where a long-term (>1 year) IT related course is offered: https://community.bu.ac.kr/info/index.do (or https://community.bu.ac.kr/smartit/index.do)

Proof of official student email domain:
I've attached a PDF file downloaded from the university's official website. It is a guide for student webmail services and confirms that @bu.ac.kr is the correct domain for students.
[백석대학교 G메일 등록 안내.PDF](https://github.com/user-attachments/files/21890129/G.PDF)