### PR TITLE
Modify Le Rosey school domain

### DIFF
--- a/lib/domains/ch/rosey.txt
+++ b/lib/domains/ch/rosey.txt
@@ -1,0 +1,1 @@
+Institut le Rosey

--- a/lib/domains/ch/rosey/stu.txt
+++ b/lib/domains/ch/rosey/stu.txt
@@ -1,1 +1,0 @@
-Institut Le Rosey


### PR DESCRIPTION
Include the whole @rosey.ch domain instead of only the @stu.rosey.ch subdomain so that teachers can also access the products.