### PR TITLE
Add palermo.edu

### DIFF
--- a/lib/domains/edu/palermo.txt
+++ b/lib/domains/edu/palermo.txt
@@ -1,0 +1,1 @@
+Universidad de Palermo


### PR DESCRIPTION
Add universidad de Palermo from Argentina.

Website: https://www.palermo.edu/

Official domain is @palermo.edu