### PR TITLE
Add Akademi Digital Indonesia (adinesia.sch.id)

### DIFF
--- a/lib/domains/id/sch/adinesia.txt
+++ b/lib/domains/id/sch/adinesia.txt
@@ -1,0 +1,1 @@
+Akademi Digital Indonesia


### PR DESCRIPTION
Add Akademi Digital Indonesia (adinesia.sch.id)

- Official email domain: adinesia.sch.id
- Official website: https://adinesia.com/
- Country: Indonesia
- Type: Vocational Education (non-formal)
- Foundation: Adinesia Foundation (Yayasan Akademi Digital Indonesia)

Proof of Eligibility:

- Long-term IT-related courses: https://adinesia.com/all-course/
- Training categories: https://adinesia.com/kategori-training/
- Domain adinesia.sch.id is officially used as the email domain for students and faculty.

Thank you for reviewing our request.