### PR TITLE
Add hufs.ac.kr

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies(HUFS)


### PR DESCRIPTION
Institution/School Name : 

Hankuk University of Foreign Studies(HUFS)


Institution/School Website : 

[https://www.hufs.ac.kr/](https://www.hufs.ac.kr/)


Announcement on the opening of school mail : 

[https://dep.hufs.ac.kr/hufs/11281/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGaHVmcyUyRjIxODAlMkYxMjQ0MDclMkZhcnRjbFZpZXcuZG8lM0Y%3D](https://dep.hufs.ac.kr/hufs/11281/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGaHVmcyUyRjIxODAlMkYxMjQ0MDclMkZhcnRjbFZpZXcuZG8lM0Y%3D)

