### PR TITLE
Add singimail.rs

### DIFF
--- a/lib/domains/rs/singimail.txt
+++ b/lib/domains/rs/singimail.txt
@@ -1,0 +1,2 @@
+Univerzitet Singidunum
+Singidunum University


### PR DESCRIPTION
Native Name: Univerzitet Singidunum
English Name: Singidunum University

Website: https://singidunum.ac.rs/
English Website: https://study.singidunum.ac.rs/

Long-term IT related course: https://singidunum.ac.rs/admission/study-programme/software-and-data-engineering

Email domain proof (screenshot from logged-in student portal, email highlighted by the yellow arrow):
<img width="1918" height="893" alt="singidunum_proof" src="https://github.com/user-attachments/assets/5367c0e8-4093-41e7-b0d9-6ae21898fbf8" />
