### PR TITLE
Add King Mongkut's Institute of Technology Ladkrabang

### DIFF
--- a/lib/domains/th/ac/kmitl.txt
+++ b/lib/domains/th/ac/kmitl.txt
@@ -1,0 +1,2 @@
+สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง
+King Mongkut's Institute of Technology Ladkrabang


### PR DESCRIPTION
URL: [KMITL Page](https://www.kmitl.ac.th/)