### PR TITLE
ADD: add domain Glasgow Caledonian University (caledonian.ac.uk) 

### DIFF
--- a/lib/domains/uk/ac/caledonian.txt
+++ b/lib/domains/uk/ac/caledonian.txt
@@ -1,0 +1,1 @@
+Glasgow Caledonian University


### PR DESCRIPTION
University official website: https://www.gcu.ac.uk/
IT course: https://www.gcu.ac.uk/study/courses/undergraduate-computing-glasgow
Domain proof (under "Setting up your email): https://www.gcu.ac.uk/currentstudents/support/it/email