### PR TITLE
Add Universidad Pedagógica y Tecnológica de Colombia

### DIFF
--- a/lib/domains/co/edu/uptc.txt
+++ b/lib/domains/co/edu/uptc.txt
@@ -1,0 +1,1 @@
+Universidad Pedagógica y Tecnológica de Colombia


### PR DESCRIPTION
This PR adds Universidad Pedagógica y Tecnológica de Colombia (uptc.edu.co) to the JetBrains educational institutions list.
