### PR TITLE
Educacyl addition.

### DIFF
--- a/lib/domains/es/jcyl/educa.txt
+++ b/lib/domains/es/jcyl/educa.txt
@@ -1,0 +1,2 @@
+CEO Camino de Santiago
+CEO Camino de Santiago


### PR DESCRIPTION
Adding the educa.jcyl.es domain, which encompasses all Castilla y León, Spain.