### PR TITLE
Add Cibertec (cibertec.edu.pe)

### DIFF
--- a/lib/domains/pe/edu/cibertec.txt
+++ b/lib/domains/pe/edu/cibertec.txt
@@ -1,0 +1,2 @@
+Cibertec
+Cibertec


### PR DESCRIPTION
Institution: Cibertec
Country: Peru
Domain to add: cibertec.edu.pe

Reason:
Add Cibertec to JetBrains/swot to allow Student licenses for emails @cibertec.edu.pe.

Evidence:
- Official website: https://www.cibertec.edu.pe
- Student portal uses the same domain: https://estudiante.cibertec.edu.pe
- Screenshots below: inbox with @cibertec.edu.pe and Student Portal (personal data redacted).
<img width="1827" height="962" alt="Portal Cibertec" src="https://github.com/user-attachments/assets/86d455ce-d580-4f1e-97d1-e0a7e3870f92" />
<img width="1360" height="938" alt="emial cibertec" src="https://github.com/user-attachments/assets/8e42fd4b-2658-424c-a25a-621c96637d95" />


Files added:
- lib/domains/pe/edu/cibertec.txt (generated by JetBrains form, unmodified)
