### PR TITLE
Add ucr.ac.cr for Universidad de Costa Rica

### DIFF
--- a/lib/domains/cr/ac/ucr.txt
+++ b/lib/domains/cr/ac/ucr.txt
@@ -1,0 +1,2 @@
+Universidad de Costa Rica
+University of Costa Rica


### PR DESCRIPTION
Add ucr.ac.cr for Universidad de Costa Rica

- Dominio: ucr.ac.cr
- Universidad: Universidad de Costa Rica
- Sitio oficial: https://www.ucr.ac.cr/
- Página de cursos IT: https://www.ecci.ucr.ac.cr/
- Nota: Este dominio es usado oficialmente para correos de estudiantes de la UCR
