### PR TITLE
Add Sejong University (sju.ac.kr) domain

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
This PR adds Sejong University (sju.ac.kr) to the list of educational institutions. 👍