### PR TITLE
Add Yeungnam University (yu.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/yu.txt
+++ b/lib/domains/kr/ac/yu.txt
@@ -1,0 +1,2 @@
+영남대학교
+Yeungnam University


### PR DESCRIPTION
This pull request adds the official domain for Yeungnam University (영남대학교), South Korea.

- Official website: https://www.yu.ac.kr
- University name (Korean): 영남대학교
- University name (English): Yeungnam University
- Official student email domain: @yu.ac.kr

This will allow students of Yeungnam University to apply for free JetBrains student licenses.
