### PR TITLE
Agrego dominio costagrande.tecnm.mx

### DIFF
--- a/lib/domains/mx/tecnm/costagrande.txt
+++ b/lib/domains/mx/tecnm/costagrande.txt
@@ -1,0 +1,1 @@
+Instituto Tecnológico de la Costa Grande


### PR DESCRIPTION
Se agrega el dominio costagrande.tecnm.mx correspondiente al Instituto Tecnológico de la Costa Grande, perteneciente al Tecnológico Nacional de México (TecNM). Esto permitirá que los estudiantes con correos institucionales de este dominio puedan acceder a beneficios educativos.
