### PR TITLE
Add Oxford College of Engineering and Management information file

### DIFF
--- a/lib/domains/np/edu/oxfordcollege.txt
+++ b/lib/domains/np/edu/oxfordcollege.txt
@@ -1,0 +1,1 @@
+Oxford College of Engineering and Management


### PR DESCRIPTION
# Add Oxford College of Engineering and Management (OCEM) to Educational Domains

## Description
This pull request seeks to add **Oxford College of Engineering and Management (OCEM)**, located in Nepal, to the JetBrains educational domains list. Adding OCEM will enable its students to utilize JetBrains' educational licenses with their institutional email addresses.

## Institution Details
- **Institution Name:** Oxford College of Engineering and Management (OCEM)  
- **Location:** Gaidakot-2, Nawalparasi, Nepal  
- **Website:** [https://www.oxfordcollege.edu.np](https://www.oxfordcollege.edu.np)  
- **Official Email Domain:** `oxfordcollege.edu.np`  
- **Student Email Format:** `student.@oxfordcollege.edu.np` (This is the standard email format based on institutional domain usage.)

## Verification Links
- **IT-Related Courses:** The institution offers a **Bachelor of Engineering in Computer Engineering** and a **Bachelor of Computer Application**, both four-year programs. Details: [https://www.oxfordcollege.edu.np/programs/10](https://www.oxfordcollege.edu.np/programs/10)  
- **Institutional Domain Proof:** The official website uses the `oxfordcollege.edu.np` domain for official communication, verifying the domain's ownership and use.

## Programs Offered
- Bachelor of Engineering in Computer Engineering (4 years)  
- Bachelor of Computer Application (4 years)

## Additional Information
- Established in 2000 A.D.  
- Affiliated with Pokhara University  
- Offers full-time engineering and IT courses

## Checklist
- [x] Institution offers IT-related degree (1+ year duration)  
- [x] Official institution name is included  
- [x] Official domain is verified for institutional use  
- [x] The student email format is a standard derivation of the institutional domain  
- [x] The website address is correct

---

Thank you for your consideration. Please let us know if any further information is required.
