### PR TITLE
Add Inha Technical College (itc.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/itc.txt
+++ b/lib/domains/kr/ac/itc.txt
@@ -1,0 +1,2 @@
+인하공업전문대학교
+Inha Technical College


### PR DESCRIPTION
### Institution Name
- 인하공업전문대학교 (Inha Technical College)

### Official Website
- https://eng.inhatc.ac.kr/eng/index.do

### Proof of IT-related long-term courses
- 정보통신공학과 등 IT 관련 장기 교육과정(2~4년) 운영
- 예시 URL: (학과·교육과정 페이지 URL 넣기)

### Proof of official student email domain
- Student/Staff email domain: **@itc.ac.kr**
- 증빙: (학교 공식 페이지 내 이메일/계정 안내 페이지 URL)  
  - URL이 없으면 아래에 스크린샷 첨부

### Notes
- 이 기관은 고등교육기관(전문대학)으로 2년·3년·전공심화(4년) 교육과정을 운영합니다.
- `itc.ac.kr` 상위 도메인만 추가하며, 모든 하위 도메인(예: `mail.itc.ac.kr`)은 자동 포함됩니다.
