### PR TITLE
Adding Munster Technological University Student email domain prefix.

### DIFF
--- a/lib/domains/ie/mymtu.txt
+++ b/lib/domains/ie/mymtu.txt
@@ -1,1 +1,1 @@
-Munster Technological University Student
+Munster Technological University


### PR DESCRIPTION
Currently the email@mtu.ie is supported for "Munster Technological University", but the student specific email@mymtu.ie is not.


College landing page - https://www.mtu.ie/
Notification of email structure for students - https://www.mymtu.ie/365/cork-campus-365/
