### PR TITLE
Added wksbildung.ch domain.

### DIFF
--- a/lib/domains/ch/wksbildung.txt
+++ b/lib/domains/ch/wksbildung.txt
@@ -1,0 +1,2 @@
+Verein Wirtschafts- und Kaderschule KV Bern
+Association for Business and Management Training Commercial Association Bern


### PR DESCRIPTION
### Description

This pull request adds the domain **`wksbildung.ch`** to the repository so that students and staff of **Verein Wirtschafts- und Kaderschule KV Bern (Association for Business and Management Training Commercial Association Bern)** can be recognized for academic licensing.

### Details

* Added file: `lib/domains/ch/wksbildung.txt`
* Content includes the full name of the institution in German and English.

### Motivation

I would like to use JetBrains educational licenses, but the **`wksbildung.ch`** domain is not yet listed in the repo. Adding this domain will enable JetBrains products for students and staff of WKS Bildung.