### PR TITLE
Add domain for Sejong University, South Korea

### DIFF
--- a/lib/domains/ac/kr/sju.txt
+++ b/lib/domains/ac/kr/sju.txt
@@ -1,2 +1,0 @@
-세종대학교
-Sejong University


### PR DESCRIPTION
Hello,

This pull request adds the official student email domain for Sejong University (`sju.ac.kr`) in South Korea.

- University Name: Sejong University (세종대학교)
- Official Website: https://www.sejong.ac.kr/

Students of this university use the `@sju.ac.kr` domain for their official email addresses. Please review and merge this request to allow them to apply for the educational license pack.

Thank you.