### PR TITLE
add hufs (Hankuk University of Foreign Studies)

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
### School Name
Hankuk University of Foreign Studies

### School Website
https://www.hufs.ac.kr

### School Email Domain(s)
- hufs.ac.kr

### Reason for the addition
Hankuk University of Foreign Studies (HUFS) is a well-established university in South Korea, 
with a strong emphasis on foreign languages, international studies, and computer science.  
The official student email domain is `@hufs.ac.kr`, which is currently not listed in JetBrains Education Program.

By adding this domain, students at HUFS will be able to apply for the JetBrains educational license more easily 
and access JetBrains IDEs for academic and research purposes.

Thank you for considering this addition.
