### PR TITLE
Add kr ac sju domain

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
Requesting add Sejong University domain.

Sejong university is located in Seoul, South Korea. detail information is below.

Thanks for reviewing my PR.

- Official website for main page: https://www.sejong.ac.kr/kor/index.do

- Official website for CS major: https://home.sejong.ac.kr/~cedpt/1.html

- Email address format: name@sju.ac.kr