### PR TITLE
Adding new domain hcw

### DIFF
--- a/lib/domains/at/ac/hcw.txt
+++ b/lib/domains/at/ac/hcw.txt
@@ -1,0 +1,1 @@
+Hochschule Campus Wien


### PR DESCRIPTION
Homepage: changed from fh-campuswien to hcw  -->  https://www.hcw.ac.at

The course I am currently in:  https://www.hcw.ac.at/studium-weiterbildung/studienangebot/computer-science-and-digital-communications-berufsbegleitend

The change of the FH to Hochschule on the campus homepage and the changes:  https://www.hcw.ac.at/studium-weiterbildung/aktuell/news-und-events/fh-campus-wien-ist-hochschule-fuer-angewandte-wissenschaften


Thank you for the change - add to the system (because in the future we won't receive e-mails on the old e-mail address of fh-campuswien)