### PR TITLE
Add Đại Học Sài Gòn (sgu.edu.vn)

### DIFF
--- a/lib/domains/vn/edu/sgu/sv.txt
+++ b/lib/domains/vn/edu/sgu/sv.txt
@@ -1,0 +1,2 @@
+Đại Học Sài Gòn
+SaiGon University

--- a/lib/domains/vn/sgu.txt
+++ b/lib/domains/vn/sgu.txt
@@ -1,0 +1,2 @@
+Đại Học Sài Gòn
+SaiGon University


### PR DESCRIPTION
This PR adds SaiGon University (Đại Học Sài Gòn) to the list of educational domains.

- Official website: https://sgu.edu.vn
- University domain: sgu.edu.vn
- Student email domain: sv.sgu.edu.vn (example: 3122411001@sv.sgu.edu.vn)

Proof:
- Official student portal shows that email addresses with @sv.sgu.edu.vn are assigned to students.
<img width="1919" height="1079" alt="Screenshot 2025-08-28 213138" src="https://github.com/user-attachments/assets/a7986288-bc72-47ab-ba15-b727a6175a4a" />

