### PR TITLE
Korea Sejong University

### DIFF
--- a/file/lib/domains/kr/ac/file/lib/domains/kr/ac/sju.txt
+++ b/file/lib/domains/kr/ac/file/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University

--- a/file/lib/domains/kr/ac/sju.txt
+++ b/file/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
Sejong University's Korean name and English name. It is located in Korea, Seoul, besides of Kunja station.