### PR TITLE
Add Universitas Qomaruddin Gresik

### DIFF
--- a/lib/domains/id/ac/uqgresik/mhs.txt
+++ b/lib/domains/id/ac/uqgresik/mhs.txt
@@ -1,0 +1,2 @@
+Universitas Qomaruddin Gresik
+Qomaruddin University of Gresik


### PR DESCRIPTION
Universitas Qomaruddin Gresik, it's located in Gresik, East Java, Indonesia