### PR TITLE
Add Newton School of Technology, Rishihood University

### DIFF
--- a/lib/domains/in/edu/rishihood/nst.txt
+++ b/lib/domains/in/edu/rishihood/nst.txt
@@ -1,0 +1,1 @@
+Newton School Of Technology, Rishihood University


### PR DESCRIPTION
This PR adds the domain `nst.rishihood.edu.in` for Newton School of Technology, Rishihood University (India).

Students with emails under this domain (e.g., kammati.a23csai@nst.rishihood.edu.in) should be eligible for JetBrains student licenses.

School Name: Newton School of Technology, Rishihood University
Country: India
Website: https://www.rishihood.edu.in
