### PR TITLE
Request to add Community of Hellenic Nations University

### DIFF
--- a/lib/domains/gr/edu/chn.txt
+++ b/lib/domains/gr/edu/chn.txt
@@ -1,0 +1,1 @@
+Community of Hellenic Nations University


### PR DESCRIPTION
Community of Hellenic Nations University

Email domain: chn.edu.gr
Greece name: Πανεπιστήμιο της Κοινότητας Ελληνικών Εθνών
English name: Community of Hellenic Nations University