### PR TITLE
Add King Mongkut's Institute of Technology Ladkrabang (kmitl.ac.th)

### DIFF
--- a/lib/domains/th/ac/kmitl.txt
+++ b/lib/domains/th/ac/kmitl.txt
@@ -1,0 +1,1 @@
+King Mongkut's Institute of Technology Ladkrabang


### PR DESCRIPTION
# Add King Mongkut’s Institute of Technology Ladkrabang (KMITL) — `kmitl.ac.th`

## University Information
- **Institution:** King Mongkut’s Institute of Technology Ladkrabang (KMITL)  
- **Country:** Thailand  
- **Official Website:** https://www.kmitl.ac.th/  
- **Domain:** `kmitl.ac.th`

## Domain Ownership & Email Usage (Evidence)
- KMITL’s official systems require sign-in with **Email (@kmitl.ac.th)** (e.g., Course Syllabus portal).  
- KMITL Data Management Center (KDMC) provides **Google Workspace for Education** accounts to **students and staff** under the institutional domain.  
- Official contact listings use `@kmitl.ac.th` mailboxes (e.g., `pr.kmitl@kmitl.ac.th`, staff profiles).

## IT-Related Bachelor’s Programs (4 years)
- **B.Eng. Software Engineering (International Program)** — School of Engineering  
  - Program site: https://se.kmitl.ac.th/  
  - Program page (incl. U. of Glasgow double-degree info): https://se.kmitl.ac.th/program
- **Computer Engineering**  
  - Department (Thai): https://www.ce.kmitl.ac.th/  
  - **International Program (CEI):** https://cei.kmitl.ac.th/  (Curriculum & courses available)
- **B.Sc. Digital Technology and Integrated Innovation (International Program)** — School of Science  
  - Program site: https://inter.science.kmitl.ac.th/  
  - Program detail (curriculum portal): https://curriculum.kmitl.ac.th/en/major/72

> All programs above are 4-year degree programs in engineering/science with strong computing/IT content and meet the repository’s requirements.

## Implementation (SWOT repository)
- **Add file:** `lib/domains/th/ac/kmitl.txt`  


## Notes
- Students and staff are provisioned with institutional Google accounts under `@kmitl.ac.th`.  
- Example official contacts (for verification): `pr.kmitl@kmitl.ac.th`, program/office addresses on kmitl.ac.th.