### PR TITLE
Add info about Sungkyunkwan University.

### DIFF
--- a/lib/domains/edu/skku/g.txt
+++ b/lib/domains/edu/skku/g.txt
@@ -1,0 +1,2 @@
+성균관대학교
+Sungkyunkwan University


### PR DESCRIPTION
Sungkyunkwan University(성균관대학교) is a university in South Korea.