### PR TITLE
Add Gulistan Institute of Entrepreneurship (gie.edu.kg)

### DIFF
--- a/lib/domains/kg/edu/gie.txt
+++ b/lib/domains/kg/edu/gie.txt
@@ -1,0 +1,1 @@
+Gulistan Institute of Entrepreneurship


### PR DESCRIPTION
## Adding Gulistan Institute of Entrepreneurship

  **Institution Details:**
  - **Name:** Gulistan Institute of Entrepreneurship
  - **Domain:** gie.edu.kg
  - **Location:** Kyrgyzstan
  - **Type:** Higher Education Institution

  **Eligibility Confirmation:**
  - ✅ Offers long-term courses (≥1 year)
  - ✅ IT-related programs available
  - ✅ Provides dedicated student email addresses (@gie.edu.kg)
  - ✅ Recognized educational institution

  **Contact Email:** bit@gie.edu.kg

  This PR adds the domain `gie.edu.kg` to enable JetBrains educational
  licenses for students and faculty at Gulistan Institute of
  Entrepreneurship.
