### PR TITLE
Added the HRUC colleges

### DIFF
--- a/lib/domains/uk/ac/hruc.txt
+++ b/lib/domains/uk/ac/hruc.txt
@@ -1,0 +1,1 @@
+  Harrow, Richmond, and Uxbridge Colleges


### PR DESCRIPTION
Added the Harrow, Richmond and Uxbridge College Domains (HRUC)
https://www.hruc.ac.uk/