### PR TITLE
Fix ITC entry: add domain itc.ac.kr for Inha Technical College

### DIFF
--- a/lib/domains/kr/ac/itc.txt
+++ b/lib/domains/kr/ac/itc.txt
@@ -1,2 +1,1 @@
-인하공업전문대학
-Inha Technical College (ITC), Incheon
+itc.ac.kr


### PR DESCRIPTION
This PR fixes the ITC entry for Inha Technical College by replacing the school name text with the actual email domain.

Added:
- itc.ac.kr

If students also use any subdomains (e.g., mail.itc.ac.kr), I can add them as well.
