### PR TITLE
Add San Francisco State University (sfsu.edu)

### DIFF
--- a/lib/domains/ec/edu/sfsu.txt
+++ b/lib/domains/ec/edu/sfsu.txt
@@ -1,0 +1,1 @@
+San Francisco state university

--- a/lib/domains/ec/edu/sfsu.txt
+++ b/lib/domains/ec/edu/sfsu.txt
@@ -1,1 +1,0 @@
-San Francisco state university

--- a/lib/domains/edu/sfsu.txt
+++ b/lib/domains/edu/sfsu.txt
@@ -1,0 +1,1 @@
+San Francisco state university


### PR DESCRIPTION
Adding sfsu.edu domain.

Official website: https://www.sfsu.edu
Computer Science Department (proof of IT-related courses): https://cs.sfsu.edu