### PR TITLE
Add IIS Confalonieri - De Chirico to Italian educational domains

### DIFF
--- a/lib/domains/it/edu/confalonieridechirico.txt
+++ b/lib/domains/it/edu/confalonieridechirico.txt
@@ -1,0 +1,2 @@
+IIS Confalonieri - De Chirico
+IIS Confalonieri - De Chirico


### PR DESCRIPTION
Adding IIS Confalonieri - De Chirico to Italian educational domains.

**School Details:**
- Name: IIS Confalonieri - De Chirico
- Domain: confalonieridechirico.edu.it
- Country: Italy
- Type: High School (Istituto di Istruzione Superiore)

This PR adds the school domain to enable educational license requests for JetBrains products.