### PR TITLE
Add UCSY (ucsy.edu.mm) to JetBrains education list

### DIFF
--- a/lib/domains/mm/edu/ucsy.txt
+++ b/lib/domains/mm/edu/ucsy.txt
@@ -1,0 +1,2 @@
+University of Computer Studies, Yangon (UCSY)
+ရန်ကုန်ကွန်ပျူတာတက္ကသိုလ်


### PR DESCRIPTION
This pull request adds University of Computer Studies, Yangon (UCSY) 
with the domain ucsy.edu.mm to the JetBrains education list.

Adding this domain will allow UCSY students to apply for free 
JetBrains Student Licenses using their university email addresses.
