### PR TITLE
Add Egyptian E-Learning University (EELU) 

### DIFF
--- a/lib/domains/eg/eelu.edu.eg.txt
+++ b/lib/domains/eg/eelu.edu.eg.txt
@@ -1,0 +1,2 @@
+الجامعه المصريه للتعلم الالكتروني
+Egyptian E-Learning University (EELU)

--- a/lib/domains/eg/student.txt
+++ b/lib/domains/eg/student.txt
@@ -1,0 +1,2 @@
+الجامعه المصريه للتعلم الالكتروني
+Egyptian E-Learning University (EELU)

--- a/student.txt
+++ b/student.txt
@@ -1,0 +1,2 @@
+الجامعه المصريه للتعلم الالكتروني
+Egyptian E-Learning University (EELU)


### PR DESCRIPTION
This pull request adds the domain `eelu.edu.eg` for the Egyptian E-Learning University (EELU) to enable students to apply for JetBrains student licenses.

- Domain: eelu.edu.eg
- University: Egyptian E-Learning University (EELU)
- Country: Egypt
- File path: domains/eg/eelu.edu.eg.txt