### PR TITLE
Add UTPL to educational domain names

### DIFF
--- a/lib/domains/ec/edu/utpl.txt
+++ b/lib/domains/ec/edu/utpl.txt
@@ -1,0 +1,1 @@
+Universidad Técnica Particular de Loja


### PR DESCRIPTION
Adds Universidad Técnica Particular de Loja's educational domain (https://www.utpl.edu.ec)