### PR TITLE
Add stecilia.edu.ph domain for St. Cecilia's College - Cebu

### DIFF
--- a/lib/domains/ph/edu/stecilia.txt
+++ b/lib/domains/ph/edu/stecilia.txt
@@ -1,0 +1,2 @@
+St. Cecilia's College-Cebu Inc.
+St. Cecilia's College-Cebu Inc.


### PR DESCRIPTION
This pull request adds the stecilia.edu.ph domain for St. Cecilia's College - Cebu.
Please approve so students can use their @stecilia.edu.ph emails for JetBrains Student Licenses.