### PR TITLE
Add a Sejong University

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
- For Sejong university in Seoul, Republic of Korea.
- Website: https://en.sejong.ac.kr/eng/index.do

<img width="866" height="626" alt="image" src="https://github.com/user-attachments/assets/99cee05a-a125-4d02-a1c8-9ed24edf525a" />

[Reference](https://en.sejong.ac.kr/eng/publishing/The_guidebook_for_student.do)