### PR TITLE
Add Nassau Community College domain students.ncc.edu

### DIFF
--- a/lib/domains/edu/ncc/students.txt
+++ b/lib/domains/edu/ncc/students.txt
@@ -1,0 +1,2 @@
+Nassau Community College
+Nassau Community College


### PR DESCRIPTION
Official school website: https://www.ncc.edu
Course catalog (1 year+ programs): https://www.ncc.edu/academics/catalog/
Proof of student email domain: https://www.ncc.edu/students/it_services/studentemail.shtml