### PR TITLE
Add Egyptian E-Learning University (EELU) domain

### DIFF
--- a/student.txt
+++ b/student.txt
@@ -1,2 +1,0 @@
-الجامعه المصريه للتعلم الالكتروني
-Egyptian E-Learning University (EELU)


### PR DESCRIPTION
This PR adds the correct domain `eelu.edu.eg` for the Egyptian E-Learning University (EELU).

- Domain: eelu.edu.eg
- University: Egyptian E-Learning University (EELU)
- Country: Egypt
- File path: domains/eg/eelu.edu.eg.txt