### PR TITLE
Create calhoun.txt

### DIFF
--- a/lib/domains/edu/calhoun.txt
+++ b/lib/domains/edu/calhoun.txt
@@ -1,0 +1,2 @@
+Calhoun Community College, Decatur, Alabama 
+Alabama college system (i.e., all colleges and universities in Alabama: <Alabama ID>@alabama.edu


### PR DESCRIPTION
attempting to add calhoun.edu to the list of colleges and universities.  older email domains used <name>@calhoun.edu (which still works), however all Alabama colleges and universities (afaik) went to a unified domain <A-number>@alabama.edu.  this is the domain that should be utilized.
