### PR TITLE
Add stcecilia.edu.ph domain for St. Cecilia's College - Cebu

### DIFF
--- a/lib/domains/ph/edu/stcecilia.txt
+++ b/lib/domains/ph/edu/stcecilia.txt
@@ -1,0 +1,1 @@
+St. Cecilia's College-Cebu Inc.

--- a/lib/domains/ph/edu/stecilia.txt
+++ b/lib/domains/ph/edu/stecilia.txt
@@ -1,2 +1,0 @@
-St. Cecilia's College-Cebu Inc.
-St. Cecilia's College-Cebu Inc.

--- a/lib/domains/ph/edu/stecilia.txt
+++ b/lib/domains/ph/edu/stecilia.txt
@@ -1,0 +1,2 @@
+St. Cecilia's College-Cebu Inc.
+St. Cecilia's College-Cebu Inc.


### PR DESCRIPTION
This pull request adds the stcecilia.edu.ph domain for St. Cecilia's College - Cebu.
The previous request had a typo (stecilia.edu.ph).
Please approve so students can apply for JetBrains Student Licenses using their @stcecilia.edu.ph emails.