### PR TITLE
feat: Add Sejong University (sju.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
Add Sejong University to the list of South Korean academic institutions.