### PR TITLE
Add Nihon University

### DIFF
--- a/lib/domains/jp/ac/nihon-u/g.txt
+++ b/lib/domains/jp/ac/nihon-u/g.txt
@@ -1,0 +1,2 @@
+日本大学
+Nihon University


### PR DESCRIPTION
Add Nihon University 

University official website:
https://www.nihon-u.ac.jp/en/

Long-term IT course page 
https://www.ce.nihon-u.ac.jp/department701/

Proof that this domain is recognized as the official student email domain:
https://www.nihon-u.ac.jp/information/20250704-3748.html
