### PR TITLE
Adding Cebu Institute of Technology - University to the list of schools

### DIFF
--- a/lib/domains/edu/cit.txt
+++ b/lib/domains/edu/cit.txt
@@ -1,0 +1,1 @@
+Cebu Institute of Technology - University


### PR DESCRIPTION
This pull request adds a new entry to the educational domains list. The change registers "Cebu Institute of Technology - University" in the `lib/domains/edu/cit.txt` file.