### PR TITLE
Adición correcta del instituto CIbertec

### DIFF
--- a/lib/domains/pe/edu/cibertec.txt
+++ b/lib/domains/pe/edu/cibertec.txt
@@ -1,0 +1,2 @@
+Cibertec
+Cybertec


### PR DESCRIPTION
Anteriormente se añadió un cibertec.txt, pero en una forma que no respeta la estructura de carpetas.