### PR TITLE
add domain for students in Lac Hong University

### DIFF
--- a/lib/domains/vn/edu/dhl.txt
+++ b/lib/domains/vn/edu/dhl.txt
@@ -1,0 +1,2 @@
+Trường Đại học Lạc Hồng
+Lac Hong University


### PR DESCRIPTION
This domain is used for Lac Hong University students and before that there was the domain lhu.edu.vn but it was only given to teachers while the domain dhl.edu.vn was given to students.