### PR TITLE
Added SJSU

### DIFF
--- a/lib/domains/edu/sjsu.txt
+++ b/lib/domains/edu/sjsu.txt
@@ -1,0 +1,1 @@
+San Jose State University


### PR DESCRIPTION
Added San Jose State University. Part of the California State University.
Example course: https://catalog.sjsu.edu/preview_course_nopop.php?catoid=10&coid=41926