### PR TITLE
university site: https://en.sejong.ac.kr/eng/index.do

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+sejong university


### PR DESCRIPTION
Korean name: 세종대학교
English name: Sejong University
University website (English): https://en.sejong.ac.kr/eng/index.do
https://en.sejong.ac.kr/eng/academics/Computer_and_Information_security.do

Description:
The file "Sejong.txt" exists, but the file "sju.txt" does not.
Therefore, the domain @sju.ac.kr does not seem to be recognized as a school domain by JetBrains. For this reason, we are uploading a new domain file named sju.ac.kr.
