### PR TITLE
add new domain ug.edu.ec

### DIFF
--- a/lib/domains/ec/edu/ug.txt
+++ b/lib/domains/ec/edu/ug.txt
@@ -1,0 +1,1 @@
+Universidad de Guayaquil


### PR DESCRIPTION
This domain for registering Guayaquil University domain in jetbrains, the domain also using by teacher, student in this university