### PR TITLE
Adding SFSU jetbrains domain list

### DIFF
--- a/lib/domains/edu/sfsu.txt
+++ b/lib/domains/edu/sfsu.txt
@@ -1,0 +1,1 @@
+San Francisco State University


### PR DESCRIPTION
Adding the domain and school name for San Francisco State University

Main Domain: https://sfsu.edu

CS Department: https://cs.sfsu.edu

Academic Technology: https://at.sfsu.edu/