### PR TITLE
Add Instituto Tecnológico de Cd. Guzmán (TecNM)

### DIFF
--- a/lib/domains/mx/tecnm/cdguzman.txt
+++ b/lib/domains/mx/tecnm/cdguzman.txt
@@ -1,0 +1,2 @@
+TecNM Campus Cd. Guzmán
+Technological Institute of Mexico, Ciudad Guzman Campus


### PR DESCRIPTION
Adding cdguzman.tecnm.mx domain for Instituto Tecnológico de Cd. Guzmán, part of TecNM.
Official website: https://cdguzman.tecnm.mx
