### PR TITLE
Add Vietnam National University, Hanoi school domain

### DIFF
--- a/lib/domains/vn/edu/vnu.txt
+++ b/lib/domains/vn/edu/vnu.txt
@@ -1,0 +1,2 @@
+Đại học Quốc gia Hà Nội
+Vietnam National University, Hanoi


### PR DESCRIPTION
This pull request adds Vietnam National University, Hanoi (VNU) to the JetBrains/swot repository.

- Official university name: Vietnam National University, Hanoi (VNU)
- Official website: https://vnu.edu.vn/
- Email domain: vnu.edu.vn
- University type: Public university
- Location: Hanoi, Vietnam

Vietnam National University, Hanoi is one of the largest and most prestigious universities in Vietnam. It offers long-term undergraduate, postgraduate, and doctoral programs in various fields, including Computer Science, Information Technology, Software Engineering, and related disciplines.

Proof of domain usage:
- The university provides email addresses under the `@vnu.edu.vn` domain for students, faculty, and staff.

Please add this domain to allow VNU students and staff to apply for JetBrains educational licenses.