### PR TITLE
Add Kyungnam College of Information & Technology

### DIFF
--- a/lib/domains/kr/ac/kit/o365.txt
+++ b/lib/domains/kr/ac/kit/o365.txt
@@ -1,0 +1,2 @@
+경남정보대학교
+Kyungnam College of Information & Technology


### PR DESCRIPTION
When I try to extend my student license, it says that my school email cannot be verified.
Please add the Korean and English school names.
Please check and merge if there are no issues.