### PR TITLE
Add Cork College of FET

### DIFF
--- a/lib/domains/ie/corketb/morrisonsislandcampus.txt
+++ b/lib/domains/ie/corketb/morrisonsislandcampus.txt
@@ -1,0 +1,1 @@
+Cork College of FET


### PR DESCRIPTION
This pull request adds morrisonsislandcampus.txt to the lib/domains/ie/corketb... directory to include the email domain for Cork College of FET in the JetBrains/swot database.

Cork College of FET website: https://fet.corketb.ie/
Cork College of FET - Morrison's Island Campus website: https://morrisonsislandcampus.ie/

