### PR TITLE
Add ctmcampusvirtual.com domain

### DIFF
--- a/lib/domains/com/ctmcampusvirtual.txt
+++ b/lib/domains/com/ctmcampusvirtual.txt
@@ -1,0 +1,1 @@
+CTM campus virtual


### PR DESCRIPTION
Add ctmcampusvirtual.com domain

CTM Campus Virtual (ctmcampusvirtual.com) is an educational institution.
Official website: https://universidadctmoficial.org/
Domain used for student emails: @ctmcampusvirtual.com
