### PR TITLE
Add Vietnam – Korea University of Information and Communication Technology (vku.udn.vn)

### DIFF
--- a/lib/domains/vn/udn/vku.txt
+++ b/lib/domains/vn/udn/vku.txt
@@ -1,0 +1,2 @@
+Trường Đại học Công nghệ Thông tin và Truyền thông Việt – Hàn
+Vietnam – Korea University of Information and Communication Technology


### PR DESCRIPTION
Add domain file for Trường Đại học Công nghệ Thông tin và Truyền thông Việt – Hàn
(Vietnam – Korea University of Information and Communication Technology).

Domain: vku.udn.vn