### PR TITLE
Add sv.sgu.edu.vn domain for Saigon University

### DIFF
--- a/lib/domains/vn/edu/sgu/sv.txt
+++ b/lib/domains/vn/edu/sgu/sv.txt
@@ -1,0 +1,1 @@
+Saigon University


### PR DESCRIPTION
This pull request adds the domain sv.sgu.edu.vn for Saigon University so that students with this domain can apply for JetBrains Student Pack.
https://www.sgu.edu.vn
Saigon University (Đại học Sài Gòn) is a public university in Vietnam.
This PR adds the official student email domain sv.sgu.edu.vn.
Official website: https://www.sgu.edu.vn/