### PR TITLE
Add Gunma Paz University (paz.ac.jp)

### DIFF
--- a/lib/domains/edu/wfusm.txt
+++ b/lib/domains/edu/wfusm.txt
@@ -1,0 +1,1 @@
+Wake Forest School of Medicine

--- a/paz.txt
+++ b/paz.txt
@@ -1,0 +1,2 @@
+群馬パース大学
+Gunma Paz University


### PR DESCRIPTION
 Add paz.ac.jp domain for Gunma Paz University

  - University website: https://www.paz.ac.jp
  - IT-related courses: Information Science, Medical Engineering
  - Student email domain: paz.ac.jp