### PR TITLE
Add G.L Bajaj Institute Of Technology

### DIFF
--- a/lib/domains/in/ac/glbitm.txt
+++ b/lib/domains/in/ac/glbitm.txt
@@ -1,0 +1,1 @@
+G.L Bajaj Institute Of Technology


### PR DESCRIPTION
Add glbitm.ac.in domain for G.L Bajaj Institute Of Technology

- University website: https://www.glbitm.org/
- IT-related courses: B.Tech in various fields including IT and CS, Master of Computer Applications
- Student email domain: glbitm.ac.in