### PR TITLE
Added Jamalpur Science & Technology University , Bangladesh

### DIFF
--- a/lib/domains/bd/ac/jstu.txt
+++ b/lib/domains/bd/ac/jstu.txt
@@ -1,0 +1,1 @@
+Jamalpur Science & Technology University


### PR DESCRIPTION
Jamalpur Science and Technology University (Bengali: জামালপুর বিজ্ঞান ও প্রযুক্তি বিশ্ববিদ্যালয়) is a government financed public university of Bangladesh. It was established on 28 November 2017 by the Act No. 24 of 2017 as the 44th public university of Bangladesh. Later it was renamed in 2024 as Jamalpur Science and Technology University. 
Current Website: https://jstu.ac.bd/
Wikipedia: https://en.wikipedia.org/wiki/Jamalpur_Science_and_Technology_University
Current Domain: jstu.ac.bd

Previous Name: Bangamata Sheikh Fojilatunnesa Mujib Science & Technology University
Previous Website: https://bsfmstu.ac.bd
Previous Domain: bsfmstu.ac.bd


* **Official website URL:** https://jstu.ac.bd/
* **Street address (including city & country):** Melandaha, Jamalpur-2012, Bangladesh ([[jstu.ac.bd](https://jstu.ac.bd/)][1])
* **URL to a page offering an IT-related long-term (>1 year) course:** Department of Computer Science and Engineering, which offers a 4-year B.Sc. Engineering degree.
    URL: https://jstu.ac.bd/index.php/dept/cse.php
* **Proof of official email domain recognized by the university:** Faculties in the CSE department have email addresses such as sujit@jstu.ac.bd,mahmudul@jstu.ac.bd,humaun@bsfmstu.ac.bd. This shows “@jstu.ac.bd” and "@bsfmstu.ac.bd" is an official domain used by university staff and also students. Links: https://jstu.ac.bd/index.php/dept/cse/faculties

**Both "@jstu.ac.bd" and "@bsfmtu.ac.bd" are the valid domain used by university staff and students.**

[1]: https://jstu.ac.bd/?"JSTU"
[2]: https://jstu.ac.bd/index.php/dept/cse.php "Computer Science and Engineering - JSTU :: Home"
[3]: https://jstu.ac.bd/index.php/dept/cse/faculties "Faculty Members of the Department - JSTU"