### PR TITLE
Add hce.edu.vn

### DIFF
--- a/lib/domains/vn/edu/hce.txt
+++ b/lib/domains/vn/edu/hce.txt
@@ -1,0 +1,1 @@
+Trường Đại học Kinh tế, Đại học Huế


### PR DESCRIPTION
This pull request adds the domain hce.edu.vn for "Trường Đại học Kinh tế, Đại học Huế" in Vietnam.

Official website: https://hce.edu.vn/