### PR TITLE
Add hufs korean name

### DIFF
--- a/lib/domains/kr/ac/hufs.txt
+++ b/lib/domains/kr/ac/hufs.txt
@@ -1,0 +1,2 @@
+한국외국어대학교
+Hankuk University of Foreign Studies


### PR DESCRIPTION
This pull request adds the Korean university domain for Hankuk University of Foreign Studies (HUFS).

- Added `hufs.txt` under `lib/domains/kr/ac/`
- This domain is used for student and faculty email addresses at HUFS
- Requesting to include it in the JetBrains educational domain list