### PR TITLE
Add Joongbu University (jungbu.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/jmail.txt
+++ b/lib/domains/kr/ac/jmail.txt
@@ -1,0 +1,2 @@
+중부대학교
+Joongbu University


### PR DESCRIPTION
This commit adds Joongbu University to the list of educational institutions.

- Official website: https://www.joongbu.ac.kr/
- Domain: jungbu.ac.kr
- Proof of IT-related courses: https://www.joongbu.ac.kr/smartit/ (Artificial Intelligence Major, School of Smart IT)
- The university provides student email addresses under jungbu.ac.kr
- The university offers long-term programs (4-year undergraduate and graduate courses)
- I am a student of Joongbu University, Artificial Intelligence Major