### PR TITLE
Add Shunde Wonder School(sdwdxx.com)

### DIFF
--- a/lib/domains/com/sdwdxx.txt
+++ b/lib/domains/com/sdwdxx.txt
@@ -1,0 +1,1 @@
+Guangdong Shunde Wonder School


### PR DESCRIPTION
Add sdwdxx.com (Guangdong Shunde Wonder School)

- **Domain:** sdwdxx.com  
- **Institution:** Shunde Wende School  
- **Location:** Shunde District, Foshan, Guangdong, China  
- **Programs:** Middle School, High School, International Division (A-Level, US High School Diploma, etc.)  
- **Evidence:** School website, international program page, faculty page  

---

**File to add:** `lib/domains/com/sdwdxx.txt`
---

### Refs

- Official website: [https://sdwdxx.com](https://sdwdxx.com)  
- Baidu Baike entry: [佛山市顺德区文德学校](https://baike.baidu.com/item/%E4%BD%9B%E5%B1%B1%E5%B8%82%E9%A0%86%E5%BE%B7%E5%8D%80%E6%96%87%E5%BE%B7%E5%AD%B8%E6%A0%A1/55979245)  
- International program info: [schoollist.m.ieduchina.com](https://schoollist.m.ieduchina.com/school/sdwdxx/admissions.html)  
- Faculty background: [xuanxiaozhuanjia.com](https://www.xuanxiaozhuanjia.com/xuexiao/sdwdxx/teacher.html)  

