### PR TITLE
Add domain vce.ac.in for Vasavi College of Engineering

### DIFF
--- a/lib/domains/in/edu/vce.txt
+++ b/lib/domains/in/edu/vce.txt
@@ -1,0 +1,1 @@
+Vasavi College of Engineering

--- a/lib/domains/in/edu/vce.txt
+++ b/lib/domains/in/edu/vce.txt
@@ -1,0 +1,1 @@
+Vasavi College Of Engineering

--- a/lib/domains/in/edu/vce.txt
+++ b/lib/domains/in/edu/vce.txt
@@ -1,1 +1,0 @@
-Vasavi College Of Engineering


### PR DESCRIPTION
This pull request adds the domain vce.ac.in.

Official website: https://www.vce.ac.in

A page with long-term IT-related courses: https://vce.ac.in/departments/cse/about-cse-department.php
(This page lists B.Tech courses including Computer Science programs.)

Proof that this domain is officially recognized by the college: 
<img width="2555" height="1351" alt="image" src="https://github.com/user-attachments/assets/5673a20b-3fa5-4148-b601-43784087b8a6" />
<img width="2559" height="1351" alt="image" src="https://github.com/user-attachments/assets/68c3fead-7903-4083-b7ab-9b3981e71ba7" />
