### PR TITLE
Added Pierce College, Puyallup Washington United States

### DIFF
--- a/lib/domains/edu/pcd/smail.txt
+++ b/lib/domains/edu/pcd/smail.txt
@@ -1,0 +1,1 @@
+Pierce College, Puyallup


### PR DESCRIPTION
### Added Pierce College, Puyallup, Washington, United States
College domain email is specific to students as mentioned on the website, ***Student Email*** System
Info: https://www.pierce.ctc.edu/tools/student-email/

College Website: https://pierce.ctc.edu/