### PR TITLE
Add iuh.edu.vn domain

### DIFF
--- a/lib/domains/vn/edu/iuh.txt
+++ b/lib/domains/vn/edu/iuh.txt
@@ -1,0 +1,1 @@
+Đại học Công nghiệp thành phố Hồ Chí Minh


### PR DESCRIPTION
This pull request adds the domain iuh.edu.vn for students of Trường Đại học Công nghiệp Thành phố Hồ Chí Minh (Industrial University of Ho Chi Minh City).
