### PR TITLE
Add caledonian.txt

### DIFF
--- a/lib/domains/uk/ac/caledonian.txt
+++ b/lib/domains/uk/ac/caledonian.txt
@@ -1,0 +1,2 @@
+Glasgow Caledonian University
+Glasgow Caledonian University


### PR DESCRIPTION
Adding the domain for @caledonian.ac.uk email addresses used by students of Glasgow Caledonian University.