### PR TITLE
Add alunos.estacio.br domain

### DIFF
--- a/lib/domains/br/estacio/alunos.txt
+++ b/lib/domains/br/estacio/alunos.txt
@@ -1,0 +1,1 @@
+Universidade Estácio de Sá


### PR DESCRIPTION
This PR adds the domain alunos.estacio.br for Universidade Estácio de Sá.
Official website: https://estacio.br
Proof that this domain is used for student emails:
- Example email: 202512345678@alunos.estacio.br