### PR TITLE
Add "@sempreunama.com.br" in education domains

### DIFF
--- a/lib/domains/br/com/sempreunama.txt
+++ b/lib/domains/br/com/sempreunama.txt
@@ -1,0 +1,2 @@
+Universidade da Amazônia
+University of the Amazon


### PR DESCRIPTION
Add the domain "sempreunama.com.br" in authorized education domains. UNAMA is the "University of the Amazon", a part of the group called "Ser Educacional", same group as the "sempreuninassau.com.br" domain.