### PR TITLE
add-akdeniz-domain

### DIFF
--- a/lib/domains/tr/edu/akdeniz.txt
+++ b/lib/domains/tr/edu/akdeniz.txt
@@ -1,0 +1,2 @@
+Akdeniz Üniversitesi
+Akdeniz University


### PR DESCRIPTION
Add domain akdeniz.edu.tr for Akdeniz Üniversitesi.

Proof & references:
- University homepage: https://www.akdeniz.edu.tr/
- Computer Engineering dept page (shows long-term IT-related programs): https://cse.akdeniz.edu.tr/tr/hakkinda-5955

Please let me know if you need additional documentation (e.g., screenshot of student e-mail page or an official PDF).
