### PR TITLE
Add Maadi STEM School (stemmaadi.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/stemmaadi.txt
+++ b/lib/domains/eg/edu/stemmaadi.txt
@@ -1,0 +1,1 @@
+stemmaadi.edu.eg 

--- a/lib/domains/eg/edu/stemmaadi/stemmaadi.txt
+++ b/lib/domains/eg/edu/stemmaadi/stemmaadi.txt
@@ -1,1 +1,0 @@
-Maadi STEM school

--- a/lib/domains/eg/edu/stemmaadi/stemmaadi.txt
+++ b/lib/domains/eg/edu/stemmaadi/stemmaadi.txt
@@ -1,0 +1,1 @@
+Maadi STEM school


### PR DESCRIPTION
Adding Maadi STEM School (stemmaadi.edu.eg) for JetBrains Student License verification.

Fixed the domain path so the correct domain (stemmaadi.edu.eg) is recognized.
