### PR TITLE
Add zagazig university

### DIFF
--- a/lib/domains/eg/edu/zu.txt
+++ b/lib/domains/eg/edu/zu.txt
@@ -1,0 +1,2 @@
+جامعة الزقازيق
+Zagazig university


### PR DESCRIPTION
As far as I understand, this allows the emails for 'Zagazig university in Egypt' to be working with the educational program.

An example of such emails is mine, which is `[censored]@eng.zu.edu.eg`

A URL that's for the university and also a proof of the `eng` subdomain is https://www.zu.edu.eg/Contents/Section/25 which has a card of the faculty of Engineering (.eng) right on top

Keep in mind, subdomains (of specific faculties) don't usually work, I linked the base URL (zu.edu.eg)

P.S I used to renew it for students but currently it doesn't work anymore, and I found out about this repo