### PR TITLE
Add Indira College of Commerce and Science

### DIFF
--- a/lib/domains/in/ac/iccs.txt
+++ b/lib/domains/in/ac/iccs.txt
@@ -1,0 +1,2 @@
+Indira College of Commerce and Science
+Indira College of Commerce and Science


### PR DESCRIPTION
This PR adds Indira College of Commerce and Science to the project.

College Name: Indira College of Commerce and Science

Website: https://iccs.ac.in/