### PR TITLE
Adding University of Houston-Downtown

### DIFF
--- a/lib/domains/edu/uhd/gator.txt
+++ b/lib/domains/edu/uhd/gator.txt
@@ -1,0 +1,1 @@
+University of Houston-Downtown

--- a/lib/domains/gator.txt
+++ b/lib/domains/gator.txt
@@ -1,0 +1,1 @@
+University of Houston-Downtown

--- a/lib/domains/gator.txt
+++ b/lib/domains/gator.txt
@@ -1,1 +1,0 @@
-University of Houston-Downtown


### PR DESCRIPTION
Adding these domains to the list:
uhd.edu
gator.uhd.edu
