### PR TITLE
Add Malta College of Arts, Science and Technology

### DIFF
--- a/lib/domains/mt/edu/mcast.txt
+++ b/lib/domains/mt/edu/mcast.txt
@@ -1,0 +1,1 @@
+Malta College of Arts, Science and Technology


### PR DESCRIPTION
Add academic domain mcast.edu.mt for Malta College of Arts, Science and Technology (MCAST).

Adds file lib/domains/mt/edu/mcast.txt containing the institution’s official name.

Links : https://www.mcast.edu.mt