### PR TITLE
Add sfsu.edu domain for San Francisco State University

### DIFF
--- a/lib/domains/edu/sfsu.txt
+++ b/lib/domains/edu/sfsu.txt
@@ -1,0 +1,1 @@
+San Francisco State University


### PR DESCRIPTION
This pull request adds the domain `sfsu.edu` for San Francisco State University.

- Official website: https://www.sfsu.edu/
- Official email info: https://its.sfsu.edu/services/email
- Students are provided with @sfsu.edu email accounts during their studies.

Thank you for reviewing this request!