### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/sv/edu/skillup.txt
+++ b/lib/domains/sv/edu/skillup.txt
@@ -1,0 +1,1 @@
+Escuela Superior de Tecnologia


### PR DESCRIPTION
Add skillup.edu.sv domain for Escuela Superior de Tecnología
Añadiendo el dominio skillup.edu.sv para la Escuela Superior de Tecnología.

- Sitio oficial:** https://skillup.edu.sv
- Programa relacionado https://skillup.edu.sv/
- Prueba del dominio: El correo institucional para estudiantes es del formato id@skillup.edu.sv 

