### PR TITLE
bedford.ac.uk

### DIFF
--- a/lib/domains/uk/ac/bedford.txt
+++ b/lib/domains/uk/ac/bedford.txt
@@ -1,0 +1,3 @@
+Bedford College & University Centre
+Bedford College Group
+.group


### PR DESCRIPTION
Domain for Bedford College Group