### PR TITLE
feat: add unversity of muhammadiyah ponorogo domain

### DIFF
--- a/lib/domains/id/ac/umpo.txt
+++ b/lib/domains/id/ac/umpo.txt
@@ -1,0 +1,2 @@
+Universitas Muhammadiyah Ponorogo
+Muhammadiyah University of Ponorogo


### PR DESCRIPTION
This PR adds the domain umpo.ac.id to the list of supported domains used for JetBrains student license verification.

For an information Universitas Muhammadiyah Ponorogo (UMPO) is a private Islamic university located in Ponorogo, East Java. It has 7 faculties and around 24 study programs (from Diploma through Postgraduate).