### PR TITLE
Add lib/domains/com/onmicrosoft/jdarcbretigny.txt

### DIFF
--- a/lib/domains/com/onmicrosoft/jdarcbretigny.txt
+++ b/lib/domains/com/onmicrosoft/jdarcbretigny.txt
@@ -1,0 +1,1 @@
+Jeanne d'Arc

--- a/lib/domains/com/onmicrosoft/jdarcbretigny.txt
+++ b/lib/domains/com/onmicrosoft/jdarcbretigny.txt
@@ -1,1 +1,1 @@
-Jeanne d'Arc
+Établissement Catholique Jeanne d'Arc de Brétigny sur Orge


### PR DESCRIPTION
This file represents the student email domain for Lycée Jeanne d'Arc, Brétigny-sur-Orge, France.

Official website: https://jeannedarc-bretigny.fr/
Evidence of an IT-related long-term curriculum: https://jeannedarc-bretigny.fr/lycee.html (BAC spécialité NSI — "Numérique et Sciences de l'Informatique" / "Digital and Computer Science").