### PR TITLE
Add usat.pe (Universidad Católica Santo Toribio de Mogrovejo)

### DIFF
--- a/lib/domains/pe/usat.txt
+++ b/lib/domains/pe/usat.txt
@@ -1,0 +1,2 @@
+Universidad Católica Santo Toribio de Mogrovejo
+Santo Toribio de Mogrovejo Catholic University


### PR DESCRIPTION
Adding Santo Toribio de Mogrovejo Catholic University (USAT) domain. Official website: https://www.usat.edu.pe
Evidence of IT-related program (>1 year): https://www.usat.edu.pe/facultad-de-ingenieria/ingenieria-de-sistemas-y-computacion/
Manual oficial: https://usat.storage.googleapis.com/tuproyectodevida/files/ManualCorreoUSAT.pdf 
Archivo añadido: lib/domains/pe/usat.txt  
Contenido del archivo:  
- Universidad Católica Santo Toribio de Mogrovejo  
- Santo Toribio de Mogrovejo Catholic University
