### PR TITLE
Add cisedu.eu

### DIFF
--- a/lib/domains/eu/cisedu.txt
+++ b/lib/domains/eu/cisedu.txt
@@ -1,0 +1,1 @@
+Cambridge International School, Bratislava


### PR DESCRIPTION
cisedu.eu - email domain for Cambridge International School, Bratislava
https://www.cambridgeschool.eu/