### PR TITLE
Add GSFC University (India)

### DIFF
--- a/lib/domains/ac/in/gsfcuniversity.txt
+++ b/lib/domains/ac/in/gsfcuniversity.txt
@@ -1,0 +1,2 @@
+GSFC University
+GSFC University


### PR DESCRIPTION
Added the domain gsfcuniversity.ac.in for GSFC University to enable student license support.