### PR TITLE
Add S.A.I.T.M (South Asian Institute of Technology and Management)

### DIFF
--- a/lib/domains/ac/in/saitm.txt
+++ b/lib/domains/ac/in/saitm.txt
@@ -1,0 +1,2 @@
+St. Andrews Institute of Technology and Management
+St. Andrews Institute of Technology and Management


### PR DESCRIPTION
This commit adds the domain for South Asian Institute of Technology and Management (SAITM).

- Official website: [http://saitm.ac.in](http://saitm.ac.in)
- Proof of domain: [link to any page showing student emails or .ac.in usage]
- Students receive email addresses in the format: name@saitm.ac.in
