### PR TITLE
add Uniatenas

### DIFF
--- a/lib/domains/br/edu/uniatenas.txt
+++ b/lib/domains/br/edu/uniatenas.txt
@@ -1,0 +1,1 @@
+Uniatenas Centro Universitário Atenas


### PR DESCRIPTION
This commit adds the uniatenas.edu.br domain, which is used for student and faculty email addresses at UniAtenas Centro Universitario Atenas.


Official website: https://www.atenas.edu.br/uniatenas