### PR TITLE
Add kpriet.ac.in domain

### DIFF
--- a/lib/domains/in/ac/kpriet.txt
+++ b/lib/domains/in/ac/kpriet.txt
@@ -1,0 +1,1 @@
+KPR Institute of Engineering and Technology, Coimbatore


### PR DESCRIPTION
Adds kpriet.ac.in — the official student email domain for KPR Institute of Engineering and Technology.
Reference: https://www.kpriet.ac.in