### PR TITLE
Add Sierra College (student.sierracollege.edu)

### DIFF
--- a/lib/domains/edu/sierracollege/student.txt
+++ b/lib/domains/edu/sierracollege/student.txt
@@ -1,0 +1,2 @@
+Sierra College
+Sierra College. https://www.sierracollege.edu/academics/interest-areas/science-technology-engineering-math/computer-science/


### PR DESCRIPTION
Adds student.sierracollege.edu for Sierra College. Data: • Official name: Sierra College • Student domain: student.sierracollege.edu • Examples: jdoe@student.sierracollege.edu, student123@student.sierracollege.edu • Proof: program page (domain ownership): https://www.sierracollege.edu/academics/interest-areas/science-technology-engineering-math/computer-science/ Compliance: • One school per PR • File path: lib/domains/edu/sierracollege/student.txt