### PR TITLE
Add unasam.edu.pe

### DIFF
--- a/lib/domains/pe/edu/unasam.txt
+++ b/lib/domains/pe/edu/unasam.txt
@@ -1,0 +1,2 @@
+Universidad Nacional Santiago Antúnez de Mayolo
+UNASAM


### PR DESCRIPTION
Adding domain `unasam.edu.pe` for Universidad Nacional Santiago Antúnez de Mayolo.

Official website: https://www.unasam.edu.pe/

Thank you!