### PR TITLE
Add upsifs.ac.in domain for Uttar Pradesh State Institute of Forensic Science

### DIFF
--- a/lib/domains/ac/in/upsifs.txt
+++ b/lib/domains/ac/in/upsifs.txt
@@ -1,0 +1,2 @@
+Uttar Padesh State Institute of Forensic Science
+Uttar Padesh State Institute of Forensic Science


### PR DESCRIPTION
This pull request adds the upsifs.ac.in domain to the swot repository. The domain is officially used by Uttar Pradesh State Institute of Forensic Science for student email addresses.

Official website: https://upsifs.ac.in  
Example student email: harshitt.2024@upsifs.ac.in  
The institute offers long-term IT-related courses.
