### PR TITLE
Add ebz-bs.de domain 

### DIFF
--- a/lib/domains/de/ebz-bs.txt
+++ b/lib/domains/de/ebz-bs.txt
@@ -1,0 +1,1 @@
+EBZ Business School


### PR DESCRIPTION
Institution: EBZ Business School  
Website: https://www.ebz-business-school.de/  

Evidence that this is the official student email domain:  
- The email domain **ebz-bs.de** is owned by EBZ Business School and forwards to the official school website https://www.ebz-business-school.de/  
- Contact page shows official addresses under the ebz-bs.de domain: https://www.ebz-business-school.de/kontakt  

Evidence of long-term (>1 year) IT-/related degree programmes:  
- EBZ offers multiple Bachelor and Master programmes (3+ years) listed under “Studiengänge” on their site: https://www.ebz-business-school.de/studiengaenge.html 


File added: `lib/domains/de/ebz-bs.txt`  
Contents: official institution name on the first line.