### PR TITLE
Add aiu.edu.eg domain for Alamein International University

### DIFF
--- a/lib/domains/eg/edu/aiu.txt
+++ b/lib/domains/eg/edu/aiu.txt
@@ -1,0 +1,1 @@
+Alamein International University


### PR DESCRIPTION
Official website: https://aiu.edu.eg
IT program: https://aiu.edu.eg/academics/field-of-computer-science-engineering/