### PR TITLE
Add Indian Institute of Technology (Indian School of Mines) Dhanbad

### DIFF
--- a/lib/domains/in/ac/iitism.txt
+++ b/lib/domains/in/ac/iitism.txt
@@ -1,0 +1,2 @@
+भारतीय प्रौद्योगिकी संस्थान (भारतीय खनि विद्यापीठ) धनबाद 
+Indian Institute of Technology (Indian School of Mines) Dhanbad


### PR DESCRIPTION
This PR adds iitism.ac.in for Indian Institute of Technology (Indian School of Mines), Dhanbad