### PR TITLE
Add Sidi Mohamed Ben Abdellah University, Fes

### DIFF
--- a/lib/domains/ma/ac/usmba.txt
+++ b/lib/domains/ma/ac/usmba.txt
@@ -1,0 +1,4 @@
+
+    Université Sidi Mohamed Ben Abdellah de Fès
+    Sidi Mohamed Ben Abdellah University Fes
+    


### PR DESCRIPTION

    Add Sidi Mohamed Ben Abdellah University, Fes, Morocco.

- Official university website: http://www.usmba.ac.ma/
- IT-related course (>1 year): https://fst-usmba.ac.ma/departement-informatique/
- The domain @usmba.ac.ma is the official email domain for enrolled students.