### PR TITLE
Add San Francisco State University (sfsu.edu)

### DIFF
--- a/lib/domains/edu/sfsu.txt
+++ b/lib/domains/edu/sfsu.txt
@@ -1,0 +1,1 @@
+San Francisco State University


### PR DESCRIPTION
School: San Francisco State University
Domain: sfsu.edu
Official site: https://www.sfsu.edu/
Files added per the “Add your school” form. Applying with institutional email jhu12@sfsu.edu.