### PR TITLE
Adding University Domain (ui.ac.id)

### DIFF
--- a/lib/domains/id/ac/ui.txt
+++ b/lib/domains/id/ac/ui.txt
@@ -1,0 +1,2 @@
+Universitas Indonesia
+University of Indonesia


### PR DESCRIPTION
This request is submitted to add the domain of Universitas Indonesia to the repository. The university referenced in this request is Universitas Indonesia (University of Indonesia), one of the leading and oldest higher education institutions in Indonesia. 

The official website of the university can be found here: https://www.ui.ac.id/en/

Thank you in advance for considering and reviewing this request.