### PR TITLE
Add domain files for P.T.P Rambaldi - De Fazio

### DIFF
--- a/lib/domains/it/edu/itedefazio.txt
+++ b/lib/domains/it/edu/itedefazio.txt
@@ -1,0 +1,1 @@
+P.T.P. "Rambaldi - De Fazio"

--- a/lib/domains/it/edu/polotecnologico.txt
+++ b/lib/domains/it/edu/polotecnologico.txt
@@ -1,0 +1,1 @@
+P.T.P. "Rambaldi - De Fazio"


### PR DESCRIPTION
Added support for the italian high school P.T.P "Rambaldi - De Fazio".

This institution uses two domains: `polotecnologico.edu.it` and `itedefazio.edu.it`.

Official website:
[ptprambaldidefazio.edu.it](https://ptprambaldidefazio.edu.it)