### PR TITLE
Create ulht.txt

### DIFF
--- a/lib/domains/pt/ulht.txt
+++ b/lib/domains/pt/ulht.txt
@@ -1,0 +1,1 @@
+Universidade Lusófona de Humanidades e Tecnologias


### PR DESCRIPTION
Add ulht.pt domain for Universidade Lusófona de Humanidades e Tecnologias - (students domain)

Hello JetBrains team,

I am adding the domain `ulht.pt`, which is used for student emails at
**Universidade Lusófona de Humanidades e Tecnologias** (Lisbon, Portugal).
Students use the subdomain `@alunos.ulht.pt`.

Proof and references:
- Official university website: https://www.ulusofona.pt
- Example of a long-term IT-related course (Computer Engineering):
  https://www.ulusofona.pt/licenciaturas/engenharia-informatica
- Evidence of official student email domain:
  https://www.ulusofona.pt/faqs/estudantes/questoes-administrativas/como-obtenho-o-meu-endereco-de-e-mail-como-estudante-da-universidade-lusofona

**Important note:**  
The domain `ulusofona.pt` already exists in this repository and is used
for professors emails.  
The domain `ulht.pt` is specifically used for **students** (`@alunos.ulht.pt`).  
Both domains are active and should coexist in the repository. Please do
not remove `ulusofona.pt`, since it serves a different group of users.

Adding `ulht.pt` ensures JetBrains can validate student emails correctly
while keeping `ulusofona.pt` for professors.