### PR TITLE
Add domain myskolae.fr for ESGI student emails

### DIFF
--- a/lib/domains/fr/myskolae.txt
+++ b/lib/domains/fr/myskolae.txt
@@ -1,1 +1,1 @@
-ESGI - Ecole Supérieure de Génie Informatique
+ESGI - École Supérieure de Génie Informatique

--- a/lib/domains/fr/myskolae.txt
+++ b/lib/domains/fr/myskolae.txt
@@ -1,0 +1,1 @@
+ESGI - Ecole Supérieure de Génie Informatique


### PR DESCRIPTION
This pull request adds the domain `myskolae.fr`, which is used for ESGI (École Supérieure de Génie Informatique) student email addresses.

- Official website of the institution: https://www.esgi.fr
- Example of long-term IT-related program (>= 1 year): https://www.esgi.fr/programmes.html
- Proof that students use `myskolae.fr` email domain: https://skolae.myintranet.online/login?ReturnUrl=%2F (student portal/login)

The domain is dedicated to ESGI students.
