### PR TITLE
Add Meerut Institute of Technology (mitmeerut.ac.in)

### DIFF
--- a/lib/domains/ac/in/mitmeerut.txt
+++ b/lib/domains/ac/in/mitmeerut.txt
@@ -1,1 +1,0 @@
-Meerut Institute of Technology

--- a/lib/domains/in/ac/mitmeerut.txt
+++ b/lib/domains/in/ac/mitmeerut.txt
@@ -1,0 +1,1 @@
+Meerut Institute of Technology


### PR DESCRIPTION
This PR adds support for student email addresses from Meerut Institute of Technology.

Domain: mitmeerut.ac.in
File location: lib/domains/ac/in/mitmeerut.txt

Official school website: https://mitmeerut.ac.in
Proof of domain ownership / academic use:
- Example student email: shivajee.cs.2022@mitmeerut.ac.in
Thank you for reviewing this request.
