### PR TITLE
Remove std.nisantasi.edu.tr from abused list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1157,7 +1157,6 @@ st.maltepe.edu.tr
 st.uskudar.edu.tr
 std.izu.edu.tr
 std.neu.edu.tr
-std.nisantasi.edu.tr
 std.yildiz.edu.tr
 stu.aydin.edu.tr
 stu.khas.edu.tr


### PR DESCRIPTION
I am a verified student of Nişantaşı Üniversitesi and my email (000000@std.nisantasi.edu.tr) is licensed under JetBrains Student Pack. This domain was blocked in abused.txt, but it is officially issued by the university and eligible for the Student Pack.