### PR TITLE
Add U1 University domain

### DIFF
--- a/lib/domains/kr/ac/yd/stu.txt
+++ b/lib/domains/kr/ac/yd/stu.txt
@@ -1,0 +1,2 @@
+유원대학교
+U1 University


### PR DESCRIPTION
This commit adds the domain stu.yd.ac.kr for U1 University (유원대학교).

Official website: https://www.u1.ac.kr
Proof of student email domain: https://www.u1.ac.kr (students use @stu.yd.ac.kr)