### PR TITLE
Adiciona o domínio ebserh.gov.br

### DIFF
--- a/lib/domains/br/gov/ebserh.txt
+++ b/lib/domains/br/gov/ebserh.txt
@@ -1,0 +1,1 @@
+Empresa Brasileira de Serviços Hospitalares


### PR DESCRIPTION
Adiciona o domínio ebserh.gov.br para permitir a solicitação de licenças estudantis para os alunos, empregados e servidores públicos da Empresa Brasileira de Serviços Hospitalares.