### PR TITLE
add domain edu.teu.ac.jp

### DIFF
--- a/lib/domains/jp/ac/teu/edu.txt
+++ b/lib/domains/jp/ac/teu/edu.txt
@@ -1,0 +1,2 @@
+東京工科大学
+Tokyo University of Technology


### PR DESCRIPTION
Add domain edu.teu.ac.jp for Tokyo University of Technology

official website : https://www.teu.ac.jp/english/index.html
