### PR TITLE
Add utp.edu.pe (Universidad Tecnológica del Perú)

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica del Perú


### PR DESCRIPTION
Added domain utp.edu.pe for Universidad Tecnológica del Perú to support JetBrains student license verification.