### PR TITLE
Add Sejong University

### DIFF
--- a/lib/domains/kr/ac/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University

--- a/lib/domains/kr/ac/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/lib/domains/kr/ac/sju.txt
@@ -1,2 +1,0 @@
-세종대학교
-Sejong University

--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
This commit adds Sejong University to the list of educational domains.
Domain: sju.ac.kr
Official website: https://www.sejong.ac.kr/