### PR TITLE
Add NIT Mizoram domain nitmz.ac.in

### DIFF
--- a/lib/domains/in/ac/nitmz.txt
+++ b/lib/domains/in/ac/nitmz.txt
@@ -1,1 +1,2 @@
 National Institute of Technology, Mizoram
+ 


### PR DESCRIPTION
This PR adds the academic email domain for National Institute of Technology Mizoram to swot at lib/domains/in/ac/nitmz.txt.

Institution: National Institute of Technology Mizoram (NIT Mizoram).

Domain to approve: nitmz.ac.in (apex domain; covers student/teacher emails where applicable).

Motivation: Enables students and faculty using nitmz.ac.in to request JetBrains educational licenses.

Evidence links: Official website, academic programs/IT/email references indicating nitmz.ac.in usage (provided for reviewer verification).

Notes: File contains the official institute name on the first line, as per repository guidelines.