### PR TITLE
Add uniplan.edu.br domain

### DIFF
--- a/lib/domains/br/edu/uniplan/aluno.txt
+++ b/lib/domains/br/edu/uniplan/aluno.txt
@@ -1,0 +1,2 @@
+Centro Universitário Planalto do Distrito Federal
+UNIPLAN


### PR DESCRIPTION
Instituição: Centro Universitário Planalto do Distrito Federal (UNIPLAN)

Site oficial: https://www.uniplan.edu.br

Página que comprova uso do domínio acadêmico: https://www.uniplan.edu.br

Página com cursos de longa duração na área de TI: https://www.uniplandf.edu.br/ensino/graduacao/tecnologicos/analise_desenvolvimento_sistemas.asp

Observação:
Este domínio é usado por estudantes de graduação e pós-graduação. A instituição oferece cursos de duração superior a 1 ano em áreas relacionadas à tecnologia da informação.