### PR TITLE
Add PES Trust pedtrust.edu.in domain for educational JetBrains licenses

### DIFF
--- a/lib/domains/in/edu/pestrust.txt
+++ b/lib/domains/in/edu/pestrust.txt
@@ -1,0 +1,1 @@
+P.E.S. Institute of Technology and Management


### PR DESCRIPTION
This pull request adds the @pestrust.edu.in domain so that students and staff of PES Modern College of Engineering can request free educational licenses for JetBrains tools.
