### PR TITLE
Adding po.edu.pl domain

### DIFF
--- a/lib/domains/pl/edu/po.txt
+++ b/lib/domains/pl/edu/po.txt
@@ -1,0 +1,2 @@
+Opole University of Technology
+Politechnika Opolska


### PR DESCRIPTION
Adding the _**po.edu.pl**_ domain, so lecturers at Opole University of Technology can benefit from using the JetBrains products:
- [The university official website URL](https://po.edu.pl/?lang=en)
- [Faculty of Computer Science](https://wi.po.edu.pl/)
- [An email that uses the domain added with this PR](https://po.edu.pl/pracownicy/salama-hassona/)