### PR TITLE
feat: Add domain for Morioka IT, Business and Design College(morijyobi.ac.jp)

### DIFF
--- a/lib/domains/jp/ac/morijyobi.txt
+++ b/lib/domains/jp/ac/morijyobi.txt
@@ -1,0 +1,2 @@
+MCL盛岡情報ビジネス&デザイン専門学校
+Morioka IT, Business and Design College (Tatsuzawa Education Group)


### PR DESCRIPTION
Hello,

I would like to add the domain [morijyobi.ac.jp] for [MCL盛岡情報ビジネス&デザイン専門学校] to the swot repository.
This institution offers long-term, IT-related courses, and this domain is used as the official email for enrolled students.
To expedite your verification process, here are the required links:

大学の公式サイト URL (University Official Website URL):
- https://morijyobi.ac.jp/

長期（1 年超）IT 関連コースの URL (URL of Long-Term IT-Related Course):
- https://morijyobi.ac.jp/course_it_itexpert/

備考: 高度情報工学科の 4 年間のカリキュラムページです。

Please let me know if you need any further information. Thank you for your time!