### PR TITLE
Add San Francisco State University domain (sfsu.edu)

### DIFF
--- a/lib/domains/edu/sfsu/sfsu.txt
+++ b/lib/domains/edu/sfsu/sfsu.txt
@@ -1,0 +1,1 @@
+sfsu.edu


### PR DESCRIPTION
This pull request adds the domain `sfsu.edu` for San Francisco State University.  
This will allow students with emails under this domain to apply for the JetBrains Student Program.
