### PR TITLE
Add mahidol.ac.th back to trusted list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1101,7 +1101,6 @@ dpu.ac.th
 kmitl.ac.th
 live.ku.th
 lpru.ac.th
-mahidol.ac.th
 mju.ac.th
 ms.kbu.ac.th
 my.buu.ac.th

--- a/lib/domains/th/ac/mahidol.txt
+++ b/lib/domains/th/ac/mahidol.txt
@@ -1,0 +1,1 @@
+Mahidol University


### PR DESCRIPTION
Mahidol University has two domain names currently: mahidol.edu and mahidol.ac.th. New staff will only have mahidol.ac.th as this comes with the new email systems. Blocking this domain will block access for new staff.