### PR TITLE
Create maricopa.txt

### DIFF
--- a/lib/domains/edu/maricopa.txt
+++ b/lib/domains/edu/maricopa.txt
@@ -1,0 +1,2 @@
+Maricopa Community Colleges
+Chandler-Gilbert Community College


### PR DESCRIPTION
Added maricopa.edu domain for Chandler-Gilbert Community College, part of the Maricopa Community Colleges District.
