### PR TITLE
Add domain for Atatürk Üniversitesi

### DIFF
--- a/lib/domains/tr/edu/atauni.txt
+++ b/lib/domains/tr/edu/atauni.txt
@@ -1,0 +1,2 @@
+Atatürk Üniversitesi
+Atatürk University


### PR DESCRIPTION
Add domain for Atatürk Üniversitesi

- Official website: https://www.atauni.edu.tr
- Proof of IT/program: https://atauni.edu.tr/bilgisayar-bilisim
- Students use emails like student@atauni.edu.tr , student@ogr.atauni.edu.tr