### PR TITLE
added nu (Nile university) to the domains/eg/edu

### DIFF
--- a/lib/domains/eg/edu/nu/nu.txt
+++ b/lib/domains/eg/edu/nu/nu.txt
@@ -1,0 +1,1 @@
+Nile University


### PR DESCRIPTION
Nile university have been added.

Official url : https://www.nu.edu.eg/
Program > 1year IT course url : https://itcs.nu.edu.eg/

