### PR TITLE
Add Nippon Engineering College of Hachioji domain

### DIFF
--- a/lib/domains/jp/ac/neec.txt
+++ b/lib/domains/jp/ac/neec.txt
@@ -1,0 +1,2 @@
+日本工学院八王子専門学校
+Nippon Engineering College of Hachioji


### PR DESCRIPTION
Official website: https://www.neec.ac.jp/
Long-term IT course: https://www.neec.ac.jp/department/it/
The domain g.neec.ac.jp / neec.ac.jp is used for student email addresses.
