### PR TITLE
Adding domain for Key Institute

### DIFF
--- a/lib/domains/com/keyinstitute.txt
+++ b/lib/domains/com/keyinstitute.txt
@@ -1,0 +1,1 @@
+Instituto Especializado de Nivel Superior Kriete de Ingeniería y Ciencias

--- a/lib/domains/sv/edu/keyinstitute.txt
+++ b/lib/domains/sv/edu/keyinstitute.txt
@@ -1,0 +1,1 @@
+Instituto Especializado de Nivel Superior Kriete de Ingeniería y Ciencias


### PR DESCRIPTION
https://www.keyinstitute.com/

Key institute (short name)
Instituto Especializado de Nivel Superior Kriete de Ingeniería y Ciencias (full name)

Is a brand new engineering school based in El Salvador with courses of about 3 years and half, focus on It and brand new technologies.

I added the .com domain for the main website, and the .edu.sv domain that is the ones that the students accounts are assigned to.