### PR TITLE
fix: remove tvtc.edu.sa from abused.txt (official educational domain)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1065,7 +1065,6 @@ rb.moe.gov.sa
 rg.moe.gov.sa
 stu.jazanu.edu.sa
 student.iatc.edu.sa
-tvtc.edu.sa
 uhb.edu.sa
 upm.edu.sa
 student.lnu.se


### PR DESCRIPTION
#### Institution/School Name  
Technical and Vocational Training Corporation (TVTC)  

#### Institution/School Website  
https://www.tvtc.gov.sa  

#### Email Users  

*Please place an x between the square brackets if yes*  
- [x] Students  
- [x] Academic/Teaching Staff  
- [x] Other/Support Staff  
- [ ] Alumni  

#### Education Levels  

*Please place an x between the square brackets if yes*  

- [ ] Post-graduate research  
- [ ] Graduate School  
- [x] College (University) or Undergraduate School or equivalent  
- [x] Community College or equivalent  
- [x] High School or equivalent  
- [x] Elementary School or equivalent  
