### PR TITLE
Add Institute of Science Tokyo

### DIFF
--- a/lib/domains/jp/ac/isct.txt
+++ b/lib/domains/jp/ac/isct.txt
@@ -1,0 +1,2 @@
+東京科学大学
+Institute of Science Tokyo


### PR DESCRIPTION
- Official website URL: https://www.isct.ac.jp/en
- a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://educ.titech.ac.jp/is/eng/
- a URL of a page showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students: https://portal.isct.ac.jp/en/sys/gmail/