### PR TITLE
Add vnu.edu.vn domain for Vietnam National University, Hanoi

### DIFF
--- a/lib/domains/vn/edu/vnu.txt
+++ b/lib/domains/vn/edu/vnu.txt
@@ -1,0 +1,2 @@
+Đại học Quốc gia Hà Nội
+Vietnam National University, Hanoi


### PR DESCRIPTION
This pull request adds the domain vnu.edu.vn for Vietnam National University, Hanoi.

Verification details:
- Official website: https://vnu.edu.vn/
- IT-related course: https://uet.vnu.edu.vn/
- Proof of student email domain: https://24022468@vnu.edu.vn/
