### PR TITLE
Add sesipb.org.br (SESI Paraíba)

### DIFF
--- a/lib/domains/br/org/sesipb.txt
+++ b/lib/domains/br/org/sesipb.txt
@@ -1,0 +1,3 @@
+Serviço Social da Indústria da Paraíba
+SESI Paraíba
+.group


### PR DESCRIPTION
Official website: https://www.fiepb.com.br/sesi
Domain used for student emails: @aluno.sesipb.org.br
Institution name: Serviço Social da Indústria da Paraíba (SESI PB)
Domain type: group (used by multiple SESI schools in Paraíba)