### PR TITLE
Add NMIMS institution details to nmims.txt

### DIFF
--- a/lib/domains/in/nmims.txt
+++ b/lib/domains/in/nmims.txt
@@ -1,0 +1,4 @@
+SVKM’s NMIMS (Narsee Monjee Institute of Management Studies)
+Mukesh Patel School of Technology Management & Engineering, Mumbai
+Mukesh Patel School of Technology Management & Engineering, Shirpur
+.group


### PR DESCRIPTION
NMIMS Official Website - https://nmims.edu/
Courses Offered - https://engineering-shirpur.nmims.edu/ and https://nmims.edu/undergraduate-engineering
There's a change in the domain, though. In college, faculties are provided with .edu extensions, and students are given .in extensions, which is strange. (Example of Student mail - studentname@nmims.in)