### PR TITLE
Add maricopa.edu domain for Maricopa County Community College District

### DIFF
--- a/lib/domains/edu/maricopa.txt
+++ b/lib/domains/edu/maricopa.txt
@@ -1,0 +1,11 @@
+Maricopa County Community College District
+Rio Salado College
+Mesa Community College
+Glendale Community College
+Scottsdale Community College
+Chandler-Gilbert Community College
+Paradise Valley Community College
+Phoenix College
+Estrella Mountain Community College
+GateWay Community College
+South Mountain Community College


### PR DESCRIPTION
# Pull Request: Add Maricopa Community Colleges (maricopa.edu)

This pull request adds **[Maricopa Community Colleges](https://www.maricopa.edu/)**  to the repository. All colleges within the Maricopa County Community College District in Arizona share the same official email domain: `@maricopa.edu`.  

## Included Colleges
- [Chandler-Gilbert Community College](https://www.cgc.edu/)  
- [Estrella Mountain Community College](https://www.estrellamountain.edu/)  
- [GateWay Community College](https://www.gatewaycc.edu/)  
- [Glendale Community College](https://www.gccaz.edu/)  
- [Mesa Community College](https://www.mesacc.edu/)  
- [Paradise Valley Community College](https://www.paradisevalley.edu/)  
- [Phoenix College](https://www.phoenixcollege.edu/)  
- [Rio Salado College](https://www.riosalado.edu/)  
- [Scottsdale Community College](https://www.scottsdalecc.edu/)  
- [South Mountain Community College](https://www.southmountaincc.edu/)  

**Domain:** `maricopa.edu`  
**Official website:** [https://www.maricopa.edu](https://www.maricopa.edu)  

This addition allows JetBrains educational license verification for all Maricopa Community College students using the shared `@maricopa.edu` domain.