### PR TITLE
Add United Arab Emirates University (uaeu.ac.ae) domain

### DIFF
--- a/lib/domains/ae/ac/uaeu.txt
+++ b/lib/domains/ae/ac/uaeu.txt
@@ -1,0 +1,2 @@
+United Arab Emirates University
+United Arab Emirates University


### PR DESCRIPTION
Added the domain file for United Arab Emirates University to support student email addresses ending with @uaeu.ac.ae.
