### PR TITLE
Add rcee.ac.in.txt domain for Ramachandra College of Engineering

### DIFF
--- a/lib/domains/in/rcee.ac.in.txt
+++ b/lib/domains/in/rcee.ac.in.txt
@@ -1,0 +1,1 @@
+Ramachandra College of Engineering


### PR DESCRIPTION
Official website: **https://www.rcee.ac.in/**

Long-term IT course page: **https://www.rcee.ac.in/**
RCEE offers many courses like: CSE, ECE, Mechanical, Civil and EEE

Domain usage: **https://www.rcee.ac.in/about/contact-us**
This page lists official emails like [helpdesk@rcee.ac.in](mailto:helpdesk@rcee.ac.in), confirming that rcee.ac.in is the official student domain.

<img width="496" height="310" alt="Screenshot 2025-10-06 195435" src="https://github.com/user-attachments/assets/d494c317-414b-4cbb-b14f-f4263034b416" />
