### PR TITLE
Add new domain of WHZ

### DIFF
--- a/lib/domains/de/whz.txt
+++ b/lib/domains/de/whz.txt
@@ -1,0 +1,2 @@
+Westsächsische Hochschule Zwickau
+University of Applied Sciences Zwickau


### PR DESCRIPTION
WHZ is migrating from `fh-zwickau.de` to `whz.de`
- [Computer Science B.Sc. course](https://www.whz.de/english/study/incomings/courses-of-study/computer-sciences-bachelor/)
- [Migration notice (German)](https://www.whz.de/zki/netzdienste/e-mail/umstellung-whzde/)