### PR TITLE
Add San Jose State University in San Jose, California, USA

### DIFF
--- a/lib/domains/edu/sjsu.txt
+++ b/lib/domains/edu/sjsu.txt
@@ -1,0 +1,1 @@
+San Jose State University


### PR DESCRIPTION
San Jose State University
www.sjsu.edu

https://en.wikipedia.org/wiki/San_Jose_State_University

San José State University (San Jose State or SJSU) is a public research university in San Jose, California. Established in 1857 as the state's first normal school, it is the oldest public university in the western United States[9] and is the founding campus of the California State University system.[10][11]

Located in downtown San Jose, San Jose State's main campus spans 154 acres (62 ha), or roughly 19 square blocks. It is accredited by the WASC Senior College and University Commission[12] and is classified among "R2: High Research Spending and Doctorate Production".[13] It is a federally-designated Hispanic-Serving Institution as well as an Asian American and Native American Pacific Islander-Serving Institution.[14]

SJSU comprises nine academic colleges, who offer over 250 undergraduate and graduate degree programs.[15] Its enrollment is about 37,000 students annually, including around 28,000 undergraduate and 9,000 graduate and professional students.[5] As of fall 2022, graduate student enrollment, Asian, and international student enrollments at SJSU were the highest of any campus in the CSU system.[5]

San Jose State's sports teams compete as the Spartans in the NCAA Division I Mountain West Conference and have won 10 team national championships and 50 individual national championships. SJSU athletes have competed in every Olympics since 1948 and have amassed 21 medals.