### PR TITLE
Add rcee.ac.in domain

### DIFF
--- a/lib/domains/in/ac/rcee.txt
+++ b/lib/domains/in/ac/rcee.txt
@@ -1,0 +1,1 @@
+Ramachandra College Of Engineering


### PR DESCRIPTION
Official Website: **https://www.rcee.ac.in/**

RCEE offers various courses, including CSE, ECE, EEE, Mechanical, and Civil.

Domain usage: **https://www.rcee.ac.in/about/contact-us**
-> This page lists officials like **helpdesk@rcee.ac.in**, confirming that rcee.ac.in is the official domain

<img width="496" height="310" alt="Screenshot 2025-10-06 195435" src="https://github.com/user-attachments/assets/1255f24e-6c9b-4564-a7c8-f1067f13632b" />
