### PR TITLE
Add sus.flb-herford.de (Friedrich-List-Berufskolleg Herford, Germany)

### DIFF
--- a/lib/domains/de/flb-herford/sus.txt
+++ b/lib/domains/de/flb-herford/sus.txt
@@ -1,0 +1,1 @@
+Friedrich-List Berufskolleg

--- a/lib/domains/de/flb-herford/sus.txt
+++ b/lib/domains/de/flb-herford/sus.txt
@@ -1,1 +1,1 @@
-Friedrich-List Berufskolleg
+Friedrich-List-Berufskolleg Herford


### PR DESCRIPTION
This is a public Berufskolleg (vocational secondary school) in Germany
Students are assigned email addresses in the format: 
name@sus.flb-herford.de