### PR TITLE
Delete lib/domains/jp/co/termnet.txt

### DIFF
--- a/lib/domains/jp/co/termnet.txt
+++ b/lib/domains/jp/co/termnet.txt
@@ -1,1 +1,0 @@
-Fuji University


### PR DESCRIPTION
This domain is clearly owned by a company, not by a university.
Fuji University is https://www.fuji-u.ac.jp/ and this co.jp domain is unrelated.