### PR TITLE
Add Institut de l'Olivier Sfax

### DIFF
--- a/lib/domains/tn/u-sfax/ios.txt
+++ b/lib/domains/tn/u-sfax/ios.txt
@@ -1,0 +1,2 @@
+Institut de l'Olivier Sfax
+معهد الزيتونة بصفاقس


### PR DESCRIPTION
Add Institut de l'Olivier Sfax
Part of University Of Sfax (https://uss.rnu.tn)