### PR TITLE
Add Flambeau High School (flambeauschools.org)

### DIFF
--- a/lib/domains/org/flambeauschools.txt
+++ b/lib/domains/org/flambeauschools.txt
@@ -1,0 +1,2 @@
+flambeauschools
+Flambeau Schools


### PR DESCRIPTION
Adding the domain for Flambeau High School, a public high school located in Tony, Wisconsin. 

School Website: https://www.flambeau.k12.wi.us/