### PR TITLE
Add Adani University to the domains list

### DIFF
--- a/lib/domains/in/ac/adaniuni.txt
+++ b/lib/domains/in/ac/adaniuni.txt
@@ -1,0 +1,1 @@
+Adani University


### PR DESCRIPTION
Add Adani University domain

University: Adani University
Website: https://adaniuni.ac.in

The domain adaniuni.ac.in is used for official university email accounts