### PR TITLE
Add Neil Gogte Institute of Technology to edu domain

### DIFF
--- a/lib/domains/in/edu/ngit.txt
+++ b/lib/domains/in/edu/ngit.txt
@@ -1,0 +1,1 @@
+Neil Gogte Institute of Technology


### PR DESCRIPTION
Official Website: https://ngit.ac.in/
Courses: https://ngit.ac.in/departments
ngit.edu.in is the official student email domain