### PR TITLE
Add smec.ac.in Domain 

### DIFF
--- a/lib/domains/in/ac/smec.txt
+++ b/lib/domains/in/ac/smec.txt
@@ -1,0 +1,1 @@
+St. Martin’s Engineering College


### PR DESCRIPTION
Added a smec.ac.in Domain in the list. This domain is associated with St. Martin’s Engineering College, Hyderabad, India