### PR TITLE
Add islec.edu.in domain for ISL Engineering College

### DIFF
--- a/lib/domains/in/edu/islec.txt
+++ b/lib/domains/in/edu/islec.txt
@@ -1,0 +1,1 @@
+ISL Engineering College


### PR DESCRIPTION
## School Details
- **Name:** ISL Engineering College
- **Official Website:** https://isl.edu.in/
- **Affiliation:** Affiliated to Osmania University, approved by AICTE with Estd: 2008
- **Location:** Hyderabad, Telangana, India
## Verification
The university recognizes islec.edu.in as an official email domain for enrolled students.
**Evidence:**
- Official website lists this domain
- Domain serves student email addresses (usernames@islec.edu.in)
## File Structure
Following the existing convention for in/edu domains:
- Created: `lib/domains/in/edu/islec.txt`
- Content: School name "ISL Engineering College"