### PR TITLE
Adding Geneva Business School

### DIFF
--- a/lib/domains/com/gbsge.txt
+++ b/lib/domains/com/gbsge.txt
@@ -1,0 +1,1 @@
+Geneva Business School


### PR DESCRIPTION
Adding Geneva Business School

Site url: https://gbsge.com/programs/master-of-international-management/#specializations

Course syllabus: 
[Business Intelligence Syllabus.pdf](https://github.com/user-attachments/files/25919140/Business.Intelligence.Syllabus.pdf)

