### PR TITLE
Added STI Ortigas-Cainta

### DIFF
--- a/lib/domains/ph/edu/sti/ortigas-cainta.txt
+++ b/lib/domains/ph/edu/sti/ortigas-cainta.txt
@@ -1,0 +1,1 @@
+STI College Ortigas-Cainta


### PR DESCRIPTION
The Ortigas-Cainta branch uses the "ortigas-cainta.sti.edu.ph" domain name for both Students and Staff