### PR TITLE
Add binus.ac.id (student emails) and remove from abused list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -567,7 +567,6 @@ vict.edu.ht
 o365.u-szeged.hu
 unibge.hu
 belajar.id
-binus.ac.id
 ecampus.ut.ac.id
 fh.unair.ac.id
 kings.ac.id

--- a/lib/domains/id/ac/binus.txt
+++ b/lib/domains/id/ac/binus.txt
@@ -1,0 +1,2 @@
+Universitas Bina Nusantara
+BINUS University


### PR DESCRIPTION
Adds the BINUS (Universitas Bina Nusantara) student domain `binus.ac.id`. This pull request also removes `binus.ac.id` from lib/domains/abused.txt. The existing `binus.edu` entry remains for faculty/staff.

**Official site**
https://www.binus.ac.id/

**IT/CS program**
https://binus.ac.id/program/computer-science-2/

**Student email issuance**
https://student.binus.ac.id/fyp/lets-do-it/

**Verification contacts:**
- BINUS IT Helpdesk: ithelpdesk@binus.edu (https://www.binus.edu/connect/website/236/IT-Helpdesk)
- BINUS Support (Admissions / general support): infobinus@binus.edu and halobinus@binus.edu (https://binus.ac.id/contact-us/)

**Notes:**
- The existing `binus.edu` entry is used by faculty/staff.
- This pull request adds `binus.ac.id`, which is used by students, and removes it from lib/domains/abused.txt.
- If maintainers need direct confirmation from BINUS IT, please contact the addresses above.
