### PR TITLE
Add Melanchthon Scholengroep and CVO (ChristenVO) domains

### DIFF
--- a/lib/domains/nl/cvo.txt
+++ b/lib/domains/nl/cvo.txt
@@ -1,0 +1,2 @@
+CVO (ChristenVO)
+.group

--- a/lib/domains/nl/cvo.txt
+++ b/lib/domains/nl/cvo.txt
@@ -1,2 +1,0 @@
-CVO (ChristenVO)
-.group

--- a/lib/domains/nl/melanchthon.txt
+++ b/lib/domains/nl/melanchthon.txt
@@ -1,0 +1,2 @@
+Melanchthon Scholengroep
+.group


### PR DESCRIPTION
Adding two related school domains from the Netherlands:

- **melanchthon.nl**: Melanchthon Scholengroep
- **cvo.nl**: CVO (ChristenVO) - parent organization

Both are groups of secondary schools offering vmbo, havo, and vwo education (4-6 year programs).

**Official websites:**
- https://melanchthon.nl
- https://cvo.nl

**Proof of educational programs:**
Melanchthon offers multi-year IT-related programs including:
- VWO (pre-university, 6 years) with computer science and informatics
- HAVO (senior general secondary, 5 years) with technology courses
- VMBO (pre-vocational, 4 years) with Tech+ and ICT tracks

**Email domain verification:**
Students and staff use @melanchthon.nl and @cvo.nl email addresses for official school communication.

Both domains include all subdomains (as per Swot guidelines).