### PR TITLE
Add missing Russian technical universities

### DIFF
--- a/lib/domains/ru/mgtu.txt
+++ b/lib/domains/ru/mgtu.txt
@@ -1,0 +1,2 @@
+Moscow State Technical University of Civil Aviation
+Moscow State Technical University of Civil Aviation

--- a/lib/domains/ru/pnrpu.txt
+++ b/lib/domains/ru/pnrpu.txt
@@ -1,0 +1,2 @@
+Perm National Research Polytechnic University
+Perm National Research Polytechnic University

--- a/lib/domains/ru/spbpu.txt
+++ b/lib/domains/ru/spbpu.txt
@@ -1,0 +1,2 @@
+Peter the Great St. Petersburg Polytechnic University
+Peter the Great St. Petersburg Polytechnic University

--- a/lib/domains/ru/tusur.txt
+++ b/lib/domains/ru/tusur.txt
@@ -1,0 +1,2 @@
+Tomsk State University of Control Systems and Radioelectronics
+Tomsk State University of Control Systems and Radioelectronics


### PR DESCRIPTION
Added 4 Russian technical universities not previously in the database:

- spbpu.ru: Peter the Great St. Petersburg Polytechnic University
- mgtu.ru: Moscow State Technical University of Civil Aviation
- tusur.ru: Tomsk State University of Control Systems and Radioelectronics
- pnrpu.ru: Perm National Research Polytechnic University