### PR TITLE
Add Santa Fe College - sfcollege.edu (students: go.sfcollege.edu)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1476,7 +1476,6 @@ utpl.edu.ec
 dharuma.edu.mv
 365.cmu.edu.tw
 kag-erding.de
-sfcollege.edu
 utcancun.edu.mx
 alunos.estacio.br
 aluno.uniasselvi.com.br

--- a/lib/domains/edu/sfcollege.txt
+++ b/lib/domains/edu/sfcollege.txt
@@ -1,0 +1,1 @@
+Santa Fe College


### PR DESCRIPTION
Dear JetBrains/swot maintainers,

Students at Santa Fe College can't access JetBrains educational licenses because `sfcollege.edu` is in `abused.txt`.

Santa Fe College is a public college in Gainesville, FL with accredited degree programs in IT and Computer Science. Student emails (`@go.sfcollege.edu`) are provisioned through Microsoft 365 and tied to enrollment - not open registration.

**Changes:**
- Added `lib/domains/edu/sfcollege.txt` > `Santa Fe College`
- Removed `sfcollege.edu` from `lib/domains/abused.txt`

Verification links:
- https://www.sfcollege.edu/
- https://www.sfcollege.edu/its/faq/how-to-login-to-office-365.html
- https://www.sfcollege.edu/academics/programs/3504.html

