### PR TITLE
Create uii.txt

### DIFF
--- a/lib/domains/mx/edu/uii.txt
+++ b/lib/domains/mx/edu/uii.txt
@@ -1,0 +1,1 @@
+Instituto Irapuato


### PR DESCRIPTION
Adds uii.edu.mx domain for Instituto Irapuato.
Official site: https://www.uii.edu.mx/
Student emails use subdomain correo.uii.edu.mx