### PR TITLE
Register the domain of Coptic College for Girls School

### DIFF
--- a/lib/domains/eg/edu/moe/cairo2.txt
+++ b/lib/domains/eg/edu/moe/cairo2.txt
@@ -1,0 +1,2 @@
+مدرسة كلية البات القبطية لغات
+Coptic College for Girls Language School


### PR DESCRIPTION
Register the domain of Coptic College for Girls School  "cairo2.moe.edu.eg" 