### PR TITLE
Add Universitas Negeri Malang (um.ac.id)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -598,7 +598,6 @@ student.uny.ac.id
 students.smanra.sch.id
 students.uajy.ac.id
 students.ukdw.ac.id
-students.um.ac.id
 ugm.ac.id
 uin-alauddin.ac.id
 uin-suka.ac.id
@@ -1546,7 +1545,6 @@ istitutofreud.it
 epu.edu.vn
 sonatech.ac.in
 itpln.ac.id
-um.ac.id
 ksu.edu.sa
 itcancun.edu.mx
 sut.edu.eg

--- a/lib/domains/id/ac/um.txt
+++ b/lib/domains/id/ac/um.txt
@@ -1,0 +1,1 @@
+Universitas Negeri Malang


### PR DESCRIPTION
Added um.ac.id domain for Universitas Negeri Malang student verification.

- Domain: um.ac.id
- Institution: Universitas Negeri Malang
- Location: Malang, Indonesia
- Website: https://um.ac.id