### PR TITLE
Added Shingu College

### DIFF
--- a/lib/domains/kr/ac/shingu.txt
+++ b/lib/domains/kr/ac/shingu.txt
@@ -1,0 +1,2 @@
+신구대학교
+Shingu College


### PR DESCRIPTION
Our college uses the g.shingu.ac.kr extension specifically for student emails. As per the guidelines stating that different extensions for students and professors are acceptable, please note that faculty members use the shingu.ac.kr parent domain.

web site: https://www.shingu.ac.kr