### PR TITLE
Add Kwame Nkrumah University of Science & Technology

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1599,7 +1599,6 @@ muet.edu.pk
 isb.edu.vn
 ice.go.kr
 uth.hn
-knust.edu.gh
 pucese.edu.ec
 uty.ac.id
 duksung.ac.kr

--- a/lib/domains/gh/edu/knust.txt
+++ b/lib/domains/gh/edu/knust.txt
@@ -1,0 +1,2 @@
+Kwame Nkrumah University of Science & Technology
+KNUST


### PR DESCRIPTION
Adding Kwame Nkrumah University of Science & Technology (KNUST) in Ghana to the whitelist. 

**Details:**
* **Official Website:** https://www.knust.edu.gh
* **IT Courses:** https://www.knust.edu.gh/academics/programmes (e.g., BSc. Computer Science, BSc. Information Technology)
* **Student Email Domain:** knust.edu.gh (e.g., student@knust.edu.gh)

The domain was previously listed as abused, but it is the primary domain for students at KNUST. I have removed it from the abused list and added it to the whitelist.