### PR TITLE
Add Lyceum of the Philippines University (lpunetwork.edu.ph)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -942,7 +942,6 @@ dlsud.edu.ph
 email.lcup.edu.ph
 feucanvas.edu.ph
 fit.edu.ph
-lpunetwork.edu.ph
 mcl.edu.ph
 mymail.mapua.edu.ph
 ncr1.deped.gov.ph

--- a/lib/domains/ph/lpunetwork.txt
+++ b/lib/domains/ph/lpunetwork.txt
@@ -1,0 +1,1 @@
+Lyceum of the Philippines University


### PR DESCRIPTION
I am adding the student email domain for Lyceum of the Philippines University (LPU) and removing it from abused.txt.

**Why this change is needed:**

- lpunetwork.edu.ph is the official Microsoft 365 email domain issued to all enrolled students at LPU.
- Moving this to the active list allows students to verify their academic status for developer tools like JetBrains.

**Verification:**

This domain is managed by the university's Information and Communications Technology Department (ICTD). For verification of this domain's status as the official student email provider, you can contact them directly at: ictd@lpu.edu.ph

I have followed the repository's structure by placing the new file in lib/domains/ph/edu/lpunetwork.txt.