### PR TITLE
Add Wycherley International School, Gampaha (wisg.lk)

### DIFF
--- a/lib/domains/lk/wisg.txt
+++ b/lib/domains/lk/wisg.txt
@@ -1,0 +1,1 @@
+Wycherley International School, Gampaha (Sri Lanka)


### PR DESCRIPTION
This pull request adds the domain for Wycherley International School, Gampaha to the SWOT library.

E-mail of our school - https://wycherley.lk/wycherley-gampaha/
Domain to add - wisg.lk
Country - Sri Lanka

I have followed the repository rules:
- The file is located in the correct directory path (`lib/domains/...`).
- The file name matches the domain exactly and ends in `.txt`.
- The first line of the file contains the official name of the university.
- The directory where the file is located is swot/lib/domains/lk/wisg.txt

Please consider merging this change so that email domains associated with Wycherley International School (wisg.lk) are recognised for the JetBrains Educational Pack.