### PR TITLE
Add akperalhikmah2brebes.ac.id domain

### DIFF
--- a/lib/domains/id/ac/akperalhikmah2brebes.txt
+++ b/lib/domains/id/ac/akperalhikmah2brebes.txt
@@ -1,0 +1,1 @@
+Akademi Keperawatan Al-Hikmah 2 Brebes


### PR DESCRIPTION
Adding domain for Akademi Keperawatan Al-Hikmah 2 Brebes. Official website: https://akperalhikmah2brebes.ac.id