### PR TITLE
Add Deen Dayal Upadhyaya College domain

### DIFF
--- a/lib/domains/in/ac/du/ddu.txt
+++ b/lib/domains/in/ac/du/ddu.txt
@@ -1,0 +1,1 @@
+Deen Dayal Upadhyaya College, University of Delhi


### PR DESCRIPTION
## Summary
- add lib/domains/in/ac/du/ddu.txt for ddu.du.ac.in
- school name: Deen Dayal Upadhyaya College, University of Delhi

## Verification
- domain is not on abused.txt
- sol-du.ac.in is stoplisted, but this change uses a different domain