### PR TITLE
Add kgc.edu.vn domain for Kien Giang College

### DIFF
--- a/lib/domains/vn/edu/kgc.txt
+++ b/lib/domains/vn/edu/kgc.txt
@@ -1,0 +1,2 @@
+Trường Cao đẳng Kiên Giang
+Kien Giang College


### PR DESCRIPTION
Add kgc.edu.vn domain for Kien Giang College

Official website: https://kgc.edu.vn

IT-related program: https://www.kgc.edu.vn/hoi-sinh-vien-gioi-thieu/6214-cong-nghe-thong-tin-nganh-hoc-dan-dau-trong-ky-nguyen-so.html 

Proof of domain usage: https://kgc.edu.vn

* The institution offers Information Technology programs as shown above.