### PR TITLE
Adding the domains used by ICL Graduate Business School (Auckland, NZ)

### DIFF
--- a/lib/domains/nz/ac/icl.txt
+++ b/lib/domains/nz/ac/icl.txt
@@ -1,0 +1,1 @@
+ICL Graduate Business School


### PR DESCRIPTION
Adding the domains used by ICL Graduate Business School (Auckland, NZ)

Academic staff/faculty domain: @icl.ac.nz
ICL student domain (for student emails): @icl.school.nz

Jetbrains teacher/student licences to be used for teaching/learning on the BBIS (information systems) degree programme:
https://icl.ac.nz/courses/bachelor-business-information-systems/

JJ