### PR TITLE
Remove g.skku.edu from abused.txt (Sungkyunkwan University official student domain)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -234,7 +234,6 @@ etudiant.edcparis.edu
 eurasia.edu
 everettcc.edu
 fvcc.edu
-g.skku.edu
 giant.cos.edu
 go.minnstate.edu
 go.shoreline.edu


### PR DESCRIPTION
Summary\n- Please remove g.skku.edu from lib/domains/abused.txt. It is an official student/staff email domain issued by Sungkyunkwan University (SKKU), Korea.\n\nEvidence (official SKKU pages)\n- SKKU Kingo Portal (Student) — Google Workspace: page explains students use id@g.skku.edu accounts and includes password-change steps for Google accounts. https://eng.skku.edu/eng/CampusLife/ITServices/KingoPortal1_4.do\n- University notice: ‘Google mail service (@g.skku.edu) will be kept while Naver Works mail …’ — confirms @g.skku.edu remains active as official mail. https://www.skku.edu/skku/mobile/notice.do?articleNo=109197&attachNo=90141&mode=download\n- International Office instruction: ‘Must use g.skku.edu account for submission.’ https://www.skku.edu/skku/international/globalComm/international01.do?articleNo=103961&attachNo=85047&mode=download\n\nRationale\n- Keeping g.skku.edu in abused.txt prevents legitimate SKKU students from automatic verification; the above official pages show it is institutionally provisioned and in current use.\n\nChange\n- Remove the line  from lib/domains/abused.txt.