### PR TITLE
Add Kaohsiung Municipal Cianjhen Senior High School

### DIFF
--- a/lib/domains/tw/edu/kh/cjhs/mail2.txt
+++ b/lib/domains/tw/edu/kh/cjhs/mail2.txt
@@ -1,0 +1,2 @@
+高雄市立前鎮高級中學
+Kaohsiung Municipal Cianjhen Senior High School


### PR DESCRIPTION
Add Taiwan Kaohsiung Municipal Cianjhen Senior High School

University name: Kaohsiung Municipal Cianjhen Senior High School
Domain: mail2.cjhs.kh.edu.tw 
Website: https://www.cjhs.kh.edu.tw