### PR TITLE
Add RMUTI (Rajamangala University of Technology Isan)

### DIFF
--- a/lib/domains/th/ac/rmuti.txt
+++ b/lib/domains/th/ac/rmuti.txt
@@ -1,0 +1,2 @@
+มหาวิทยาลัยเทคโนโลยีราชมงคลอีสาน
+Rajamangala University of Technology Isan


### PR DESCRIPTION
- Official Website: https://rmuti.ac.th/one/
- IT Course Link: https://ades.rmuti.ac.th/coursedetail?course=18
- Domain Proof: @rmuti.ac.th is the official email domain provided to students.