### PR TITLE
Remove seoultech.ac.kr from abused domains list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -705,7 +705,6 @@ office.gtec.ac.kr
 office.uos.ac.kr
 office.ut.ac.kr
 office.ysc.ac.kr
-seoultech.ac.kr
 smail.kongju.ac.kr
 sookmyung.ac.kr
 st.dima.ac.kr


### PR DESCRIPTION
Removed 'seoultech.ac.kr' from the list of abused domains because it valid email domain