### PR TITLE
Add domain for United States International University-Africa

### DIFF
--- a/lib/domains/ke/ac/usiu.txt
+++ b/lib/domains/ke/ac/usiu.txt
@@ -1,0 +1,2 @@
+United States International University Africa
+United States International University Africa


### PR DESCRIPTION
Official website:
https://www.usiu.ac.ke

Example of IT-related course (1+ year):
https://www.usiu.ac.ke/school-of-science-and-technology/

Proof that the domain is used for student emails:
United States International University-Africa uses the usiu.ac.ke domain for official communication. Institutional email addresses such as slakinyi@usiu.ac.ke are publicly listed on the official website, indicating active use of this domain for university communication and student-related services.