### PR TITLE
Add smk.belajar.id domain

### DIFF
--- a/lib/domains/id/belajar/smk.txt
+++ b/lib/domains/id/belajar/smk.txt
@@ -1,0 +1,1 @@
+SMK Negeri 1 Kota Probolinggo


### PR DESCRIPTION
This PR adds the domain "smk.belajar.id" to the repository.

The file is located at: "lib/domains/id/belajar/smk.txt"

It contains the official school name:
- SMK Negeri 1 Kota Probolinggo

This will allow students and staff with email addresses ending in @smk.belajar.id to verify their educational institution status with JetBrains products.