### PR TITLE
Add Universitas Muhammadiyah Bandung

### DIFF
--- a/lib/domains/id/ac/umbandung.txt
+++ b/lib/domains/id/ac/umbandung.txt
@@ -1,0 +1,1 @@
+Universitas Muhammadiyah Bandung


### PR DESCRIPTION
Add Universitas Muhammadiyah Bandung (umbandung.ac.id) to the university list.