### PR TITLE
Update banu.txt with bandirma.edu.tr aliases

### DIFF
--- a/lib/domains/tr/edu/bandirma/ogr.txt
+++ b/lib/domains/tr/edu/bandirma/ogr.txt
@@ -1,0 +1,1 @@
+Bandirma Onyedi Eylul University

--- a/lib/domains/tr/edu/bandirma/ogr.txt
+++ b/lib/domains/tr/edu/bandirma/ogr.txt
@@ -1,1 +1,0 @@
-Bandirma Onyedi Eylul University

--- a/lib/domains/tr/edu/banu.txt
+++ b/lib/domains/tr/edu/banu.txt
@@ -1,2 +1,3 @@
-Bandırma Onyedi Eylül Üniversitesi
 Bandirma Onyedi Eylul University
+bandirma.edu.tr
+ogr.bandirma.edu.tr


### PR DESCRIPTION
The university uses both banu.edu.tr and bandirma.edu.tr domains. Students use @ogr.bandirma.edu.tr. This update ensures all student emails can be verified.