### PR TITLE
Add umb.edu.co domain

### DIFF
--- a/lib/domains/co/edu/umb/academia.txt
+++ b/lib/domains/co/edu/umb/academia.txt
@@ -1,0 +1,1 @@
+Universidad Manuela Beltrán


### PR DESCRIPTION
Official website: https://umb.edu.co

IT-related program (1+ year):
https://umb.edu.co/programa/ingenieria-de-software/

Proof of email domain:
Students of Universidad Manuela Beltrán are provided with institutional email addresses under the academia.umb.edu.co domain, which is used as the official student email system.
