### PR TITLE
Add uca.ac.ma — Université Cadi Ayyad, Marrakesh, Morocco

### DIFF
--- a/lib/domains/ma/ac/uca.txt
+++ b/lib/domains/ma/ac/uca.txt
@@ -1,0 +1,1 @@
+Université Cadi Ayyad


### PR DESCRIPTION
Adding student email domain for Cadi Ayyad University (UCA), Marrakesh, Morocco.
Official university site: https://www.uca.ac.ma
Student email format: username@uca.ac.ma