### PR TITLE
Add Range Sixth Form (range.sefton.sch.uk)

### DIFF
--- a/lib/domains/uk/sch/sefton/range.txt
+++ b/lib/domains/uk/sch/sefton/range.txt
@@ -1,0 +1,1 @@
+Range Sixth Form


### PR DESCRIPTION
## Summary
- Add Range Sixth Form with email domain `range.sefton.sch.uk`
- New file: `lib/domains/uk/sch/sefton/range.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)