### PR TITLE
Add bse.eu for Barcelona School of Economics

### DIFF
--- a/lib/domains/eu/bse.txt
+++ b/lib/domains/eu/bse.txt
@@ -1,0 +1,2 @@
+Barcelona School of Economics
+Barcelona Graduate School of Economics


### PR DESCRIPTION
This PR adds bse.eu for Barcelona School of Economics.

Official website:
- https://bse.eu

Official page showing a long-term IT-related program:
- https://bse.eu/masters-degrees/data-science/data-science-methodology

Official page explaining degree recognition:
- https://bse.eu/masters-degrees/admissions

I am also providing proof that enrolled students receive and use email addresses at this domain.

<img width="251" height="63" alt="Captura de pantalla 2026-04-12 221626d" src="https://github.com/user-attachments/assets/9bd29713-5536-4a28-ac91-89f6cb9edc92" />
