### PR TITLE
Add STI Meycauayan to domains list

### DIFF
--- a/lib/domains/ph/edu/sti/meycauayan.txt
+++ b/lib/domains/ph/edu/sti/meycauayan.txt
@@ -1,1 +1,1 @@
-STI Meycauayan
+STI College Meycauayan

--- a/lib/domains/ph/edu/sti/meycauayan.txt
+++ b/lib/domains/ph/edu/sti/meycauayan.txt
@@ -1,0 +1,1 @@
+STI Meycauayan


### PR DESCRIPTION
Specifically the `meycauayan.sti.edu.ph` email domain for JetBrains Student Pack.

Note that this commit is created and signed off via the STI College Meycauayan student email address for verification purposes on GitHub web editor.

* **Official campus website**: https://www.sti.edu/ (none, so I point at the STI College site proper) / https://www.facebook.com/meycauayan.sti.edu (Facebook profile of the campus)

* **Campus Directory page from STI**: https://sti.edu/campuses-details.asp?campus_id=TUVZ