### PR TITLE
Add Bucheon University (bcu.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/bcu.txt
+++ b/lib/domains/kr/ac/bcu.txt
@@ -1,0 +1,2 @@
+부천대학교
+BUCHEON UNIVERSITY


### PR DESCRIPTION
Adding Bucheon University, a South Korean educational institution.

- **Official name (Korean):** 부천대학교
- **Official name (English):** Bucheon University
- **Official website:** https://www.bc.ac.kr
- **Student email domain:** bcu.ac.kr

This `.ac.kr` domain is issued under the Korean academic domain namespace managed by KRNIC, which is restricted to accredited educational institutions in Korea. The `bcu.txt` file provided was supplied directly by JetBrains as part of our educational license request.