### PR TITLE
Add UTN - Facultad Regional Tucumán (FRT) domain.

### DIFF
--- a/lib/domains/ar/edu/utn/frt.txt
+++ b/lib/domains/ar/edu/utn/frt.txt
@@ -1,0 +1,1 @@
+Facultad Regional Tucumán - Universidad Tecnológica Nacional

--- a/lib/domains/ar/edu/utn/frt/alu.txt
+++ b/lib/domains/ar/edu/utn/frt/alu.txt
@@ -1,0 +1,1 @@
+universidad tecnologica nacional


### PR DESCRIPTION
Adding the frt.utn.edu.ar domain to the recognized schools list for JetBrains student licenses.