### PR TITLE
Add snu.ac.kr

### DIFF
--- a/lib/domains/kr/ac/snu.txt
+++ b/lib/domains/kr/ac/snu.txt
@@ -1,0 +1,2 @@
+서울대학교
+Seoul National University


### PR DESCRIPTION
Add domain snu.ac.kr for 서울대학교(Seoul National University, South Korea)