### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/kr/ac/shingu.txt
+++ b/lib/domains/kr/ac/shingu.txt
@@ -1,0 +1,2 @@
+신구대학교
+Shingu College


### PR DESCRIPTION
The file has been deleted, so I am requesting it again. Our college uses the g.shingu.ac.kr extension specifically for student emails. As per the guidelines stating that different extensions for students and professors are acceptable, please note that faculty members use the shingu.ac.kr parent domain.

1. University Name
- 신구대학교
- Shingu College

2. University official website URL https://www.shingu.ac.kr/index.do

3. IT related division URL https://software.shingu.ac.kr/index.do

4. Official email domain for the enrolled students https://www.shingu.ac.kr/html/gsuite.html