### PR TITLE
Added Ataturk University Student Domain

### DIFF
--- a/lib/domains/tr/edu/atauni/ogr.txt
+++ b/lib/domains/tr/edu/atauni/ogr.txt
@@ -1,0 +1,1 @@
+Atatürk University


### PR DESCRIPTION
Adding the official student domain for Ataturk University, Turkey.
(ogr.atauni.edu.tr)