### PR TITLE
Add domain for Palestine Technical University - Kadoorie

### DIFF
--- a/lib/domains/ps/edu/ptuk/students.txt
+++ b/lib/domains/ps/edu/ptuk/students.txt
@@ -1,1 +1,2 @@
+جامعة فلسطين التقنية خضوري
 Palestine Technical University - Kadoorie

--- a/lib/domains/ps/edu/ptuk/students.txt
+++ b/lib/domains/ps/edu/ptuk/students.txt
@@ -1,0 +1,1 @@
+Palestine Technical University - Kadoorie

--- a/lib/domains/ps/edu/students.txt
+++ b/lib/domains/ps/edu/students.txt
@@ -1,0 +1,2 @@
+جامعة فلسطين التقنية خضوري
+Palestine Technical University - Kadoorie

--- a/lib/domains/ps/edu/students.txt
+++ b/lib/domains/ps/edu/students.txt
@@ -1,2 +1,0 @@
-جامعة فلسطين التقنية خضوري
-Palestine Technical University - Kadoorie


### PR DESCRIPTION
Added the missing 'ptuk' directory to match the student email domain: students.ptuk.edu.ps. This corrects my previous request.