### PR TITLE
Add Shanghai Industrial Technology School

### DIFF
--- a/lib/domains/com/gyjs.txt
+++ b/lib/domains/com/gyjs.txt
@@ -1,0 +1,2 @@
+上海市工业技术学校
+Shanghai Industrial Technology School


### PR DESCRIPTION
The correct URL for my school is [https://www.shgyjs.cn/](https://www.shgyjs.cn/) (not gyjs.com), but my student email is @gyjs.com. We have numerous CS-related majors, which you can find at [https://www.shgyjs.cn/Article/Showz/2305095071500391/2305123948800279](https://www.shgyjs.cn/Article/Showz/2305095071500391/2305123948800279) and [https://www.shgyjs.cn/Article/Showz/2305123394100562/2305123948800280](https://www.shgyjs.cn/Article/Showz/2305123394100562/2305123948800280) Some of these programs and courses have been active since 2012, as shown here: [https://www.shgyjs.cn/Article/Show2/2011164311202089/](https://www.shgyjs.cn/Article/Show2/2011164311202089/).