### PR TITLE
Add San Joaquin Delta College (mustangs.deltacollege.edu)

### DIFF
--- a/lib/domains/edu/deltacollege/mustangs.txt
+++ b/lib/domains/edu/deltacollege/mustangs.txt
@@ -1,0 +1,2 @@
+San Joaquin Delta College
+San Joaquin Delta College


### PR DESCRIPTION
## Adding San Joaquin Delta College

**Domain:** mustangs.deltacollege.edu
**Institution:** San Joaquin Delta College (Delta College)
**Location:** Stockton, California, USA

### Verification
- Official website: https://www.deltacollege.edu
- The domain `mustangs.deltacollege.edu` is the official student email domain for enrolled students at San Joaquin Delta College
- Delta College is an accredited community college offering long-term IT-related courses including Computer Science, Computer Information Science, and Software Development programs
- Course catalog with IT programs: https://www.deltacollege.edu/academics/programs

### File added
`lib/domains/edu/deltacollege/mustangs.txt` containing:
```
San Joaquin Delta College
San Joaquin Delta College
```