### PR TITLE
Add CGC Jhanjeri domain

### DIFF
--- a/lib/domains/in/cgcjhanjeri.txt
+++ b/lib/domains/in/cgcjhanjeri.txt
@@ -1,0 +1,1 @@
+Chandigarh Group of Colleges, Jhanjeri

--- a/lib/domains/in/cgcjhanjeri.txt
+++ b/lib/domains/in/cgcjhanjeri.txt
@@ -1,1 +1,0 @@
-Chandigarh Group of Colleges, Jhanjeri


### PR DESCRIPTION
Added domain cgcjhanjeri.in for Chandigarh Group of Colleges, Jhanjeri.

Official website: https://www.cgc.ac.in/
This institution offers long-term IT-related courses.
Students are assigned official email IDs under this domain.