### PR TITLE
added ssmeridionale

### DIFF
--- a/lib/domains/it/ssmeridionale.txt
+++ b/lib/domains/it/ssmeridionale.txt
@@ -1,0 +1,1 @@
+Scuola Superiore Meridionale


### PR DESCRIPTION
official website https://www.ssmeridionale.it
This guide for access to bibliographic services shows that a @ssmeridionale.it address (given to all students) is needed https://www.ssmeridionale.it/wp-content/uploads/2025/06/Manuale-di-accesso-via-Proxy.pdf 