### PR TITLE
Add sistemas.frc.utn.edu.ar

### DIFF
--- a/lib/domains/ar/edu/utn/frc/sistemas.txt
+++ b/lib/domains/ar/edu/utn/frc/sistemas.txt
@@ -1,0 +1,1 @@
+Facultad Regional de Córdoba - Universidad Tecnológica Nacional


### PR DESCRIPTION
Added domain `sistemas.frc.utn.edu.ar` for **Universidad Tecnológica Nacional**, Argentina.

- **University official website**: https://www.frc.utn.edu.ar/
- **IT-related course (long-term)**: https://www.institucional.frc.utn.edu.ar/sistemas/
- **Proof of domain ownership**: I've attached a screenshot showing my student email address using this domain, issued by the university.

<img width="929" height="324" alt="image" src="https://github.com/user-attachments/assets/be462c11-ef78-4def-bc7e-a2e684f287ba" />


