### PR TITLE
add Faculdade Estacio from brazil

### DIFF
--- a/lib/domains/estacio/alunos.txt
+++ b/lib/domains/estacio/alunos.txt
@@ -1,0 +1,1 @@
+Faculdade Estacio


### PR DESCRIPTION
This PR adds "Faculdade Estácio" (Brazil) to the supported institutions list. Estácio is one of the largest private universities in the country, and this addition ensures students can properly access academic licenses.
