### PR TITLE
Remove dtcc domain from the abused list 

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -225,7 +225,6 @@ daytonastate.edu
 deltacollege.edu
 dillard.edu
 dragons.hutchcc.edu
-dtcc.edu
 eco.maranatha.edu
 email.phoenix.edu
 email.tjc.edu

--- a/lib/domains/dtcc
+++ b/lib/domains/dtcc
@@ -1,1 +1,2 @@
 Delaware Technical Community College
+dtcc.edu

--- a/lib/domains/dtcc
+++ b/lib/domains/dtcc
@@ -1,2 +1,1 @@
 Delaware Technical Community College
-dtcc.edu

--- a/lib/domains/dtcc
+++ b/lib/domains/dtcc
@@ -1,0 +1,2 @@
+Delaware Technical Community College
+dtcc.edu


### PR DESCRIPTION
Remove dtcc.edu from the abused list, as this is an Accredited institution, Delaware Technical Community College, with a Computer Science Major. 