### PR TITLE
Add Nisikyushu University

### DIFF
--- a/lib/domains/jp/ac/nisikyu-u.txt
+++ b/lib/domains/jp/ac/nisikyu-u.txt
@@ -1,0 +1,2 @@
+西九州大学
+Nisikyushu University


### PR DESCRIPTION
Please add the official domain for Nisikyushu University.

University Website: https://www.nisikyu-u.ac.jp/

Proof of Course: 
https://www.nisikyu-u.ac.jp/faculty/digital/
https://www.nisikyu-u.ac.jp/digital/grade1_2/