### PR TITLE
Adding hbni.ac.in domain for Homi Bhabha National Institute

### DIFF
--- a/lib/domains/in/ac/hbni.txt
+++ b/lib/domains/in/ac/hbni.txt
@@ -1,0 +1,1 @@
+Homi Bhabha National Institute


### PR DESCRIPTION
University official website URL: hbni.ac.in
URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university:
http://hbni.ac.in/academic_programs.html
<img width="1920" height="1080" alt="IT Long Term Courses" src="https://github.com/user-attachments/assets/d627fa7e-9001-45d7-915c-5eeec89a59c7" />


