### PR TITLE
Add connect.hku.hk for The University of Hong Kong

### DIFF
--- a/lib/domains/hk/hku/connect.txt
+++ b/lib/domains/hk/hku/connect.txt
@@ -1,0 +1,1 @@
+The University of Hong Kong


### PR DESCRIPTION
This PR adds the official HKU student email domain `connect.hku.hk` for The University of Hong Kong.

This request is specifically for the student email namespace `connect.hku.hk`, not the general staff domain `hku.hk`, and not the graduate domain `graduate.hku.hk`.

Verification:
- Official university website:
  https://www.hku.hk/

- Official HKU page stating that HKU Connect is the student email service:
  https://its.hku.hk/kb/what-is-hku-connect-email-service-for-students/


