### PR TITLE
Add UNIFAN (aluno.unifan.net.br)

### DIFF
--- a/lib/domains/br/net/unifan/aluno.txt
+++ b/lib/domains/br/net/unifan/aluno.txt
@@ -1,0 +1,1 @@
+Centro Universitario Nobre (UNIFAN)


### PR DESCRIPTION
## Add Centro Universitario Nobre (UNIFAN)

Adding support for the institutional student email domain `aluno.unifan.net.br` used by students at Centro Universitario Nobre (UNIFAN), located in Feira de Santana, Bahia, Brazil.

**Official website:** https://www.unifan.net.br

**e-MEC (Ministry of Education registry):** https://emec.mec.gov.br/emec/consulta-cadastro/detalhamento/d96957f455f6405d14c6542552b0f6eb/MTcxOA==

The institution is an active, MEC-accredited university center. The domain `unifan.net.br` is registered to the institution on Registro.br.