### PR TITLE
Add alunos.estacio.br domain for student verification

### DIFF
--- a/lib/domains/br/estacio/alunos.txt
+++ b/lib/domains/br/estacio/alunos.txt
@@ -1,0 +1,3 @@
+Universidade Estácio de Sá
+Estácio
+Estácio University


### PR DESCRIPTION
I would like to add the domain alunos.estacio.br for student verification.

Institution: Universidade Estácio de Sá

Official website:
https://estacio.br/

The domain alunos.estacio.br is used as the official student email domain for enrolled students.

I am currently enrolled in undergraduate programs in Software Engineering and Administration.

Additional proof can be provided if necessary.