### PR TITLE
Add Art Fetchers Institute (afi.edu.in)

### DIFF
--- a/lib/domains/in/edu/afi.txt
+++ b/lib/domains/in/edu/afi.txt
@@ -1,0 +1,1 @@
+Art Fetchers Institute


### PR DESCRIPTION
Requesting to add Art Fetchers Institute (AFI) to the educational whitelist. 
Official website: https://afi.edu.in/. 
We provide long-term design education in Navi Mumbai.