### PR TITLE
Add vvit.net domain

### DIFF
--- a/lib/domains/net/vvit.txt
+++ b/lib/domains/net/vvit.txt
@@ -1,0 +1,1 @@
+Vasireddy Venkatadri International Technological University


### PR DESCRIPTION
Adding domain for Vasireddy Venkatadri Institute of Technology.
Official website: https://www.vvitguntur.com