### PR TITLE
Add University of Foreign Language Studies - UDN (sv.ufl.udn.vn)

### DIFF
--- a/lib/domains/vn/udn/ufl/sv.txt
+++ b/lib/domains/vn/udn/ufl/sv.txt
@@ -1,0 +1,2 @@
+TRƯỜNG ĐẠI HỌC NGOẠI NGỮ - ĐẠI HỌC ĐÀ NẴNG
+University of Foreign Language Studies, the University of Da Nang – UFL


### PR DESCRIPTION
Add domain `sv.ufl.udn.vn` for University of Foreign Language Studies, the University of Da Nang (UFL-UDN), Vietnam.

- Institution: TRƯỜNG ĐẠI HỌC NGOẠI NGỮ - ĐẠI HỌC ĐÀ NẴNG
- English: University of Foreign Language Studies, the University of Da Nang
- Student email domain: `sv.ufl.udn.vn`