### PR TITLE
Add huflit.edu.vn

### DIFF
--- a/huflit.txt
+++ b/huflit.txt
@@ -1,0 +1,2 @@
+Trường Đại học Ngoại ngữ - Tin học TP. Hồ Chí Minh (HUFLIT)
+Ho Chi Minh City University of Foreign Languages - Information Technology

--- a/huflit.txt
+++ b/huflit.txt
@@ -1,2 +1,0 @@
-Trường Đại học Ngoại ngữ - Tin học TP. Hồ Chí Minh (HUFLIT)
-Ho Chi Minh City University of Foreign Languages - Information Technology

--- a/lib/domains/vn/edu/huflit.txt
+++ b/lib/domains/vn/edu/huflit.txt
@@ -1,0 +1,2 @@
+Trường Đại học Ngoại ngữ - Tin học TP. Hồ Chí Minh (HUFLIT)
+Ho Chi Minh City University of Foreign Languages - Information Technology


### PR DESCRIPTION
Add `huflit.edu.vn` for Ho Chi Minh City University of Foreign Languages and Information Technology (HUFLIT).

School name:
- Trường Đại học Ngoại ngữ - Tin học Thành phố Hồ Chí Minh (HUFLIT)
- Ho Chi Minh City University of Foreign Languages and Information Technology

Official website:
- https://huflit.edu.vn/

This domain is used for academic email addresses.