### PR TITLE
Add ESCO - Escola de Serviços e Comércio do Oeste (pt/sefo)

### DIFF
--- a/lib/domains/pt/sefo/alunos.txt
+++ b/lib/domains/pt/sefo/alunos.txt
@@ -1,0 +1,2 @@
+ESCO - Escola de Serviços e Comércio do Oeste
+ESCO


### PR DESCRIPTION
Adding the student email domain for **ESCO - Escola de Serviços e Comércio do Oeste**, a professional course school in Portugal (grades 9–12).

The school offers multi-year IT-related professional courses including Cisco networking programs, qualifying under the repository criteria for long-term (>1 year) IT-related courses.

- **Domain:** alunos.sefo.pt (student-only subdomain)
- **Country:** Portugal