### PR TITLE
Add KSRM College of Engineering

### DIFF
--- a/lib/domains/in/ac/ksrmce.txt
+++ b/lib/domains/in/ac/ksrmce.txt
@@ -1,0 +1,2 @@
+KSRM College Of Engineering
+KSRM College Of Engineering


### PR DESCRIPTION
Add KSRM College of engineering, Kadapa, Andhra Pradesh, India.
https://ksrmce.ac.in/
You can visit official site of college from above link.