### PR TITLE
Add Universitas Brawijaya (ub.ac.id)

### DIFF
--- a/lib/domains/id/ac/ub.txt
+++ b/lib/domains/id/ac/ub.txt
@@ -1,0 +1,1 @@
+Universitas Brawijaya


### PR DESCRIPTION
Add Universitas Brawijaya to the swot directory.

- **University**: Universitas Brawijaya
- **Domain**: ub.ac.id
- **File added**: `lib/domains/id/ac/ub.txt`

### Additional Information

- **Official website**: https://ub.ac.id

### Note
The domain `brawijaya.ac.id` already exists in this repository. However, `ub.ac.id` is a separate, widely-used domain by the university — particularly `student.ub.ac.id` for student emails. This PR adds `ub.ac.id` to ensure students using this domain can also be recognized.