### PR TITLE
Add ISEP-AT institution information

### DIFF
--- a/lib/domains/sn/edu/isepat.txt
+++ b/lib/domains/sn/edu/isepat.txt
@@ -1,0 +1,1 @@
+ISEP-AT (Institut Supérieur d'Enseignement Professionnel Amadou Trawaré de Diamniadio)


### PR DESCRIPTION
Ajout de l'ISEP-AT (Institut Supérieur d'Enseignement Professionnel Amadou Trawaré de Diamniadio) avec le domaine email étudiant `isepat.edu.sn`.

Site officiel : https://isepdiamniadio.com/

L'école propose des formations en informatique (TIC, développement, administration systèmes, sécurité, cloud).