### PR TITLE
add college of engineering adoor

### DIFF
--- a/lib/domains/in/ac/cea.txt
+++ b/lib/domains/in/ac/cea.txt
@@ -1,0 +1,1 @@
+College Of Engineering, Adoor


### PR DESCRIPTION
# Add College of Engineering, Adoor

This pull request adds College of Engineering, Adoor to the JetBrains Swot database for student verification.

## College Information
- **Name:** College of Engineering, Adoor
- **Location:** Adoor, Pathanamthitta, Kerala, India
- **Official Website:** https://cea.ac.in

## Changes
- Added domain configuration for the college's email system
- New file: `lib/domains/in/ac/cea.txt` with college name and details

## Purpose
This addition enables students of College of Engineering, Adoor to receive verified student benefits through the JetBrains Student License program using their `.cea.ac.in` email addresses.