### PR TITLE
Add Chulalongkorn University domain (chula.ac.th)

### DIFF
--- a/lib/domains/th/ac/chula.txt
+++ b/lib/domains/th/ac/chula.txt
@@ -1,0 +1,2 @@
+จุฬาลงกรณ์มหาวิทยาลัย
+Chulalongkorn University


### PR DESCRIPTION
Hi JetBrains Team,

I would like to add **Chulalongkorn University** to the SWOT repository. Please find the required information below:

* **University Official Website:** [https://www.chula.ac.th/en/](https://www.chula.ac.th/en/)
* **Examples of IT-related Degree Programs:** 
  * [Bachelor of Engineering in Computer Engineering (CP)](https://www.cp.eng.chula.ac.th/en/prospective/bachelor/)
  * [Bachelor of Engineering in Computer Engineering and Digital Technology (CEDT)](https://www.cp.eng.chula.ac.th/cedt/)
  * *Note: These are examples of the university's 4-year degree programs focusing on Computer Science, Software Engineering, and Digital Technology.*

* **Email Domain Proof:** 
  * [Email Service for Students](https://www.it.chula.ac.th/en/service/en-email-nisit/) - This page confirms the university provides `@student.chula.ac.th` addresses for enrolled students.
  * [Email Service for Staff](https://www.it.chula.ac.th/en/service/en-email-personal/) - This page confirms the `@chula.ac.th` domain for university staff and faculty members.

Thank you for your review.