### PR TITLE
Add lums.edu.pk domain; remove from abused list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1752,7 +1752,6 @@ mrcet.ac.in
 nrru.ac.th
 ogr.kent.edu.tr
 uom.lk
-lums.edu.pk
 mustudent.ac.tz
 modern-academy.edu.eg
 365.ono.ac.il

--- a/lib/domains/pk/edu/lums.txt
+++ b/lib/domains/pk/edu/lums.txt
@@ -1,0 +1,1 @@
+Lahore University of Management Sciences

--- a/lib/domains/pk/edu/lums.txt
+++ b/lib/domains/pk/edu/lums.txt
@@ -1,1 +1,2 @@
 Lahore University of Management Sciences
+LUMS


### PR DESCRIPTION
## Summary
- Add `lib/domains/pk/edu/lums.txt` for **Lahore University of Management Sciences** (`lums.edu.pk`).
- Remove `lums.edu.pk` from `lib/domains/abused.txt` so student email verification can use the swot dataset for this domain.

## External references
- **QS World University Rankings (institution profile):** https://www.topuniversities.com/universities/lahore-university-management-sciences-lums
- **Google Scholar (search scoped to `lums.edu.pk`):** https://scholar.google.com/scholar?q=lums.edu.pk

## Maintainer notes
Per [CONTRIBUTING.md](https://github.com/JetBrains/swot/blob/master/CONTRIBUTING.md), abuse-list changes are sensitive. If JetBrains still requires GitHub/ISIC verification for this domain, please comment and we can adjust or close.

## References
- Official site: https://lums.edu.pk/
- Student email domain documentation can be linked in follow-up if requested.