### PR TITLE
Unblock hccc.edu and add Hudson County Community College domain

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1513,7 +1513,6 @@ usm.ac.id
 erzeszow.pl
 tedankara.k12.tr
 office.pknu.ac.kr
-hccc.edu
 ujat.mx
 ist.edu.pk
 nlaredo.tecnm.mx

--- a/lib/domains/edu/hccc.txt
+++ b/lib/domains/edu/hccc.txt
@@ -1,0 +1,1 @@
+Hudson County Community College


### PR DESCRIPTION
This PR restores Hudson County Community College's domain support by:

1. Removing `hccc.edu` from the abuse list.
2. Adding the school entry at `lib/domains/edu/hccc.txt`.

### Why this change
`hccc.edu` is the official domain of Hudson County Community College (HCCC), an accredited higher-education institution with long-term IT/STEM-related programs.

### Supporting references
- Official website: https://www.hccc.edu/
- Program catalog / academic offerings: https://www.hccc.edu/programs-courses/explore-all-programs.html
- Computer Science A.S. (leading to B.S.): https://www.hccc.edu/programs-courses/academic-pathways/stem/computer-science-as-bs.html
- Student IT form showing student email pattern (`student1234@live.hccc.edu`): https://www.hccc.edu/administration/its/help-desk-request-form-student.html

### Changed files
- `lib/domains/abused.txt` (removed `hccc.edu`)
- `lib/domains/edu/hccc.txt` (added school name)

### Notes
If there was prior abuse associated with a subdomain, this can be refined with more specific allow/block rules.