### PR TITLE
Add Seoul National University domain

### DIFF
--- a/lib/domains/kr/ac/snu.txt
+++ b/lib/domains/kr/ac/snu.txt
@@ -1,0 +1,2 @@
+서울대학교
+Seoul National University


### PR DESCRIPTION
Added snu.ac.kr domain for Seoul National University student verification.