### PR TITLE
Added domain for Technological University of Chile

### DIFF
--- a/lib/domains/cl/inacapmail.txt
+++ b/lib/domains/cl/inacapmail.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica de Chile - INACAP
+Technological University of Chile - INACAP


### PR DESCRIPTION
Fix the inacap.cl that was added incorrectly.