### PR TITLE
Add University of Nigeria Nsukka

### DIFF
--- a/lib/domains/ng/edu/unn.txt
+++ b/lib/domains/ng/edu/unn.txt
@@ -1,0 +1,1 @@
+University of Nigeria Nsukka 


### PR DESCRIPTION
Adding University of Nigeria Nsukka (unn.edu.ng) to the list of supported educational institutions.