### PR TITLE
Add passy-buzenval.com domain for La Salle Passy Buzenval

### DIFF
--- a/lib/domains/com/passy-buzenval.txt
+++ b/lib/domains/com/passy-buzenval.txt
@@ -1,0 +1,2 @@
+La Salle Passy Buzenval
+La Salle Passy Buzenval High School


### PR DESCRIPTION
School: La Salle Passy Buzenval

Official website:
https://www.passy-buzenval.com/

IT-related studies:
The school offers science and engineering-oriented programs including mathematics, physics, and engineering sciences (SI), which include programming and technical projects over multiple years.

Proof of domain:
https://www.passy-buzenval.com/
This domain is officially used by the school to provide student email addresses.