### PR TITLE
Add University of the Built Environment (student.ube.ac.uk)

### DIFF
--- a/lib/domains/uk/ac/ube/student.txt
+++ b/lib/domains/uk/ac/ube/student.txt
@@ -1,0 +1,2 @@
+  University of the Built Environment
+  University College of Estate Management


### PR DESCRIPTION
This PR adds student.ube.ac.uk, the enrolled-student email domain for the
University of the Built Environment (UBE), Reading, UK.

UBE is the post-merger rebrand of the University College of Estate
Management (UCEM) and the London School of Architecture, approved by the
Office for Students in June 2025. The legacy UCEM domain is already
accepted in this repo at lib/domains/uk/ac/ucem.txt, so this PR extends
coverage to the institution's current primary student domain rather than
introducing a new provider.

I am an enrolled student on the BSc (Hons) Quantity Surveying programme
and my university email is issued on the student.ube.ac.uk subdomain.

Verification information:

- Official website: https://www.ube.ac.uk/
- Courses page (long-term, >1 year): https://www.ube.ac.uk/courses/
  The BSc Quantity Surveying and BSc Building Surveying are both
  three-to-six year programmes and include BIM and Digital Construction
  modules.
- Postgraduate programmes: https://www.ube.ac.uk/postgraduate/
- Evidence that @student.ube.ac.uk is the official student email domain:
  see attached screenshot of my UBE student portal profile below.

Related existing entry in this repo: lib/domains/uk/ac/ucem.txt (added by
@AliKhalili). Happy to clarify anything or provide additional evidence on
request.

<img width="739" height="823" alt="Screenshot 2026-04-24 at 01 29 59" src="https://github.com/user-attachments/assets/266dbad5-f136-445f-b09f-0dbb7e6339e5" />
