### PR TITLE
Please register this school to the domain.

### DIFF
--- a/lib/domains/kr/ac/gnue.txt
+++ b/lib/domains/kr/ac/gnue.txt
@@ -1,0 +1,2 @@
+광주교육대학교
+Gwangju National University of Education


### PR DESCRIPTION
Gwangju National University of Education is located in Gwangju, South Korea.
