### PR TITLE
Add Sultan Moulay Slimane University information

### DIFF
--- a/lib/domains/ma/ac/usms.txt
+++ b/lib/domains/ma/ac/usms.txt
@@ -1,0 +1,2 @@
+Université Sultan Moulay Slimane
+Sultan Moulay Slimane University


### PR DESCRIPTION
This is an official academic domain of Université Sultan Moulay Slimane in Morocco. Students use @usms.ac.ma emails.