### PR TITLE
Add ecampus.ut.ac.id for Universitas Terbuka

### DIFF
--- a/lib/domains/id/ac/ut/ecampus.txt
+++ b/lib/domains/id/ac/ut/ecampus.txt
@@ -1,0 +1,1 @@
+Universitas Terbuka


### PR DESCRIPTION
Add ecampus.ut.ac.id domain for Universitas Terbuka (Indonesia).

Official website: https://www.ut.ac.id
The subdomain ecampus.ut.ac.id is used for student email accounts.