### PR TITLE
Add Anadolu University - AÖF (aof.anadolu.edu.tr)

### DIFF
--- a/lib/domains/tr/edu/anadolu/aof.txt
+++ b/lib/domains/tr/edu/anadolu/aof.txt
@@ -1,0 +1,1 @@
+Anadolu University - AÖF


### PR DESCRIPTION
This PR adds the domain aof.anadolu.edu.tr, which is used by Anadolu University - AÖF.

Email addresses under this domain are issued to enrolled students of the Open Education system at Anadolu University. These accounts are used for official communication and student services.

Although anadolu.edu.tr may already be listed, this subdomain is specifically dedicated to AÖF students and is actively used as their primary institutional email domain.

Example email format: `username@aof.anadolu.edu.tr`

This addition helps properly recognize AÖF students for services relying on the SWoT repository.

Thank you.