### PR TITLE
fix: add Yanbu Industrial College to rcjy list

### DIFF
--- a/lib/domains/sa/edu/rcjy.txt
+++ b/lib/domains/sa/edu/rcjy.txt
@@ -1,2 +1,5 @@
 كلية الجبيل الصناعية
 Jubail Industrial College
+كلية ينبع الصناعية
+Yanbu Industrial College
+.group


### PR DESCRIPTION
Updating the RCJY (Royal Commission for Jubail and Yanbu) entry to include both major industrial colleges.

Previously, only Jubail Industrial College was listed. Both institutions share the same domain and student portal.

Verification:
- Unified Portal: https://rcjy.edu.sa/
- Student Edugate: https://edugate.rcjy.edu.sa/jyup/init

Added the `.group` tag as the domain represents multiple distinct colleges.