### PR TITLE
Add Ain Shams University (asu.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/asu.txt
+++ b/lib/domains/eg/edu/asu.txt
@@ -1,0 +1,1 @@
+Ain Shams University


### PR DESCRIPTION
Added Ain Shams University domain `asu.edu.eg` to the database.

University website: https://www.asu.edu.eg