### PR TITLE
docs(domains): add UTN FRBB email domain

### DIFF
--- a/lib/domains/ar/edu/utn/frbb.txt
+++ b/lib/domains/ar/edu/utn/frbb.txt
@@ -1,0 +1,1 @@
+Facultad Regional Bahía Blanca - Universidad Tecnológica Nacional


### PR DESCRIPTION
## Summary
- Adds lib/domains/ar/edu/utn/frbb.txt for UTN Facultad Regional Bahía Blanca.
- Uses the official campus name and covers subdomains under frbb.utn.edu.ar.

## Evidence
- Official site exposes webmail at webmail.frbb.utn.edu.ar.
- Webmail login explicitly says: Nombre de usuario (Sin @frbb.utn.edu.ar).
- The site lists an IT-related long-term course: Tecnicatura Universitaria en Programación.
 

## Notes
- The requested sae.frbb.utn.edu.ar is a subdomain, so Swot should register the base campus domain instead.