### PR TITLE
Add INACAP student email domain inacapmail.cl

### DIFF
--- a/lib/domains/cl/inacapmail.txt
+++ b/lib/domains/cl/inacapmail.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica de Chile - INACAP
+Technological University of Chile - INACAP


### PR DESCRIPTION
This PR adds the student email domain used by INACAP (Universidad Tecnologica de Chile - INACAP).

- Added file: lib/domains/cl/inacapmail.txt
- Domain to validate: inacapmail.cl

Current INACAP domain entry already exists as lib/domains/cl/inacap.txt; this PR adds the separate student domain in a different second-level domain.
