### PR TITLE
Add Universitas Harkat Negeri details and student email

### DIFF
--- a/lib/domains/edu/harkatnegeri.txt
+++ b/lib/domains/edu/harkatnegeri.txt
@@ -5,6 +5,7 @@ Universitas Harkat Negeri
 harkatnegeri.ac.id
 
 #### Email Users
+student.harkatnegeri.ac.id
 
 *Please place an x between the square brackets if yes*
 - [ x] Students

--- a/lib/domains/edu/harkatnegeri.txt
+++ b/lib/domains/edu/harkatnegeri.txt
@@ -1,0 +1,24 @@
+#### Institution/School Name 
+Universitas Harkat Negeri
+
+#### Instiution/School Website
+harkatnegeri.ac.id
+
+#### Email Users
+
+*Please place an x between the square brackets if yes*
+- [ x] Students
+- [ ] Academic/Teaching Staff
+- [ ] Other/Support Staff
+- [ ] Alumni
+
+#### Education Levels
+
+*Please place an x between the square brackets if yes*
+
+- [ ] Post-graduate research
+- [ ] Graduate School
+- [x ] College (University) or Undergraduate School or equivalent
+- [ ] Community College or equivalent
+- [ ] High School or equivalent
+- [ ] Elementary School or equivalent


### PR DESCRIPTION
This pull request adds a new entry for Universitas Harkat Negeri to the `lib/domains/edu/harkatnegeri.txt` file. The entry specifies the institution's name, website, student email domain, and indicates that the domain is used by undergraduate students.

Institution domain addition:

* Added `lib/domains/edu/harkatnegeri.txt` to register Universitas Harkat Negeri, including its website, student email domain (`student.harkatnegeri.ac.id`), and usage details for undergraduate students.