### PR TITLE
feat: add Carlos Hilado Memorial State University (chmsc.edu.ph and chmsu.edu.ph)

### DIFF
--- a/lib/domains/ph/edu/chmsc.txt
+++ b/lib/domains/ph/edu/chmsc.txt
@@ -1,0 +1,2 @@
+Carlos Hilado Memorial State University
+Carlos Hilado Memorial State College

--- a/lib/domains/ph/edu/chmsu.txt
+++ b/lib/domains/ph/edu/chmsu.txt
@@ -1,0 +1,1 @@
+Carlos Hilado Memorial State University


### PR DESCRIPTION
Added Carlos Hilado Memorial State University (CHMSU) to the Philippine domain list.

University Details
Official Website: https://chmsu.edu.ph

IT Course Proof: [CHMSU Academic Programs](https://chmsu.edu.ph/academics/) (Offers BS in Information Systems and BS in Information Technology).

Note on Domains
The institution transitioned from Carlos Hilado Memorial State College (CHMSC) to Carlos Hilado Memorial State University (CHMSU) per Republic Act No. 11336.

I have included both chmsc.edu.ph and chmsu.edu.ph because the university is currently maintaining both domains for student and faculty email addresses during the transition period.

Verification
Both domains resolve to the same institution. You can verify the legislative change here: [RA 11336](https://lawphil.net/statutes/repacts/ra2019/ra_11336_2019.html).