### PR TITLE
Add Observatoire de la Côte d’Azur (OCA) domain

### DIFF
--- a/lib/domains/eu/oca.txt
+++ b/lib/domains/eu/oca.txt
@@ -1,0 +1,1 @@
+Observatoire de la Côte d'Azur


### PR DESCRIPTION
This PR adds `oca.eu` as a recognized academic domain for Observatoire de la Côte d’Azur (OCA), a French higher education and research institution.

OCA has a formal teaching mission, defined as contributing to the initial and continuing education of students and research personnel. It has a dedicated training unit and its staff teach across Earth sciences, astronomy and astrophysics, fundamental physics, and related scientific and technical subjects.

OCA is a founding member of Université Côte d’Azur, where much of its teaching activity takes place. Its higher education activities include Bachelor level courses, Master’s programmes, PhD training, doctoral courses, the Space Sciences Certificate, student space projects through the University Space Center, specialised training schools, and international teaching initiatives.

Reference: https://www.oca.eu/en/training