### PR TITLE
Add Huzhou University student domain (stu.zjhu.edu.cn)

### DIFF
--- a/lib/domains/cn/edu/zjhu/stu.txt
+++ b/lib/domains/cn/edu/zjhu/stu.txt
@@ -1,0 +1,1 @@
+Huzhou University


### PR DESCRIPTION
   * Description: Added the student subdomain for Huzhou
     University in China to support academic license verification.
       * School URL: https://www.zjhu.edu.cn
       * Student Email: xxx@stu.zjhu.edu.cn