### PR TITLE
Faculty of Engineering - Port Said University

### DIFF
--- a/lib/domains/eg/edu/psu/eng.txt
+++ b/lib/domains/eg/edu/psu/eng.txt
@@ -1,0 +1,2 @@
+Faculty of Engineering - Port Said University
+Faculty of Engineering - Port Said University


### PR DESCRIPTION
# Add Faculty of Engineering - Port Said University to Recognized Schools

### Description
This PR requests the addition of the **Faculty of Engineering at Port Said University** to the list of recognized educational institutions. Verification of this institution will enable students and academic staff to apply for JetBrains educational licenses using their university-issued email addresses.

### Institution Details
* **Full Name:** Faculty of Engineering, Port Said University
* **Location:** Port Said, Egypt
* **Official University Portal:** [https://psu.edu.eg/en/home-en/](https://psu.edu.eg/en/home-en/)
* **Faculty Homepage:** [https://eng.psu.edu.eg/](https://eng.psu.edu.eg/)
    > **Note on Accessibility:** The faculty-specific domain (`eng.psu.edu.eg`) is hosted on Egyptian academic infrastructure. While it is the active, official site for students, it may occasionally be unreachable from certain international IP ranges due to local network configurations. The main university portal remains globally accessible.

### Academic Verification
* **Primary Email Domain:** `@eng.psu.edu.eg`
* **Secondary/General Domain:** `@psu.edu.eg` (Used by university administration and other faculties)
* **Independent Rankings:** [[Times Higher Education - Port Said University Profile](https://www.timeshighereducation.com/world-university-rankings/port-said-university)](https://www.timeshighereducation.com/world-university-rankings/port-said-university)
* **Encyclopedia Reference:** [[Port Said University - Wikipedia](https://en.wikipedia.org/wiki/Port_Said_University)](https://en.wikipedia.org/wiki/Port_Said_University)
* **Legal Status:** A government-funded public institution fully accredited by the Egyptian Ministry of Higher Education.