### PR TITLE
chore: added new national open university of Nigeria domain

### DIFF
--- a/lib/domains/ng/edu/noun.txt
+++ b/lib/domains/ng/edu/noun.txt
@@ -1,0 +1,1 @@
+National Open University of Nigeria


### PR DESCRIPTION
National open university of Nigeria was using https://nou.edu.ng/ , but a new domain has been registered "noun.edu.ng" and it's been used for email and official tasks.

![New Noun Email web screenshot](https://res.cloudinary.com/micakindev/image/upload/v1777305879/temp/noun-email_d2lxej.webp)


![New Noun Email web screenshot 2](https://res.cloudinary.com/micakindev/image/upload/v1777306082/temp/newnounemail_zmvigt.webp)



