### PR TITLE
Add sunmoon.ac.kr

### DIFF
--- a/lib/domains/kr/ac/sunmoon.txt
+++ b/lib/domains/kr/ac/sunmoon.txt
@@ -1,0 +1,2 @@
+선문대학교
+Sunmoon University


### PR DESCRIPTION
Official university website:
https://www.sunmoon.ac.kr/

IT-related course / department:
https://ais.sunmoon.ac.kr/ais/index.do
https://sm.sunmoon.ac.kr/ais/cm/cntnts/cntntsView.do?cntntsId=240328&mi=44957

Evidence that the university uses the sunmoon.ac.kr domain:
https://graduate.sunmoon.ac.kr/graduate/cm/cntnts/cntntsView.do?cntntsId=240432&mi=45989
https://global.sunmoon.ac.kr/bbs/content.php?co_id=student_01