### PR TITLE
Remove CCSU student domain from stoplist

### DIFF
--- a/lib/domains/cn/edu/ccsu.txt
+++ b/lib/domains/cn/edu/ccsu.txt
@@ -1,1 +1,1 @@
-Changsha Unversity
+Changsha University

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -169,7 +169,6 @@ std.uestc.edu.cn
 stu.ahu.edu.cn
 stu.bzuu.edu.cn
 stu.ccit.edu.cn
-stu.ccsu.edu.cn
 stu.cdut.edu.cn
 stu.cpu.edu.cn
 stu.csust.edu.cn


### PR DESCRIPTION
ccsu.edu.cn is already listed for Changsha University.

The university's official Network and Modern Education Technology Center states that student email addresses use the stu.ccsu.edu.cn domain, while staff email addresses use ccsu.edu.cn:
https://nic.ccsu.cn/info/1521/4201.htm

This PR removes stu.ccsu.edu.cn from the stoplist so official student email addresses can be recognized.
