### PR TITLE
Add ucm.ac.mz domain

### DIFF
--- a/lib/domains/mz/ac/ucm.txt
+++ b/lib/domains/mz/ac/ucm.txt
@@ -1,0 +1,2 @@
+Universidade Católica de Moçambique
+Catholic University of Mozambique


### PR DESCRIPTION
Add domain for Universidade Católica de Moçambique (ucm.ac.mz).

Official website: https://www.ucm.ac.mz  
This domain is used by the institution for student and staff emails.