### PR TITLE
Add Chung-Ang University

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
This pull request adds Chung-Ang University.

Official website:
https://www.cau.ac.kr

The submitted domain is cau.ac.kr, which is used for Chung-Ang University email addresses.