### PR TITLE
Add CEFET-RJ University

### DIFF
--- a/lib/domains/br/cefet-rj.txt
+++ b/lib/domains/br/cefet-rj.txt
@@ -1,0 +1,1 @@
+Centro Federal de Educação Tecnológica Celso Suckow da Fonseca


### PR DESCRIPTION
## Why this domain should be added

Please add `cefet-rj.br` as an academic domain for **Centro Federal de Educação Tecnológica Celso Suckow da Fonseca (CEFET/RJ)**, a public higher-education institution in Brazil.

## Evidence

- Official website: https://www.cefet-rj.br/
- Institutional emails are issued under `@cefet-rj.br`
- Institution type: public higher-education institution
- Country: Brazil

## Notes

I understand the domain may have been removed previously due to abuse.
If needed, I can provide additional official documentation proving current student status and institutional domain ownership.
