### PR TITLE
Add Chung-Ang University domain

### DIFF
--- a/lib/domains/kr/ac/cau.txt
+++ b/lib/domains/kr/ac/cau.txt
@@ -1,0 +1,2 @@
+중앙대학교
+Chung-Ang University


### PR DESCRIPTION
University email domain: cau.ac.kr

Official website: https://www.cau.ac.kr/

Institution name:
중앙대학교
Chung-Ang University

This PR adds the official email domain for 중앙대학교 / Chung-Ang University, an accredited university in South Korea.

Supporting information:
- Official university website: https://www.cau.ac.kr/
- Country: South Korea
- Korean name: 중앙대학교
- English name: Chung-Ang University