### PR TITLE
Add Sejong University name in Korean and English

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
Please add sju.ac.kr as an official email domain for Sejong University.

Official website:
https://www.sejong.ac.kr/

IT-related long-term course:
https://home.sejong.ac.kr/~cedpt/

Proof of official student email domain:
https://en.sejong.ac.kr/eng/academics/IT_Service.do

<img width="1301" height="769" alt="image" src="https://github.com/user-attachments/assets/5970f629-b5ab-40ef-a283-66f7aa779586" />
