### PR TITLE
Add Beni-Suef University domain (bsu.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/bsu.txt
+++ b/lib/domains/eg/edu/bsu.txt
@@ -1,0 +1,2 @@
+جامعة بني سويف
+Beni-Suef University


### PR DESCRIPTION
University domain: bsu.edu.eg

Official website:
https://www.bsu.edu.eg/

Example of IT-related course (long-term):
https://www.fci.bsu.edu.eg/Content.aspx?section_id=15338&cat_id=230

