### PR TITLE
Add Ocean University of China student information

### DIFF
--- a/lib/domains/cn/edu/ouc/stu.txt
+++ b/lib/domains/cn/edu/ouc/stu.txt
@@ -1,0 +1,2 @@
+Ocean University of China
+中国海洋大学


### PR DESCRIPTION
The domain ouc.edu.cn (in this repo) is used by staff, and stu.ouc.edu.cn is strictly allocated to enrolled students. I am adding the student-specific domain as per the contributing guidelines.