### PR TITLE
Add Build Bright University (bbu.edu.kh)

### DIFF
--- a/lib/domains/edu/bbu/bbu.txt
+++ b/lib/domains/edu/bbu/bbu.txt
@@ -1,0 +1,5 @@
+Build Bright University (BBU) is a private university in Cambodia.
+
+Website: https://web.bbu.edu.kh
+
+The domain bbu.edu.kh is used for official institutional email addresses for students and staff.


### PR DESCRIPTION
Institution name: Build Bright University
Website: https://web.bbu.edu.kh
Domain: bbu.edu.kh

Build Bright University (BBU) is a recognized private university in Cambodia providing higher education programs including undergraduate and graduate degrees.

This domain is used for official institutional email addresses for students, faculty, and staff.

Evidence:
- Official website: https://web.bbu.edu.kh
- Public academic programs listed on website

Please add this domain to the whitelist for educational benefits verification.