### PR TITLE
Add ceroble.edu.gt (APDE El Roble)

### DIFF
--- a/lib/domains/gt/edu/ceroble.txt
+++ b/lib/domains/gt/edu/ceroble.txt
@@ -1,0 +1,1 @@
+APDE El Roble


### PR DESCRIPTION
Adding the official domain for APDE El Roble school in Guatemala to enable educational licenses for students and staff.