### PR TITLE
Added Helenic French School Kalamari

### DIFF
--- a/lib/domains/gr/edu-kalamari.txt
+++ b/lib/domains/gr/edu-kalamari.txt
@@ -1,0 +1,2 @@
+Ελληνογαλλική Σχολή Καλαμαρί
+Helenic French School Kalamari


### PR DESCRIPTION
The domain '@edu-kalamari.gr' is the email adresses given out by my school eventhough the main website is kalamari.gr also if you see edu-kalamari.gr is the ASEK (asynchronous education website of our school through which all of the schools emails are made) also this is the mail client of my school:
<img width="2115" height="1308" alt="image" src="https://github.com/user-attachments/assets/30c567cf-b69e-4585-8369-852467357dd4" />

