### PR TITLE
Add Universitas Teknologi Yogyakarta

### DIFF
--- a/lib/domains/id/ac/uty.txt
+++ b/lib/domains/id/ac/uty.txt
@@ -1,0 +1,2 @@
+Universitas Teknologi Yogyakarta
+University of Technology Yogyakarta


### PR DESCRIPTION
I would like to add the email domain for Universitas Teknologi Yogyakarta (UTY) to the SWOT repository so that students can access JetBrains academic licenses.

Here are the details for verification:
- Official Website: https://uty.ac.id
- IT-Related Course: https://uty.ac.id/page/visi-misi-program-studi-informatika (Undergraduate program in Informatics)
- Domain Proof: The domain @student.uty.ac.id is the official email format provided to all enrolled students at our university.

The domain uty.ac.id covers all subdomains, including student.uty.ac.id.

Thank you for your assistance!