### PR TITLE
Add SEJONG UNIVERSITY

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+SEJONG UNIVERSITY


### PR DESCRIPTION

Official website: https://en.sejong.ac.kr
Student email domain proof: https://www.sejong.ac.kr/kor/unilife/email-service.do