### PR TITLE
Add jnujaipur.ac.in domain for Jaipur National University

### DIFF
--- a/lib/domains/in/ac/jnujaipur.txt
+++ b/lib/domains/in/ac/jnujaipur.txt
@@ -1,0 +1,1 @@
+Jaipur National University


### PR DESCRIPTION
Add Jaipur National University domain

Official website: https://www.jnujaipur.ac.in
Course page (B.Tech CSE): https://www.jnujaipur.ac.in/programmes/ug-programmes/btech-computer-science-and-engineering

Students are issued official email addresses under the domain jnujaipur.ac.in.
<img width="1920" height="1080" alt="Screenshot (45)" src="https://github.com/user-attachments/assets/188e376e-7a5d-4ff1-bda0-576c5842ca53" />
