### PR TITLE
Add bfw-neueslernen.de (Berufsförderungswerk Nürnberg)

### DIFF
--- a/lib/domains/de/bfw-neueslernen.txt
+++ b/lib/domains/de/bfw-neueslernen.txt
@@ -1,0 +1,2 @@
+Berufsförderungswerk Nürnberg
+BFW Nürnberg


### PR DESCRIPTION
Adding `bfw-neueslernen.de`, the participant e-learning domain of 
**Berufsförderungswerk Nürnberg gemeinnützige GmbH**, a state-recognized 
German vocational rehabilitation and retraining institution under §51 SGB IX, 
AZAV-certified.

**Institution website:**  
https://www.bfw-nuernberg.de

**IT-related course (>1 year):**  
BFW Nürnberg offers the 2-year IHK-certified retraining program 
"Kaufmann/-frau für Digitalisierungsmanagement" (KfDM) and other 
state-recognized IT professions among 20+ vocational programs.  
- https://www.bfw-nuernberg.de/ueber-uns.html  
- https://www.bfw-nuernberg.de/standorte.html

**Domain officially used as participant email/e-learning domain:**  
The institution explicitly references `bfw-neueslernen.de` as the 
participant intranet ("Teilnehmer-Intranet / TNI") issued only to 
enrolled retraining participants:  
https://www.bfw-nuernberg.de/fuer-rehabilitanden/teilnehmer-intranet.html

**Imprint confirming sole operator:**  
https://owa.bfw-neueslernen.de/moodledaten/46/Impressum-5.htm  
Operated solely by Berufsförderungswerk Nürnberg gemeinnützige GmbH 
(HRB 2368, Amtsgericht Nürnberg). Staff use a separate domain 
(`bfw-nuernberg.de`).

**Alumni handling:**  
Per imprint section 4.4, participant email accounts are deleted at 
program end and access is fully revoked after a 24-month retention 
period. The domain is not used by long-term alumni.

Consistent with existing entries: bfw-hamburg.txt, bfw-koeln.txt, 
bfw-leipzig.txt, bfw-dortmund/, etc.