### PR TITLE
Add Thebes Higher Institute of Management & Information Technology - Giza

### DIFF
--- a/lib/domains/eg/edu/tiba/tiba.txt
+++ b/lib/domains/eg/edu/tiba/tiba.txt
@@ -1,0 +1,1 @@
+Thebes Higher Institute of Management & Information Technology - Giza


### PR DESCRIPTION
Please add the domain tiba.edu.eg for Thebes Higher Institute of Management & Information Technology located in Giza, Egypt.
Official Website/Proof: [http://thebes.edu.eg/en/institutes/thebes-higher-institute-of-management-information-technology%20-%20Giza]