### PR TITLE
Added University of Medellin domain

### DIFF
--- a/lib/domains/co/edu/udemedellin.txt
+++ b/lib/domains/co/edu/udemedellin.txt
@@ -1,0 +1,2 @@
+Universidad de Medellín
+University of Medellin


### PR DESCRIPTION
Former University of Medellin domain: udem updated to: udemedellin.