### PR TITLE
Add Sanko gakuen omiya mirai ai & it college

### DIFF
--- a/lib/domains/jp/sankogakuen.txt
+++ b/lib/domains/jp/sankogakuen.txt
@@ -1,0 +1,2 @@
+大宮みらいai&it専門学校
+Omiya Mirai AI & IT College


### PR DESCRIPTION
official website: https://www.sanko.ac.jp/omiya-ai/en/
official website(English ver.): https://www.sanko.ac.jp/omiya-ai/en/

a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: https://www.sanko.ac.jp/omiya-ai/department/course/ai-programming.html
a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university(English ver.): https://www.sanko.ac.jp/omiya-ai/en/department/course/ai-programming.html