### PR TITLE
add Universitas Indonesia domain

### DIFF
--- a/lib/domains/id/ac/ui.txt
+++ b/lib/domains/id/ac/ui.txt
@@ -1,0 +1,2 @@
+Universitas Indonesia
+University of Indonesia


### PR DESCRIPTION
add Universitas Indonesia domain, which is: `ui.ac.id` so our academic community can use JetBrains product for learning