### PR TITLE
Add Chulalongkorn University (student.chula.ac.th)

### DIFF
--- a/lib/domains/th/ac/chula/student.txt
+++ b/lib/domains/th/ac/chula/student.txt
@@ -1,0 +1,1 @@
+Chulalongkorn University


### PR DESCRIPTION
Add Chulalongkorn University, a leading public research university in Bangkok, Thailand.

- Domain: `student.chula.ac.th`
- File: `lib/domains/th/ac/chula/student.txt`