### PR TITLE
Add Lviv Polytechnic National University domain

### DIFF
--- a/lib/domains/ua/lpnu.txt
+++ b/lib/domains/ua/lpnu.txt
@@ -1,0 +1,2 @@
+Національний університет «Львівська політехніка»
+Lviv Polytechnic National University


### PR DESCRIPTION
Add Lviv Polytechnic National University domain

Official website: https://lpnu.ua
Domain lpnu.ua is used for student email addresses.