### PR TITLE
Add Sejong University (sju.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University

--- a/lib/domains/kr/sju.txt
+++ b/lib/domains/kr/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University

--- a/lib/domains/kr/sju.txt
+++ b/lib/domains/kr/sju.txt
@@ -1,2 +1,0 @@
-세종대학교
-Sejong University


### PR DESCRIPTION
I ask JetBrains to add my university domain.

University name: Sejong University (Seoul, South Korea)
University domain: @sju.ac.kr
University URL: https://www.sejong.ac.kr/
Computer Science and Engineering URL: https://en.sejong.ac.kr/eng/academics/computer-sciences-and-engineering.do
Email service URL: https://www.sejong.ac.kr/kor/unilife/email-service.do

Sejong University is a university in Seoul, South Korea, and it has a Computer Science and Engineering department.
The official student email domain for current students is @sju.ac.kr.

Please review, and if everything looks good, merge please.
Thank you :)

(my email: iacid123@sju.ac.kr)