### PR TITLE
Add Mahatma Gandhi Chitrakoot Gramodaya University (MGCGV), India

### DIFF
--- a/lib/domains/org/gramodayadistance.txt
+++ b/lib/domains/org/gramodayadistance.txt
@@ -1,0 +1,2 @@
+Mahatma Gandhi Chitrakoot Gramodaya University
+Mahatma Gandhi Chitrakoot Gramodaya Vishwavidyalaya (MGCGV)


### PR DESCRIPTION
This pull request adds Mahatma Gandhi Chitrakoot Gramodaya University (MGCGV) to the JetBrains educational institutions database.

Institution Information:
- Full Name: Mahatma Gandhi Chitrakoot Gramodaya University
- Alternate Name: Mahatma Gandhi Chitrakoot Gramodaya Vishwavidyalaya (MGCGV)
- Country: India
- IAU ID: IAU-011182
- Website: http://gramodayadistance.org
- Institution Type: Public University

Accreditation:
The university is listed in the World Higher Education Database (WHED) maintained by IAU and is accredited by UGC, AICTE, ICAR, and NCTE (India).

History:
Founded in 1991 as Chitrakoot Gramodaya Vishwavidyalaya, later renamed Mahatma Gandhi Gramodaya Vishwavidyalaya, and received its current name in 1997.

Please let me know if any additional information is required.