### PR TITLE
Add domain student.iuh.edu.vn for Industrial University of Ho Chi Minh City

### DIFF
--- a/lib/domains/vn/iuh.txt
+++ b/lib/domains/vn/iuh.txt
@@ -1,0 +1,2 @@
+Trường Đại học Công nghiệp TP.HCM
+Industrial University of Ho Chi Minh City


### PR DESCRIPTION
University Name: Industrial University of Ho Chi Minh City (IUH).
Domain: student.iuh.edu.vn
Country: Vietnam.
Reason: Adding student email domain for JetBrains Educational licenses.