### PR TITLE
Add email ecampus Universitas Terbuka.

### DIFF
--- a/lib/domains/id/ac/ut/ecampus.txt
+++ b/lib/domains/id/ac/ut/ecampus.txt
@@ -1,0 +1,1 @@
+Universitas Terbuka


### PR DESCRIPTION
Universitas Terbuka Jl. Cabe Raya, Pondok Cabe, Pamulang, Tangerang Selatan, Banten, Indonesia 15437.

Adding ecampus email which student use.

University official URL: https://www.ut.ac.id/

Recognition the ecampus email by Universitas Terbuka can be seem for the official site at the bottom page, specifically written WEBMAIL:

<img width="1920" height="947" alt="image" src="https://github.com/user-attachments/assets/7237c765-3526-40ef-8c63-0ca6510e888f" />

https://ecampus.ut.ac.id/

Thank you.