### PR TITLE
Add Universidad Continental domain (continental.edu.pe) from Peru

### DIFF
--- a/lib/domains/pe/edu/continental.txt
+++ b/lib/domains/pe/edu/continental.txt
@@ -1,0 +1,1 @@
+Universidad Continental


### PR DESCRIPTION
Hi JetBrains team,

I'm requesting to add the email domain continental.edu.pe for Universidad Continental in Peru.

<img width="1080" height="2280" alt="Screenshot_20260505_181240_Gmail" src="https://github.com/user-attachments/assets/71f6cf58-ce37-4930-8ba9-e26814ada50b" />
University Details:
- Official Website: https://www.continental.edu.pe
- IT Program: https://guiasderecursos.continental.edu.pe/ingenieria-de-sistemas-e-informatica
- Domain: continental.edu.pe

Evidence:
- The domain continental.edu.pe is the official email domain for enrolled students and staff at Universidad Continental, as confirmed by multiple official emails from the institution (empleabilidad@continental.edu.pe and others)
- Universidad Continental is an accredited institution offering "Ingeniería de Sistemas e Informática" (Systems and Computer Engineering), a long-term IT-related degree program
- I have official email communications, payment receipts, and certifications from the university confirming this is the official domain

Thank you!
<img width="1080" height="2280" alt="Screenshot_20260505_181250_Gmail" src="https://github.com/user-attachments/assets/e9543c59-402c-41fa-85d6-a6156d2a8d6a" />
<img width="1080" height="2280" alt="Screenshot_20260505_181313_Gmail" src="https://github.com/user-attachments/assets/db821c03-344e-4d7d-8ae7-743d6a64eddc" />
