### PR TITLE
Add comunidad.unam.mx for Universidad Nacional Autónoma de México

### DIFF
--- a/lib/domains/mx/unam/comunidad.txt
+++ b/lib/domains/mx/unam/comunidad.txt
@@ -1,0 +1,2 @@
+Universidad Nacional Autónoma de México
+UNAM


### PR DESCRIPTION
Add comunidad.unam.mx for Universidad Nacional Autónoma de México (UNAM)

Official evidence:
- https://correocomunidad.unam.mx/
- https://sistemas.tic.unam.mx/index.php/correo-electronico-unam/

`@comunidad.unam.mx` is an official institutional email domain recognized and operated by UNAM for students and staff with active academic or professional activity at the university.