### PR TITLE
Add ebc.edu.mx for Escuela Bancaria y Comercial

### DIFF
--- a/lib/domains/mx/ebc/edu.txt
+++ b/lib/domains/mx/ebc/edu.txt
@@ -1,0 +1,2 @@
+Escuela Bancaria y Comercial
+EBC

--- a/lib/domains/mx/unam/comunidad.txt
+++ b/lib/domains/mx/unam/comunidad.txt
@@ -1,0 +1,2 @@
+Universidad Nacional Autónoma de México
+UNAM


### PR DESCRIPTION
Add ebc.edu.mx for Escuela Bancaria y Comercial (EBC)

Official evidence:
- https://www.ebc.mx/
- https://www.ebc.edu.mx/

`@ebc.edu.mx` is the official institutional email domain used by students of Escuela Bancaria y Comercial, a private Mexican university.