### PR TITLE
Add Universidad Nacional Agraria de la Selva

### DIFF
--- a/lib/domains/pe/edu/unas.txt
+++ b/lib/domains/pe/edu/unas.txt
@@ -1,0 +1,2 @@
+Universidad Nacional Agraria de la Selva
+National Agrarian University of the Jungle


### PR DESCRIPTION
Official university website: https://www.unas.edu.pe/

The domain unas.edu.pe belongs to Universidad Nacional Agraria de la Selva.

This request adds the official university name for the student email domain unas.edu.pe.

University name:
Universidad Nacional Agraria de la Selva

Student email domain:
unas.edu.pe