### PR TITLE
Add National Dairy Research Institute domain

### DIFF
--- a/lib/domains/in/res/ndri.txt
+++ b/lib/domains/in/res/ndri.txt
@@ -1,0 +1,2 @@
+National Dairy Research Institute, karnal, India
+https://www.ndri.res.in/


### PR DESCRIPTION
Added academic domain for National Dairy Research Institute (NDRI), Karnal, India.

Official website:
https://www.ndri.res.in/
