### PR TITLE
Add Industrial University of Ho Chi Minh City domain

### DIFF
--- a/lib/domains/vn/iuh.txt
+++ b/lib/domains/vn/iuh.txt
@@ -1,0 +1,2 @@
+Trường Đại học Công nghiệp TP.HCM
+Industrial University of Ho Chi Minh City


### PR DESCRIPTION
The email domain `student.iuh.edu.vn` is actively used by Industrial University of Ho Chi Minh City for student email accounts, but it appears the DNS record is not publicly resolvable.

Example student email format:
`23647241.bao@student.iuh.edu.vn`

Could you please verify manually or allow `iuh.edu.vn` / `sv.iuh.edu.vn` instead?
