### PR TITLE
Create du.txt

### DIFF
--- a/lib/domains/in/ac/du.txt
+++ b/lib/domains/in/ac/du.txt
@@ -1,0 +1,2 @@
+University of Delhi
+Delhi University


### PR DESCRIPTION
Official Website:
https://www.du.ac.in/

IT-related courses:
https://cs.du.ac.in/
https://www.du.ac.in/index.php?page=departments

The domain du.ac.in is officially used by the University of Delhi.