### PR TITLE
Add AE Prosa (aeprosa.pt)

### DIFF
--- a/lib/domains/pt/aeprosa.txt
+++ b/lib/domains/pt/aeprosa.txt
@@ -1,0 +1,2 @@
+Agrupamento de Escolas Pinheiro e Rosa
+AE Prosa


### PR DESCRIPTION
**Institution:** Agrupamento de Escolas Pinheiro e Rosa (AEPROSA)
**Domain:** aeprosa.pt
**Country:** Portugal

**Official website:** https://www.aeprosa.pt

**Proof of student email domain:**
- Student portal: https://moodle.aeprosa.pt/login/index.php
- School services portal: https://pessoal.aeprosa.pt
- Student card portal: https://unicardsige-portal.aeprosa.pt

The domain aeprosa.pt is used for student email addresses and school services.

**IT-related courses:**
The school offers professional courses (cursos profissionais) including IT-related training as part of the Portuguese secondary education system (ensino secundário - cursos profissionais de nível IV).

Thank you for reviewing this request!