### PR TITLE
Add Faculty of Computers and Information - Menofia University

### DIFF
--- a/lib/domains/eg/edu/menofia/ci.txt
+++ b/lib/domains/eg/edu/menofia/ci.txt
@@ -1,0 +1,2 @@
+Menofia University - Faculty of Computers and Information
+جامعة المنوفية - كلية الحاسبات والمعلومات


### PR DESCRIPTION
Hello JetBrains Team,

I would like to add the domain ci.menofia.edu.eg to the swot list. This domain is dedicated to the students of the Faculty of Computers and Information at Menofia University, Egypt.

Supporting Information:
Official Website: https://www.menofia.edu.eg/fci/View/57670/en

Course Proof: Our faculty offers a 4-year Bachelor's degree in Computer Science and Information Technology.

Domain Recognition: The domain ci.menofia.edu.eg is the official email domain provided to all enrolled students at the faculty.

Thank you for your support