### PR TITLE
Create ceccharlevoix.txt

### DIFF
--- a/lib/domains/ca/qc/ceccharlevoix.txt
+++ b/lib/domains/ca/qc/ceccharlevoix.txt
@@ -1,0 +1,1 @@
+Centre d'études collégiales en Charlevoix


### PR DESCRIPTION
Official domain for Centre d'études collégiales en Charlevoix (CECC)

Website:
https://cecccharlevoix.ca/

The domain ceccharlevoix.qc.ca is used for official staff and student email addresses.