### PR TITLE
SVKM's Shri Bhagubhai Maftlal 

### DIFF
--- a/lib/domains/com/onmicrosoft/svkmmumbai.txt
+++ b/lib/domains/com/onmicrosoft/svkmmumbai.txt
@@ -1,0 +1,1 @@
+Shri Bhagubhai Mafatlal 

--- a/lib/domains/com/onmicrosoft/svkmmumbai.txt
+++ b/lib/domains/com/onmicrosoft/svkmmumbai.txt
@@ -1,1 +1,2 @@
-Shri Bhagubhai Mafatlal 
+Shri Bhagubhai Mafatlal
+svkm.group

--- a/lib/domains/com/onmicrosoft/svkmmumbai.txt
+++ b/lib/domains/com/onmicrosoft/svkmmumbai.txt
@@ -1,2 +1,2 @@
-Shri Bhagubhai Mafatlal
+Shri Bhagubhai Mafatlal Polytechnic and college of engineering
 svkm.group


### PR DESCRIPTION
This pull request adds Shri Bhagubhai Maftlal Polytechnic College to the JetBrains SWOT repository for student license verification.

School name: Shri Bhagubhai Maftlal
Country: India
Domain added: lib/domain/com/onmicrosft/svkmumbai.txt

Official website: https://sbmp.ac.in/
page which will verify it is more than a year : https://sbmp.ac.in/information-technology-diploma/
