### PR TITLE
Add utp.edu.pe domain

### DIFF
--- a/lib/domains/pe/utp.txt
+++ b/lib/domains/pe/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+UTP


### PR DESCRIPTION
Official university website:
https://utp.edu.pe

IT related course:
https://utp.edu.pe/pregrado/facultad-de-ingenieria/ingenieria-de-sistemas-e-informatica

Proof that the domain is used by enrolled students:
https://www.youtube.com/watch?v=nGER-Be6ExU
https://xpedition.utp.edu.pe/productos-digitales/utpclass

The domain utp.edu.pe is used for official student email accounts.