### PR TITLE
Add Keimyung University (KMU) domain for kr

### DIFF
--- a/lib/domains/kr/kmu.txt
+++ b/lib/domains/kr/kmu.txt
@@ -1,0 +1,2 @@
+계명대학교
+Keimyung University (KMU)


### PR DESCRIPTION
## Summary
- Add `lib/domains/kr/kmu.txt` for Keimyung University (계명대학교, KMU)

## Test plan
- [ ] Verify domain file is correctly placed under `lib/domains/kr/`
- [ ] Verify file contains correct university name in Korean and English

🤖 Generated with [Claude Code](https://claude.com/claude-code)