### PR TITLE
Add Kommuri Pratap Reddy Institute of Technology (KPRIT)

### DIFF
--- a/lib/domains/in/ac/kpritech.txt
+++ b/lib/domains/in/ac/kpritech.txt
@@ -1,0 +1,2 @@
+Kommuri Pratap Reddy Institute of Technology (KPRIT), Hyderabad, Telangana
+https://www.kpritech.ac.in/


### PR DESCRIPTION
## Description
This PR adds the official domain for Kommuri Pratap Reddy Institute of Technology (KPRIT), located in Hyderabad, Telangana, India. This will allow students and faculty to access academic discounts and licenses.

## Details
- **Institution Name:** Kommuri Pratap Reddy Institute of Technology (KPRIT)
- **Official Website:** https://www.kpritech.ac.in/
- **Domain:** kpritech.ac.in

## Verification
The institution is affiliated with Jawaharlal Nehru Technological University, Hyderabad (JNTUH). The provided domain is the primary academic domain used by students for official correspondence.