### PR TITLE
Industrial University of Ho Chi Minh City

### DIFF
--- a/lib/domains/vn/edu/iuh/student.txt
+++ b/lib/domains/vn/edu/iuh/student.txt
@@ -1,0 +1,2 @@
+Đại học Công Nghiệp TP. Hồ Chí Minh
+Industrial University of Ho Chi Minh City


### PR DESCRIPTION
Add Industrial University of Ho Chi Minh City (IUH) student email domain support.

This pull request adds the `student.iuh.edu.vn` domain for students of Industrial University of Ho Chi Minh City in Vietnam.

Thank you to the JetBrains team and contributors for maintaining the SWOT repository and supporting students around the world with access to educational tools and developer resources.
