### PR TITLE
Ajout du domaine ucad.edu.sn

### DIFF
--- a/lib/domains/sn/edu/ucad.txt
+++ b/lib/domains/sn/edu/ucad.txt
@@ -1,0 +1,3 @@
+Université Cheikh Anta Diop de Dakar
+UCAD
+Cheikh Anta Diop University of Dakar


### PR DESCRIPTION
Universite Cheikh Anta Diop de Dakar
Web Site : https://www.ucad.sn/
