### PR TITLE
added Chengdu Institute of Biology in the domain

### DIFF
--- a/lib/domains/cn/ac/cib.txt
+++ b/lib/domains/cn/ac/cib.txt
@@ -1,0 +1,1 @@
+Chengdu Institute of Biology, Chinese Academy of Sciences


### PR DESCRIPTION
added the domain for **Chengdu Institute of Biology**, Chinese academy of Sciences : http://english.cib.cas.cn/