### PR TITLE
add UTN Facultad Regional La Rioja to the domain library

### DIFF
--- a/lib/domains/ar/edu/utn/frlr.txt
+++ b/lib/domains/ar/edu/utn/frlr.txt
@@ -1,0 +1,1 @@
+UTN Facultad Regional La Rioja


### PR DESCRIPTION
Adding UTN Facultad Regional La Rioja official url: https://www.frlr.utn.edu.ar/
