### PR TITLE
Add University of Science and Technology Beijing student domain

### DIFF
--- a/lib/domains/cn/edu/ustb/xs.txt
+++ b/lib/domains/cn/edu/ustb/xs.txt
@@ -1,0 +1,2 @@
+北京科技大学
+University of Science and Technology Beijing


### PR DESCRIPTION
This pull request adds the official student email domain for University of Science and Technology Beijing.

Domain added:
xs.ustb.edu.cn

File added:
lib/domains/cn/edu/ustb/xs.txt

Official university website:
https://www.ustb.edu.cn/

Official student email service page:
https://info.ustb.edu.cn/xyyy/xsyx/index.htm

The official student email format is:
student_id@xs.ustb.edu.cn

This domain is used for student email accounts at University of Science and Technology Beijing.