### PR TITLE
Add utp.edu.pe for Universidad Tecnológica del Perú

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+Technological University of Peru


### PR DESCRIPTION
Adding utp.edu.pe for Universidad Tecnológica del Perú.

Official website:
https://www.utp.edu.pe

The university offers long-term degree programs in Software Engineering, Computer Science, Information Technology, and related fields.

Official student email domain:
@utp.edu.pe

Example student email format:
U########@utp.edu.pe

There is already an existing similar entry (upt.txt), but the official institutional student domain used by Universidad Tecnológica del Perú is utp.edu.pe.

I can provide additional proof or screenshots if needed.