### PR TITLE
Add alu.murciaeduca.es - IES Ingeniero de la Cierva

### DIFF
--- a/lib/domains/es/murciaeduca/alu.txt
+++ b/lib/domains/es/murciaeduca/alu.txt
@@ -1,0 +1,1 @@
+IES Ingeniero de la Cierva


### PR DESCRIPTION
Add domain for IES Ingeniero de la Cierva, Murcia, Spain.

- Domain: alu.murciaeduca.es
- Institution: IES Ingeniero de la Cierva (Instituto de Educación Secundaria y Formación Profesional)
- Country: Spain
- Official website: https://www.iescierva.net
- Offers FP Grado Medio y Superior (higher education): https://www.iescierva.net/oferta-formativa-fp-25-26/

The institution provides long-term IT-related vocational training at both intermediate and higher levels, qualifying under the SWoT inclusion criteria.