### PR TITLE
Add International College of Makeni (ICOM) email domain

### DIFF
--- a/lib/domains/ng/edu/icom.txt
+++ b/lib/domains/ng/edu/icom.txt
@@ -1,0 +1,1 @@
+International College of Makeni (ICOM)

--- a/lib/domains/sl/edu/icom.txt
+++ b/lib/domains/sl/edu/icom.txt
@@ -1,0 +1,2 @@
+International College of Makeni
+ICOM


### PR DESCRIPTION
Official website:
https://icom.edu.sl/

IT-related course:
https://icom.edu.sl/courses/diploma-in-software-engineering/

Proof of official email domain:
Students and lecturers are issued official email addresses under the @icom.edu.sl domain.

Attached screenshot from the university portal showing an official @icom.edu.sl lecturer account.
<img width="1874" height="783" alt="potal" src="https://github.com/user-attachments/assets/fc97695a-ec14-401c-a1b1-b4ce01745bf6" />
