### PR TITLE
Add utoronto domain

### DIFF
--- a/lib/domains/ca/utoronto/mail.txt
+++ b/lib/domains/ca/utoronto/mail.txt
@@ -1,0 +1,1 @@
+University of Toronto


### PR DESCRIPTION
utoronto is the domain for the University of Toronto email addresses.