### PR TITLE
Add Lviv Polytechnic National University (lpnu.ua)

### DIFF
--- a/lib/domains/ua/lpnu.txt
+++ b/lib/domains/ua/lpnu.txt
@@ -1,0 +1,2 @@
+Національний університет «Львівська політехніка»
+Lviv Polytechnic National University


### PR DESCRIPTION
Adds `lib/domains/ua/lpnu.txt` for **Національний університет «Львівська політехніка»** / **Lviv Polytechnic National University** so students with `@lpnu.ua` email addresses are recognized as academic users.

Official site: https://lpnu.ua