### PR TITLE
Add arandas.txt with institution name

### DIFF
--- a/lib/domains/mx/edu/tecmm/arandas.txt
+++ b/lib/domains/mx/edu/tecmm/arandas.txt
@@ -1,0 +1,1 @@
+Tecnológico Superior de Jalisco Arandas


### PR DESCRIPTION
I noticed some existing entries in the tecmm folder. As far as I know, these are all part of the same university network: 'Tecnológico Superior de Jalisco.' There are around 16 institutes (and more incoming) using the @x.tecmm.edu.mx domain, and it would be ideal if all of them worked out of the box. Do we need to add each one manually?

I read the following in the README.md:

> For domains shared by multiple institutions (e.g., a school district), please add the word .group as the last line.

Is that applicable in this case?