### PR TITLE
Add Minhaj University Lahore (mul.edu.pk)

### DIFF
--- a/mul.txt
+++ b/mul.txt
@@ -1,0 +1,1 @@
+Minhaj University Lahore


### PR DESCRIPTION
Adding the domain for Minhaj University Lahore. Official website: https://mul.edu.pk/