### PR TITLE
Add RUPP to kh/edu domain file

### DIFF
--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,1 @@
+Royal University of Phnom Penh


### PR DESCRIPTION
Add RUPP to kh/edu domain
Domian of Royal University of Phnom Penh : https://www.rupp.edu.kh/

The Royal University of Phnom Penh is a national research university of Cambodia, located in the Phnom Penh capital. Established in 1960, it is the country's largest university. It hosts around 30,000 students in undergraduate and postgraduate programmes.

Address : Russian Federation Blvd (110), Phnom Penh 120404, Cambodia
Founded: 1960