### PR TITLE
Add Sejong University, Republic of Korea

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+세종대학교
+Sejong University


### PR DESCRIPTION
link for the university: `https://www.sejong.ac.kr/`