### PR TITLE
Add Mariengymnasium-Warendorf

### DIFF
--- a/lib/domains/de/mgw365.txt
+++ b/lib/domains/de/mgw365.txt
@@ -1,0 +1,1 @@
+Mariengymnasium-Warendorf


### PR DESCRIPTION
Official Website: https://www.mariengymnasium.org
Page with course offering: https://mariengymnasium.org/informatik/
Page with proof of domain (§8): https://mariengymnasium.org/wp-content/uploads/2025/11/nutzerordnung_neu_2021.pdf