### PR TITLE
Add Universidad Tecnológica del Perú

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,2 @@
+Universidad Tecnológica del Perú
+Technological University of Peru


### PR DESCRIPTION
This pull request adds the academic email domain for Universidad Tecnológica del Perú.

Domain: utp.edu.pe
School: Universidad Tecnológica del Perú
English name: Technological University of Peru