### PR TITLE
Add Suez Canal University

### DIFF
--- a/lib/domains/eg/edu/suez.txt
+++ b/lib/domains/eg/edu/suez.txt
@@ -1,0 +1,2 @@
+Suez Canal University
+جامعة قناة السويس


### PR DESCRIPTION
Adding Suez Canal University to the Egyptian educational domains.

- Domain: `suez.edu.eg`
- Name: Suez Canal University
- Native Name: جامعة قناة السويس