### PR TITLE
Add cftestatalaricayparinacota.cl

### DIFF
--- a/lib/domains/cl/cftestatalaricayparinacota.txt
+++ b/lib/domains/cl/cftestatalaricayparinacota.txt
@@ -1,0 +1,2 @@
+Centro de Formación Técnica Arica y Parinacota.cl
+Technical Formation Center Arica y Parinacota

--- a/lib/domains/cl/cftestatalaricayparinacota.txt
+++ b/lib/domains/cl/cftestatalaricayparinacota.txt
@@ -1,2 +1,2 @@
-Centro de Formación Técnica Arica y Parinacota.cl
+Centro de Formación Técnica Arica y Parinacota
 Technical Formation Center Arica y Parinacota


### PR DESCRIPTION
## Summary
- Add cftestatalaricayparinacota.cl for Centro de Formacion Tecnica Arica y Parinacota

## References
- Official website: https://www.cftestatalaricayparinacota.cl/
- Programs page: https://cftestatalaricayparinacota.cl/areas-formativas/
- Contact information showing addresses on this domain: https://www.cftestatalaricayparinacota.cl/