### PR TITLE
Add senshu university domain

### DIFF
--- a/lib/domains/jp/ac/senshu-u/edu.txt
+++ b/lib/domains/jp/ac/senshu-u/edu.txt
@@ -1,0 +1,2 @@
+専修大学
+Senshu University


### PR DESCRIPTION
Add domain for Senshu University.

Official university website:
https://www.senshu-u.ac.jp/
Official proof that `edu.senshu-u.ac.jp` is used as the Microsoft account domain for students:
https://www.senshu-u.ac.jp/isc/guidance.html

Senshu University has the School of Network and Information, which covers computer science, data science, and practical information technology.