### PR TITLE
Add std.txt for University of Electronic Science and Technology

### DIFF
--- a/lib/domains/cn/edu/uestc/std.txt
+++ b/lib/domains/cn/edu/uestc/std.txt
@@ -1,0 +1,1 @@
+University of Electronic Science and Technology of China


### PR DESCRIPTION
I am submitting `std.uestc.edu.cn` as an official student email domain for the University of Electronic Science and Technology of China (UESTC).

Verification information:

1. Official university website:
   - https://www.uestc.edu.cn/
   - https://en.uestc.edu.cn/

2. Long-term IT-related course/program offered by the university:
   - https://en.uestc.edu.cn/info/1097/3174.htm

3. Proof that the submitted domain is recognized as an official student email domain:

   - Official UESTC Information Center page for the student email system:
     https://info.uestc.edu.cn/yyxt/xsyjxt.htm

   - Student email system login page:
     https://mail.std.uestc.edu.cn/

   - Screenshot 1: 
<img width="3416" height="2322" alt="CleanShot 2026-05-16 at 13 07 22@2x" src="https://github.com/user-attachments/assets/69f9341d-0d08-47eb-9bce-f6c572ae0420" />

   - Screenshot 2: 
<img width="3416" height="2322" alt="CleanShot 2026-05-16 at 13 06 36@2x" src="https://github.com/user-attachments/assets/f93f8290-b286-44d2-8045-23051140bdfd" />

The submitted domain `std.uestc.edu.cn` is used for UESTC student email accounts. The official Information Center page lists the Student Email System as a service for students and links to `https://mail.std.uestc.edu.cn/`. The student email login page also shows `std.uestc.edu.cn` as the email domain option.

Please let me know if any additional information is required.