### PR TITLE
add khwopa college of engineering edu domain

### DIFF
--- a/lib/domains/np/edu/khwopa.txt
+++ b/lib/domains/np/edu/khwopa.txt
@@ -1,0 +1,2 @@
+Khwopa College of Engineering
+Khwopa College of Engineering (Tribhuvan University)


### PR DESCRIPTION
This `.edu` domain belongs to Khwopa College of Engineering, which is affiliated with Tribhuvan University. Please do not confuse it with the `khec` domain, which belongs to Khwopa Engineering College affiliated with Purbanchal University.
