### PR TITLE
Added Universidad de Concepción (udec) domain

### DIFF
--- a/lib/domains/cl/udec.txt
+++ b/lib/domains/cl/udec.txt
@@ -1,0 +1,2 @@
+Universidad de Concepción
+University of Concepción


### PR DESCRIPTION
As it is stated in the _Malla Curricular_ (Study Program) section of https://admision.udec.cl/ciencias-fisicas/, my career offers three Computational Physics _(Física Computacional)_ courses anually.

Also, in the attached image it is shown that the Uni recognizes the domain udec.cl for the students email (screenshot taken from the institutional intranet)

<img width="942" height="278" alt="image" src="https://github.com/user-attachments/assets/c1f8646c-27c4-464d-bfb0-b7e3771afead" />
