### PR TITLE
Add mines-paris.org domain

### DIFF
--- a/lib/domains/org/mines-paris.txt
+++ b/lib/domains/org/mines-paris.txt
@@ -1,0 +1,1 @@
+Ecole des Mines de Paris


### PR DESCRIPTION
This pull request adds the domain mines-paris.org for Mines Paris - PSL.

Official website:
https://www.minesparis.psl.eu/

The submitted domain is:
mines-paris.org

I confirm that I have read the repository rules.