### PR TITLE
fix: support stu subdomain for Minjiang University

### DIFF
--- a/lib/domains/cn/edu/mju.txt
+++ b/lib/domains/cn/edu/mju.txt
@@ -1,0 +1,2 @@
+Minjiang University
+闽江大学

--- a/lib/domains/cn/edu/mju.txt
+++ b/lib/domains/cn/edu/mju.txt
@@ -1,2 +1,0 @@
-Minjiang University
-闽江大学

--- a/lib/domains/cn/edu/mju/stu.txt
+++ b/lib/domains/cn/edu/mju/stu.txt
@@ -1,0 +1,2 @@
+闽江大学
+Minjiang University


### PR DESCRIPTION
First of all, thanks for merging the root domain previously! While the other subdomains are working flawlessly, the student subdomain was hitting some recognition snags, so I am adding the stu subdomain here to fix it.

​**Description**
​Added support for the student subdomain (`stu.mju.edu.cn`) to resolve recognition and verification issues in systems like Zed and JetBrains.
​The root domain configuration remains intact to ensure staff and alumni verification continues to work seamlessly.

**​Official Proof / Verification Link**
- **​Source Link:**
https://xjzx.mju.edu.cn/2020/0603/c4652a200078/page.htm

- **​Translation/Description:** 
This is the official announcement published by the Modern Educational Technology Center of Minjiang University. It explicitly details the launch and user guidelines for the campus electronic mailbox system, confirming that the official email suffix designated for students is @stu.mju.edu.cn.