### PR TITLE
Add senati.pe (Peru) to educational domains

### DIFF
--- a/lib/domains/pe/senati.txt
+++ b/lib/domains/pe/senati.txt
@@ -1,0 +1,1 @@
+Servicio Nacional de Adiestramiento en Trabajo Industrial


### PR DESCRIPTION
Hi! I'm adding SENATI (Servicio Nacional de Adiestramiento en Trabajo Industrial) from Peru. It is a major technical institution and the domain senati.pe is used exclusively for students and faculty. This will help students access educational licenses for Zed and JetBrains tools. Thanks!