### PR TITLE
Add Hosei University (hosei.ac.jp)

### DIFF
--- a/lib/domains/ac/hosei.txt
+++ b/lib/domains/ac/hosei.txt
@@ -1,2 +1,0 @@
-法政大学
-Hosei University

--- a/lib/domains/ac/hosei.txt
+++ b/lib/domains/ac/hosei.txt
@@ -1,0 +1,2 @@
+法政大学
+Hosei University

--- a/lib/domains/jp/ac/hosei.txt
+++ b/lib/domains/jp/ac/hosei.txt
@@ -1,0 +1,2 @@
+法政大学
+Hosei University


### PR DESCRIPTION
Add Hosei University, Japan.
Domain: hosei.ac.jp