### PR TITLE
Add Universitas Indonesia (ui.ac.id)

### DIFF
--- a/lib/domains/id/ac/ui.txt
+++ b/lib/domains/id/ac/ui.txt
@@ -1,0 +1,2 @@
+Universitas Indonesia
+University of Indonesia


### PR DESCRIPTION
## School Details
- **Name:** Universitas Indonesia
- **Domain:** ui.ac.id
- **File:** lib/domains/id/ac/ui.txt

## Verification
- Official website: https://www.ui.ac.id
- Universitas Indonesia is a public research university in Depok, Indonesia — one of the oldest and largest universities in the country.
- Students receive email addresses at `ui.ac.id`.