### PR TITLE
Universidad de Dagupan

### DIFF
--- a/lib/domains/ph/edu/cdd.txt
+++ b/lib/domains/ph/edu/cdd.txt
@@ -1,0 +1,1 @@
+Universidad de Dagupan


### PR DESCRIPTION
## Description
This PR adds the official domain for Universidad de Dagupan (UdD), a fully accredited higher education institution located in Dagupan City, Pangasinan, Philippines.

## Verification Details
- **University Name:** Universidad de Dagupan
- **Domain:** udd.edu.ph
- **Accreditation:** Recognized by the Commission on Higher Education (CHED), Philippines.
- **Programs:** Offers BS in Computer Science and BS in Information Technology. 
- **Website for Verification:** https://udd.edu.ph/ (or official CHED registry)

Adding this domain will allow verified students and faculty members to seamlessly access JetBrains Educational licenses for PyCharm and other IDEs.