### PR TITLE
Add Instituto Tecnológico de Zitácuaro by GC

### DIFF
--- a/lib/domains/mx/tecnm/zitacuaro.txt
+++ b/lib/domains/mx/tecnm/zitacuaro.txt
@@ -1,0 +1,2 @@
+Instituto Tecnologico de Zitacuaro
+Technological Institute of Zitácuaro


### PR DESCRIPTION
This pull request adds the official educational domain for Instituto Tecnológico de Zitácuaro, part of Tecnológico Nacional de México.

Official website:
https://zitacuaro.tecnm.mx/

Proof of institutional email/domain usage:
The official website lists institutional contact emails under the zitacuaro.tecnm.mx domain, such as escolares@zitacuaro.tecnm.mx.

The institution offers long-term higher education programs related to IT, including Ingeniería en Sistemas Computacionales and other engineering programs through Tecnológico Nacional de México.

This domain should allow students and faculty members from Instituto Tecnológico de Zitácuaro to request JetBrains educational licenses.

Regards