### PR TITLE
Add ecampus.ut.ac.id

### DIFF
--- a/lib/domains/id/ac/ut/ecampus.txt
+++ b/lib/domains/id/ac/ut/ecampus.txt
@@ -1,0 +1,2 @@
+Universitas Terbuka
+Open University of Indonesia


### PR DESCRIPTION
### University Information

University: Universitas Terbuka

Official Website:
https://www.ut.ac.id

### Email Domain

Requesting addition of the official academic email domain:

ecampus.ut.ac.id

Students receive email accounts in the format:

NIM@ecampus.ut.ac.id

### Evidence

Documentation showing usage of the academic email domain:

https://kms.ut.ac.id/kms-ut/bagaimana-cara-mengakses-akun-ecampus-mahasiswa/

### IT-related Programs

Faculty of Science and Technology:

https://fst.ut.ac.id