### PR TITLE
Add Atatürk University domain (atauni.edu.tr)

### DIFF
--- a/lib/domains/tr/edu/atauni/atauni.txt
+++ b/lib/domains/tr/edu/atauni/atauni.txt
@@ -1,0 +1,2 @@
+Atatürk Üniversitesi
+Atatürk University


### PR DESCRIPTION
Adds the official domain for Atatürk University.

The domain atauni.edu.tr is used by both students and academic staff. Student email addresses use the subdomain ogr.atauni.edu.tr, which is covered by the main domain.

University name:
- Atatürk Üniversitesi
- Atatürk University