### PR TITLE
Add Hanoi University of Civil Engineering

### DIFF
--- a/lib/domains/vn/edu/huce/st.txt
+++ b/lib/domains/vn/edu/huce/st.txt
@@ -1,0 +1,2 @@
+Trường Đại học Xây Dựng Hà Nội
+Hanoi University of Civil Engineering


### PR DESCRIPTION
This pull request adds the official student email domain for Hanoi University of Civil Engineering.

Official website: https://huce.edu.vn

The domain st.huce.edu.vn is used for student email accounts at Hanoi University of Civil Engineering.

The university offers long-term IT-related programs such as Computer Science / Information Technology / Software Engineering-related courses.