### PR TITLE
Add aptus.org — Corporación de la Educación Aptus Chile

### DIFF
--- a/lib/domains/org/aptus.txt
+++ b/lib/domains/org/aptus.txt
@@ -1,0 +1,1 @@
+Corporación de la Educación Aptus Chile


### PR DESCRIPTION
## Resubmission — Replaces #39895

Previous PR #39895 was closed because I incorrectly included a `lib/domains/org/aptus/aptus.txt` file (which corresponded to the non-existent `aptus.aptus.org` domain). This new PR contains only `lib/domains/org/aptus.txt` for the `aptus.org` domain.

## Institution

- Official name: Corporación de la Educación Aptus Chile
- Official website: https://www.aptus.org
- Country: Chile
- Type: Non-profit educational foundation

## Request for exception

I'd like to be transparent: Aptus is a non-profit foundation that supports schools in Chile with teacher training, curriculum, and assessment tools, rather than a traditional university with enrolled students. We do operate in the K-12 ecosystem.

However, we maintain a permanent staff of educators, instructional designers, software engineers, and data analysts who work full-time on educational technology — including our internal pedagogical management platform. These professionals use \`@aptus.org\` emails and would benefit from JetBrains tools.

If this does not qualify under the standard rules, I fully understand and we will reach out to sales@jetbrains.com instead, as suggested in the README. Thank you for reviewing.