### PR TITLE
Add Escola Poeta Al Berto School

### DIFF
--- a/lib/domains/pt/es-al-berto.txt
+++ b/lib/domains/pt/es-al-berto.txt
@@ -1,0 +1,1 @@
+Escola Secundária Poeta Al Berto


### PR DESCRIPTION
Add school named "Poeta Al Berto" in Sines, Portugal.
www.es-al-berto.com