### PR TITLE
Request to add

### DIFF
--- a/lib/domains/uk/co/burnsallprimaryschool.txt
+++ b/lib/domains/uk/co/burnsallprimaryschool.txt
@@ -1,0 +1,1 @@
+Burnsall Voluntary Aided Primary School


### PR DESCRIPTION
We would like to add Burnsall Voluntary Aided Primary School in the UK.

The school's official government link is: https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/121622

Please verify and approve this; we need to develop a school early childhood education system.