### PR TITLE
Add br.estacio.alunos.txt

### DIFF
--- a/lib/domains/br/estacio/alunos.txt
+++ b/lib/domains/br/estacio/alunos.txt
@@ -1,0 +1,1 @@
+Faculdade Estacio


### PR DESCRIPTION
### Description
Please add the official student academic domain for Estácio to the JetBrains Swot registry so that students can verify their academic status and access educational licenses.

### Institution Details
* **Official Name of the Institution:** Estácio (Universidade Estácio de Sá / Centro Universitário Estácio)
* **Country:** Brazil
* **Official Website:** https://estacio.br

### Domain to be Added
* `alunos.estacio.br` (represented as `br/estacio/alunos.txt` in the repository structure)

### Verification/Evidence
Estácio is one of the largest higher education institutions in Brazil, fully accredited by the Brazilian Ministry of Education (MEC). You can verify its official status directly on our main website or via the MEC official registry (e-MEC).