### PR TITLE
Add Damanhour University Faculty of Science domain

### DIFF
--- a/lib/domains/eg/edu/dmu/sci.txt
+++ b/lib/domains/eg/edu/dmu/sci.txt
@@ -1,0 +1,1 @@
+Damanhour University


### PR DESCRIPTION
Adds the `sci.dmu.edu.eg` domain for Damanhour University Faculty of Science.

Verification links:
- Official faculty website: https://damanhour.dmu.edu.eg/en/scimfac/pages/Home.aspx
- Official faculty contact page showing `info@sci.dmu.edu.eg`: https://sc.dmu.edu.eg/sectors/sector/?sector_type=college_establishment
- Official Damanhour University page listing long-term Faculty of Science programs, including Computer Science and Physics and Computer Science: https://www.damanhour.edu.eg/EN/Pages/Page.aspx?id=12431

Note: `dmu.edu.eg` is listed in `lib/domains/abused.txt`, so this PR intentionally adds only the Faculty of Science subdomain instead of the parent domain.

Validation:
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home ./gradlew run`