### PR TITLE
Add rgs.bayern

### DIFF
--- a/lib/domains/bayern/rgs.txt
+++ b/lib/domains/bayern/rgs.txt
@@ -1,0 +1,1 @@
+Richard-Glimpel-Schule


### PR DESCRIPTION
Add Richard-Glimpel-Schule (rgs.bayern)

Hi! This is a state-approved special education school (Sonderpädagogisches Förderzentrum) in Bavaria, Germany. 
* Official website: https://rgs.bayern
* Verification in the official school database of the Bavarian Ministry of Education: https://www.km.bayern.de/schule/6228
