### PR TITLE
Add @utp.edu.pe domain for Universidad Tecnológica del Perú

### DIFF
--- a/lib/domains/pe/edu/utp.txt
+++ b/lib/domains/pe/edu/utp.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica del Perú


### PR DESCRIPTION
Official university website:
https://www.utp.edu.pe/

Systems Engineering program:
https://www.utp.edu.pe/pregrado/facultad-de-ingenieria/ingenieria-de-sistemas-e-informatica

Student emails are issued under the domain:
@utp.edu.pe

Additional verification:

* My academic status has already been verified by GitHub Education (Student Developer Pack).
* The same student email/domain was also accepted by JetBrains Student Pack.
* The domain is actively used by students for institutional services and academic communication.

This domain belongs to Universidad Tecnológica del Perú (UTP), an officially recognized university in Peru.