### PR TITLE
Add NK Orchid College of Engineering & Technology, Solapur 

### DIFF
--- a/lib/domains/in/ac/orchidengg.txt
+++ b/lib/domains/in/ac/orchidengg.txt
@@ -1,0 +1,1 @@
+NK Orchid College of Engineering & Technology, Solapur


### PR DESCRIPTION
Request to include NK Orchid College of Engineering & Technology, Solapur, with the domain name “orchidengg.ac.in”.