### PR TITLE
Add Sri Guru Gobind Singh College of Commerce

### DIFF
--- a/lib/domains/in/ac/sggscc.txt
+++ b/lib/domains/in/ac/sggscc.txt
@@ -1,0 +1,1 @@
+Sri Guru Gobind Singh College of Commerce


### PR DESCRIPTION
Add the official student email domain for Sri Guru Gobind Singh College of Commerce, University of Delhi.  sggscc.ac.in maps to lib/domains/in/ac/sggscc.txt. 

Official website: https://www.sggscc.ac.in/  Long-term IT-related course: https://www.sggscc.ac.in/academics/bcompsci/programdetails

Official domain/student email proof: https://www.sggscc.ac.in/administration/iccgendersensitization