### PR TITLE
Add SID – Scuola Italiana Design

### DIFF
--- a/lib/domains/com/scuolaitalianadesign.txt
+++ b/lib/domains/com/scuolaitalianadesign.txt
@@ -1,0 +1,2 @@
+SID - Scuola Italiana Design
+https://www.scuolaitalianadesign.com/


### PR DESCRIPTION
Institution Details

- Official Name: Scuola Italiana Design (SID)
- Country: Italy
- Domain: scuolaitalianadesign.com
- Website: https://www.scuolaitalianadesign.com/

Eligibility

SID is a higher education institute offering a three-year academic program in Design and Communication, officially recognised as a First-Level Academic Diploma (assimilated to a Bachelor's Degree) since the 2023–24 academic year.

The curriculum includes dedicated coursework in digital design, UI/UX, and multimedia, which require the use of professional development tools.

Supporting Evidence

- Course page: https://www.scuolaitalianadesign.com/corsi/diploma-accademico/
- The domain scuolaitalianadesign.com is used as the official institutional email for students and staff.

Checklist

- Institution offers at least one long-term course (>1 year) related to IT
- Institution is a physical entity with student attendance
- Domain is not on the stoplist or abuse list
- Domain provides email addresses to enrolled students