### PR TITLE
Add `eng` and `fci` only under the domain `kfs.edu.eg`

### DIFF
--- a/lib/domains/eg/edu/kfs/eng.txt
+++ b/lib/domains/eg/edu/kfs/eng.txt
@@ -1,0 +1,2 @@
+كلية الهندسة، جامعة كفر الشيخ
+Faculty of Engineeing, Kafrelsheikh University

--- a/lib/domains/eg/edu/kfs/fci.txt
+++ b/lib/domains/eg/edu/kfs/fci.txt
@@ -1,0 +1,2 @@
+كلية الحاسبات والمعلومات، جامعة كفر الشيخ
+Faculty of Computers and Information, Kafrelsheikh University


### PR DESCRIPTION
It appears that this university has been wrongly banned, but the abuse can be mitigated by allowing only students from these two faculties.

- **Faculty of Engineering:**
https://www.kfs.edu.eg/engeng/
Study Plans:
https://kfs.edu.eg/engeng/display_dep.aspx?topic=88983&dep=695

- **Faculty of Computers and Information:**
https://www.kfs.edu.eg/engcomputers/
Study Plans:
https://kfs.edu.eg/engcomputers/display_dep.aspx?topic=101129&dep=852