### PR TITLE
Add kcg.edu

### DIFF
--- a/lib/domains/edu/kcg.txt
+++ b/lib/domains/edu/kcg.txt
@@ -1,0 +1,3 @@
+京都コンピュータ学院
+Kyoto Computer Gakuin
+KCG


### PR DESCRIPTION
Official website:
https://www.kcg.edu

Official email proof:
Students receive official @kcg.edu email addresses.