### PR TITLE
Add stu.hosei.ac.jp

### DIFF
--- a/lib/domains/jp/ac/hosei/stu.txt
+++ b/lib/domains/jp/ac/hosei/stu.txt
@@ -1,0 +1,2 @@
+法政大学
+Hosei University


### PR DESCRIPTION
Add official student email domain for Hosei University.

Official website:
https://www.hosei.ac.jp/

Student email domain:
stu.hosei.ac.jp

IT-related course page:
https://cis.hosei.ac.jp/