### PR TITLE
Add psp school domain

### DIFF
--- a/lib/domains/th/ac/pho.txt
+++ b/lib/domains/th/ac/pho.txt
@@ -1,0 +1,2 @@
+โรงเรียนโพธิสัมพันธ์พิทยาคาร
+Phothisamphanphitthayakhan School


### PR DESCRIPTION
School: Phothisamphanphitthayakhan School

Official website:
https://www.pho.ac.th

Student email example:
33242@pho.ac.th