### PR TITLE
Add Korea National University of Education (knue.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/knue.txt
+++ b/lib/domains/kr/ac/knue.txt
@@ -1,0 +1,2 @@
+한국교원대학교
+Korea National University of Education


### PR DESCRIPTION
Add knue.ac.kr (Korea National University of Education / 한국교원대학교).

Official site: https://www.knue.ac.kr