### PR TITLE
Add Universidad de La Salle email domain

### DIFF
--- a/lib/domains/co/edu/unisalle.txt
+++ b/lib/domains/co/edu/unisalle.txt
@@ -1,0 +1,1 @@
+Universidad de La Salle


### PR DESCRIPTION
This pull request adds the Universidad de La Salle email domain for JetBrains educational license verification.