### PR TITLE
Add Shizuoka University to shizuoka.txt

### DIFF
--- a/lib/domains/jp/ac/shizuoka.txt
+++ b/lib/domains/jp/ac/shizuoka.txt
@@ -1,0 +1,1 @@
+Shizuoka University


### PR DESCRIPTION
### Verification Information
- **Official Website:** https://www.shizuoka.ac.jp
- **IT/Computer Science Course Evidence:** https://www.inf.shizuoka.ac.jp/english/ (Faculty of Informatics)
- **Domain Email Proof:** The domain `shizuoka.ac.jp` is the standard academic suffix issued to all active students and faculty members at Shizuoka University.