### PR TITLE
Add ubd.ac.id for Buddhi Dharma University

### DIFF
--- a/lib/domains/id/ac/ubd.txt
+++ b/lib/domains/id/ac/ubd.txt
@@ -1,0 +1,2 @@
+Universitas Buddhi Dharma
+Buddhi Dharma University


### PR DESCRIPTION
Official website:
https://buddhidharma.ac.id/

IT related course:
https://fst.buddhidharma.ac.id/

The university provides official student email accounts using the @ubd.ac.id domain.
