### PR TITLE
Add Universidad Don Bosco de El Salvador

### DIFF
--- a/lib/domains/sv/edu/udb.txt
+++ b/lib/domains/sv/edu/udb.txt
@@ -1,0 +1,2 @@
+Universidad Don Bosco
+Universidad Don Bosco, El Salvador


### PR DESCRIPTION
Official university website: https://www.udb.edu.sv/

The university provides student academic email accounts under the subdomain @alumno.udb.edu.sv.
Official proof: https://www.udb.edu.sv/udb/pagina/live-edu

The official site states that students must have an academic account in the @alumno.udb.edu.sv domain and therefore be active students of the university.

According to the SWOT repository rules, adding the main domain udb.edu.sv should also include its subdomains, including alumno.udb.edu.sv.