### PR TITLE
Add Universiti Putra Malaysia (UPM) to upm.txt

### DIFF
--- a/lib/domains/my/edu/upm.txt
+++ b/lib/domains/my/edu/upm.txt
@@ -1,0 +1,1 @@
+Universiti Putra Malaysia


### PR DESCRIPTION
Adding Universiti Putra Malaysia (UPM), a Malaysian public research university.

About the institution:
- Official website: https://www.upm.edu.my
- UPM is ranked in the top 150 of QS World University Rankings.
- The Faculty of Computer Science and Information Technology offers 
  multiple IT-related undergraduate and postgraduate programs 
  (BSc Computer Science, Software Engineering, etc.), all with 
  duration of 4 years or longer.

Email domains:
- Staff: @upm.edu.my
- Students: @student.upm.edu.my (subdomain, covered by upm.txt)

Official source confirming @student.upm.edu.my as the official 
student email domain:
https://upm.edu.my/news/upms_official_e_mail_for_new_students_launched-25155

I am currently a student at UPM. Happy to provide additional 
verification (webmail screenshot, student ID, etc.) if required.