### PR TITLE
Dipont Huayao Collegiate School Kunshan

### DIFF
--- a/lib/domains/com/dipont-hc.txt
+++ b/lib/domains/com/dipont-hc.txt
@@ -1,0 +1,2 @@
+昆山狄邦华曜学校
+Dipont Huayao Collegiate School Kunshan


### PR DESCRIPTION
Add Dipont Huayao Collegiate School Kunshan (dipont-hc.com)

- School Name: Dipont Huayao Collegiate School Kunshan
- Official Website: https://www.dipont-hc.com
- Domain to Add: dipont-hc.com
- Description: This is an international school providing K-12 education (including high school computer science and IT-related courses). I am the IT infrastructure administrator of this school. This domain email is strictly assigned to our faculty members and students. 
- Proof of Educational Status: The school website clearly states its educational nature as an international collegiate school.