### PR TITLE
Add Sungkyunkwan University (skku.edu)

### DIFF
--- a/lib/domains/edu/skku.txt
+++ b/lib/domains/edu/skku.txt
@@ -1,0 +1,1 @@
+Sungkyunkwan University


### PR DESCRIPTION
Adds `skku.edu` for Sungkyunkwan University.

- Official website: https://www.skku.edu/eng/
- IT-related long-term program (Computer Science & Engineering, 4-year undergrad):
  https://cse.skku.edu/eng_cse/intro.do
- Proof that skku.edu is the official student/faculty email domain:
  https://www.skku.edu/eng/edu/board/notice.do  (or attach a screenshot of your student/faculty portal showing @skku.edu)

Note: a subdomain entry already exists at `lib/domains/edu/skku/g.txt` (g.skku.edu).
This PR adds the parent domain `skku.edu` to cover all SKKU email addresses.
