### PR TITLE
This pull request adds the official academic email domain for Institute of Space Technology (IST), Islamabad, Pakistan.

### DIFF
--- a/lib/domains/pk/edu/ist.txt
+++ b/lib/domains/pk/edu/ist.txt
@@ -1,0 +1,1 @@
+Institute of Space Technology


### PR DESCRIPTION
Domain added: ist.edu.pk

IST is a public-sector higher education institute in Pakistan offering undergraduate and graduate programs in engineering, computing, space technology, and applied sciences. The institute offers computing-related programs, including Computer Science, Artificial Intelligence, Data Science, Software Engineering, and Computer Engineering.

Evidence:

Official IST website: https://ist.edu.pk/
IST admissions FAQ/computing programs page: https://ist.edu.pk/admission?section=admission-faq
IST academics - computing page: https://ist.edu.pk/academics?section=computing
HEC university listing/recognition page: https://www.hec.gov.pk/english/universities/Pages/Islamabad/Institute-of-Space-Technology.aspx