### PR TITLE
Add due.udn.vn domain

### DIFF
--- a/lib/domains/vn/udn/due.txt
+++ b/lib/domains/vn/udn/due.txt
@@ -1,0 +1,2 @@
+Đại học Kinh tế - Đại học Đà Nẵng
+University of Economics - The University of Danang


### PR DESCRIPTION
Institutional domain for University of Economics - The University of Danang.
Student emails use the @due.udn.vn domain.