### PR TITLE
Add uca.txt with university names

### DIFF
--- a/lib/domains/ma/ac/uca.txt
+++ b/lib/domains/ma/ac/uca.txt
@@ -1,0 +1,3 @@
+Université Cadi Ayyad
+Cadi Ayyad University
+جامعة القاضي عياض


### PR DESCRIPTION
Adding the official email domain uca.ac.ma for Université Cadi Ayyad.

Official university website: https://www.uca.ma
Official ENSA Marrakech website: https://ensa-marrakech.uca.ma
ENSA Marrakech is part of Université Cadi Ayyad.
Student emails use the uca.ac.ma domain.