### PR TITLE
Add University of South China (usc.edu.cn) 

### DIFF
--- a/lib/domains/cn/edu/usc/stu.txt
+++ b/lib/domains/cn/edu/usc/stu.txt
@@ -1,0 +1,2 @@
+南华大学
+University of South China


### PR DESCRIPTION
Please add the student email domain for University of South China (南华大学).

- Official Website: https://www.usc.edu.cn
- Domain to add: stu.usc.edu.cn
