### PR TITLE
Add Saigon University (sgu.edu.vn)

### DIFF
--- a/lib/domains/vn/edu/sgu.txt
+++ b/lib/domains/vn/edu/sgu.txt
@@ -1,0 +1,2 @@
+Đại Học Sài Gòn
+Saigon University


### PR DESCRIPTION
Add sgu.edu.vn domain for Saigon University (Đại Học Sài Gòn), Vietnam.