### PR TITLE
Add JUET

### DIFF
--- a/lib/domains/in/ac/juet.txt
+++ b/lib/domains/in/ac/juet.txt
@@ -1,0 +1,1 @@
+Jaypee University of Engineering & Technology (JUET)


### PR DESCRIPTION
Add juet.ac.in for Jaypee University of Engineering & Technology.

Official website: [juet.ac.in](https://juet.ac.in)
