### PR TITLE
Add UTN - Facultad Regional San Nicolas

### DIFF
--- a/lib/domains/ar/edu/utn/tupad.txt
+++ b/lib/domains/ar/edu/utn/tupad.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica Nacional - Facultad Regional San Nicolás


### PR DESCRIPTION
Add **Facultad Regional San Nicolas** as official headquarters of online program for tech degree in computer programming. (Universidad Tecnológica Nacional)