### PR TITLE
Add mahasiswa.ung.ac.id for Universitas Negeri Gorontalo

### DIFF
--- a/lib/domains/id/ac/ung/mahasiswa.txt
+++ b/lib/domains/id/ac/ung/mahasiswa.txt
@@ -1,0 +1,1 @@
+Universitas Negeri Gorontalo


### PR DESCRIPTION
This PR adds the student email subdomain for Universitas Negeri Gorontalo.

Student email addresses are issued under mahasiswa.ung.ac.id, for example:
student@mahasiswa.ung.ac.id

The main university domain ung.ac.id already exists in the database, but some education verification systems require the exact student email subdomain.