### PR TITLE
Adding domain pucgo.edu.br

### DIFF
--- a/lib/domains/br/edu/pucgo.txt
+++ b/lib/domains/br/edu/pucgo.txt
@@ -1,0 +1,1 @@
+Pontifícia Universidade Católica de Goiás

--- a/lib/domains/br/edu/pucgo.txt
+++ b/lib/domains/br/edu/pucgo.txt
@@ -1,1 +1,2 @@
-Pontifícia Universidade Católica de Goiás
+Pontifícia Universidade Católica de Goias
+Pontifical Catholic University of Goiás


### PR DESCRIPTION
The university has more than one domain.
The domain pucgoias.edu.br is already available. Works for teachers because the teachers mail are on that domain.
However, students have mail on domain pucgo.edu.br.
Please, add this domain in order the students can apply to student pack. 