### PR TITLE
Add svcolleges.txt with college name entries

### DIFF
--- a/lib/domains/in/edu/svcolleges.txt
+++ b/lib/domains/in/edu/svcolleges.txt
@@ -1,0 +1,2 @@
+sv college of engineering
+sv college of engineering


### PR DESCRIPTION
This domain belongs to Sri Venkateswara College of Engineering, Tirupati.

Official website:
https://svcolleges.edu.in/

The institution offers long-term academic programs in engineering and related fields.

Student email addresses are issued under this domain: example: dileep.b@svcolleges.edu.in

Proof attached:

College website link : https://svcolleges.edu.in/

Screenshot of student email / portal showing the domain
<img width="3004" height="810" alt="image" src="https://github.com/user-attachments/assets/81e48400-857d-46a7-81c1-196fcfaeb062" />
<img width="3018" height="1820" alt="image" src="https://github.com/user-attachments/assets/00cea749-bb8f-462c-8955-3249b3f75c7c" />
