### PR TITLE
Add Universidade Jean Piaget de Moçambique (unipiaget.ac.mz)

### DIFF
--- a/lib/domains/mz/ac/unipiaget.txt
+++ b/lib/domains/mz/ac/unipiaget.txt
@@ -1,0 +1,1 @@
+Universidade Jean Piaget de Moçambique


### PR DESCRIPTION
 Adds the academic domain unipiaget.ac.mz for Universidade Jean Piaget de Moçambique.

  - File: lib/domains/mz/ac/unipiaget.txt
  - Follows the nested TLD/SLD structure: mz → ac → unipiaget.txt
  - Official university domain, not on the stoplist

  University website: https://www.unipiaget.ac.mz