### PR TITLE
Add Universitas Terbuka (ut.ac.id)

### DIFF
--- a/lib/domains/id/ac/ut.txt
+++ b/lib/domains/id/ac/ut.txt
@@ -1,0 +1,1 @@
+Universitas Terbuka


### PR DESCRIPTION
Add Universitas Terbuka (Indonesia Open University) to the list of recognized academic institutions under the Indonesian `.ac.id` domain.

Universitas Terbuka is a state-owned open university in Indonesia, established in 1984 by the Indonesian government. It is the country's primary distance learning institution, serving over 300,000 active students across Indonesia and abroad. UT is accredited by the Indonesian government and is a member of the Asian Association of Open Universities (AAOU).
This domain was previously missing from the swot database.