### PR TITLE
 Add Universitas Terbuka (Open University) email domain

### DIFF
--- a/lib/domains/id/ac/ut/ecampus.txt
+++ b/lib/domains/id/ac/ut/ecampus.txt
@@ -1,0 +1,1 @@
+Universitas Terbuka


### PR DESCRIPTION
 Adds the student email domain ecampus.ut.ac.id for Universitas Terbuka, Indonesia.

  Example student email format:
  056096123@ecampus.ut.ac.id

  Additional information:
  - Official university website: https://www.ut.ac.id/
  - The student website portal for conducting lectures : https://myut.ut.ac.id/
  - The FKIP Universitas Terbuka website lists an official ecampus.ut.ac.id email address: https://fkip.ut.ac.id/en/
  - UT MyUT documentation mentions students logging in with nim@ecampus.ut.ac.id:

documentation or pdf for further approval is on this file
[screencapture-myut-ut-ac-id-dashboard-beranda-v2-2026-06-02-16_12_07.pdf](https://github.com/user-attachments/files/28501868/screencapture-myut-ut-ac-id-dashboard-beranda-v2-2026-06-02-16_12_07.pdf)
