### PR TITLE
Add Alexandria University (alexu.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/alexu.txt
+++ b/lib/domains/eg/edu/alexu.txt
@@ -1,0 +1,1 @@
+Alexandria University


### PR DESCRIPTION
Add Alexandria University, Egypt.

Domain: alexu.edu.eg