### PR TITLE
Add Universitas Terbuka (ut.ac.id)

### DIFF
--- a/lib/domains/id/ac/ut.txt
+++ b/lib/domains/id/ac/ut.txt
@@ -1,0 +1,2 @@
+Universitas Terbuka
+Open University


### PR DESCRIPTION
Hello, I would like to add the domain for Universitas Terbuka, Indonesia.

Here are the details to help speed up the verification process:
* **Official Website:** https://www.ut.ac.id/
* **IT-Related Course:** Universitas Terbuka offers a 4-year Bachelor's Degree in Information Systems (Sistem Informasi). Details can be found at the Faculty of Science and Technology website: https://fst.ut.ac.id/
* **Student Email Proof:** The university provides official student emails (`@ecampus.ut.ac.id`) for all enrolled students to access academic portals and Microsoft 365 services.