### PR TITLE
Add student email domain for Tra Vinh University

### DIFF
--- a/lib/domains/edu/tvu.txt
+++ b/lib/domains/edu/tvu.txt
@@ -1,0 +1,1 @@
+Tra Vinh University


### PR DESCRIPTION
University: Tra Vinh University
Website: https://tvu.edu.vn
Student email domain: st.tvu.edu.vn

This domain is used for official student email accounts.