### PR TITLE
Add yangtzeu.edu.cn (Yangtze University)

### DIFF
--- a/lib/domains/cn/edu/yangtzeu.txt
+++ b/lib/domains/cn/edu/yangtzeu.txt
@@ -1,0 +1,1 @@
+yangtzeu.edu.cn


### PR DESCRIPTION
This PR adds the domain yangtzeu.edu.cn for Yangtze University (长江大学), a public higher education institution in China.

Official website: https://english.yangtzeu.edu.cn/
Programs / admission information: https://www.yangtzeu.edu.cn/xxgk/xxjj.htm

Students and staff use institutional email addresses in the format name@yangtzeu.edu.cn.