### PR TITLE
Okayama Shoka University (base domain is osu.ac.jp) Added

### DIFF
--- a/lib/domains/jp/ac/osu/mse.txt
+++ b/lib/domains/jp/ac/osu/mse.txt
@@ -1,0 +1,1 @@
+Okayama Shoka University


### PR DESCRIPTION
Please add Okayama Shoka University domain (@mse/osu/ac/jp)