### PR TITLE
Add Universitas Terbuka (ut.ac.id)

### DIFF
--- a/lib/domains/id/ac/ut.txt
+++ b/lib/domains/id/ac/ut.txt
@@ -1,0 +1,1 @@
+Universitas Terbuka


### PR DESCRIPTION
Add Universitas Terbuka (Universitas Terbuka / Open University Indonesia) to the SWOT database.

Domain: ut.ac.id
Subdomains include: ecampus.ut.ac.id (student LMS), myut.ut.ac.id (SSO portal), mail.ecampus.ut.ac.id

Universitas Terbuka is a public university in Indonesia with accreditation A from BAN-PT.