### PR TITLE
Add Universitas Katolik Santo Thomas (ust.ac.id)

### DIFF
--- a/lib/domains/id/ac/ust.txt
+++ b/lib/domains/id/ac/ust.txt
@@ -1,0 +1,1 @@
+Universitas Katolik Santo Thomas


### PR DESCRIPTION
Institution Name:
Universitas Katolik Santo Thomas

Website:
https://www.ust.ac.id

Domain:
ust.ac.id

The university provides official email addresses for students and staff using this domain.

Evidence:
https://www.ust.ac.id