### PR TITLE
Add Universidad Nacional Federico Villarreal domain

### DIFF
--- a/lib/domains/pe/edu/unfv.txt
+++ b/lib/domains/pe/edu/unfv.txt
@@ -1,0 +1,2 @@
+Universidad Nacional Federico Villarreal
+UNFV


### PR DESCRIPTION
This domain belongs to Universidad Nacional Federico Villarreal (UNFV), a public university in Peru.

Official website:
https://www.unfv.edu.pe/

The university offers several IT-related engineering programs, including:

* Computer Engineering (Ingeniería Informática) (https://web.unfv.edu.pe/facultades/fiei/escuelas/escuela-profesional-de-ingenieria-informatica/perfil-profesional)
* Electronic Engineering (Ingeniería Electrónica) (https://web.unfv.edu.pe/facultades/fiei/escuelas/escuela-profesional-de-ingenieria-electronica/perfil-profesional)
* Telecommunications Engineering (Ingeniería de Telecomunicaciones) (https://web.unfv.edu.pe/facultades/fiei/escuelas/escuela-profesional-de-ingenieria-de-telecomunicaciones/perfil-profesional)

Faculty website:
https://www.unfv.edu.pe/fiei

Official university website:
https://www.unfv.edu.pe/

The university provides institutional email accounts under the unfv.edu.pe domain to its enrolled students and academic staff.

Thank you.