### PR TITLE
Add Universidad de Pamplona (unipamplona.edu.co)

### DIFF
--- a/lib/domains/co/edu/unipamplona.txt
+++ b/lib/domains/co/edu/unipamplona.txt
@@ -1,0 +1,1 @@
+Universidad de Pamplona


### PR DESCRIPTION
Official domain of Universidad de Pamplona, Colombia.

Website:
https://www.unipamplona.edu.co