### PR TITLE
Add Lyallpur Khalsa College of Engineering (lkcengg.edu.in)

### DIFF
--- a/lib/domains/in/edu/lkcengg.txt
+++ b/lib/domains/in/edu/lkcengg.txt
@@ -1,0 +1,1 @@
+Lyallpur Khalsa College of Engineering


### PR DESCRIPTION
Adding domain `lkcengg.edu.in` for **Lyallpur Khalsa College of Engineering**, Jalandhar, Punjab, India.

- Official website: https://lkctc.edu.in
- The college offers long-term IT-related courses (B.Tech in Computer Science, Information Technology, etc.)
- Domain `lkcengg.edu.in` is used as the official student email domain