### PR TITLE
Add cju.ac.kr university domain

### DIFF
--- a/lib/domains/kr/ac/cju.txt
+++ b/lib/domains/kr/ac/cju.txt
@@ -1,0 +1,1 @@
+Cheongju University


### PR DESCRIPTION
Please add Cheongju University domain for JetBrains student license.