### PR TITLE
Add students subdomain for HTL Leonding

### DIFF
--- a/lib/domains/at/ac/htl-leonding/students.txt
+++ b/lib/domains/at/ac/htl-leonding/students.txt
@@ -1,0 +1,1 @@
+Höhere Technische Bundeslehranstalt Leonding (Students)


### PR DESCRIPTION
This PR adds the explicit 'students' subdomain for HTBLA Leonding in Austria. 
The main school domain (htl-leonding.ac.at) is already in the database, but student email addresses are issued under '@students.htl-leonding.ac.at'. Adding this ensures third-party tools syncing with this database can properly verify student accounts.