### PR TITLE
Add Universitas Terbuka (ut.ac.id)

### DIFF
--- a/lib/domains/id/ac/ut.txt
+++ b/lib/domains/id/ac/ut.txt
@@ -1,0 +1,1 @@
+Universitas Terbuka


### PR DESCRIPTION
Adds Universitas Terbuka (Open University Indonesia) to the list of supported educational institutions.\n\nDomain: ut.ac.id