### PR TITLE
Add Joseph Ayo Babalola University (jabu.edu.ng)

### DIFF
--- a/lib/domains/ng/edu/jabu.txt
+++ b/lib/domains/ng/edu/jabu.txt
@@ -1,0 +1,1 @@
+Joseph Ayo Babalola University


### PR DESCRIPTION
## Summary

Adds **Joseph Ayo Babalola University (JABU)** to the academic domain list.

- **Domain:** `jabu.edu.ng` (with subdomains like `students.jabu.edu.ng`)
- **Location:** Ikeji-Arakeji, Osun State, Nigeria
- **Type:** Private university

This allows students and staff with `@students.jabu.edu.ng` and `@jabu.edu.ng` email addresses to be recognized for academic discounts.

## Test plan

- [x] File placed at `lib/domains/ng/edu/jabu.txt`
- [x] Content is the official university name: "Joseph Ayo Babalola University"
- [ ] CI should pass (text file follows the existing format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)