### PR TITLE
Add Institute of Technology of Cambodia (itc.edu.kh)

### DIFF
--- a/lib/domains/kh/edu/itc.txt
+++ b/lib/domains/kh/edu/itc.txt
@@ -1,0 +1,1 @@
+Institute of Technology of Cambodia


### PR DESCRIPTION
Adding domain itc.edu.kh for Institute of Technology of Cambodia, Phnom Penh, Cambodia.

- Official website: https://itc.edu.kh/
- The institute offers long-term IT-related programs (Engineering, Computer Science, Information Technology, etc.)
- Domain itc.edu.kh is used as the official student email domain for ITC Cambodia