### PR TITLE
Add nbc.edu.np

### DIFF
--- a/lib/domains/np/edu/nbc.txt
+++ b/lib/domains/np/edu/nbc.txt
@@ -1,0 +1,1 @@
+Nepal Business College


### PR DESCRIPTION
### Nepal Business College uses the domain nbc.edu.np.

Official website:
https://nbc.edu.np/

Nepal Business College is a higher education institution in Nepal offering programs including BBA, BIT, BHM, and MBA.

Students are issued email addresses under the nbc.edu.np domain.
