### PR TITLE
Add Sejong University information in sju.txt

### DIFF
--- a/lib/domains/kr/ac/sju.txt
+++ b/lib/domains/kr/ac/sju.txt
@@ -1,0 +1,2 @@
+Sejong University
+세종대학교


### PR DESCRIPTION
Adding sju.ac.kr domain for Sejong University. Official site: https://www.sejong.ac.kr — students receive email addresses @sju.ac.kr