### PR TITLE
Add PUCMM domain (ce.pucmm.edu.do) - Dominican Republic

### DIFF
--- a/lib/domains/do/edu/pucmm.txt
+++ b/lib/domains/do/edu/pucmm.txt
@@ -1,0 +1,2 @@
+Pontificia Universidad Católica Madre y Maestra
+PUCMM

--- a/lib/domains/do/edu/pucmm.txt
+++ b/lib/domains/do/edu/pucmm.txt
@@ -1,2 +1,0 @@
-Pontificia Universidad Católica Madre y Maestra
-PUCMM

--- a/lib/domains/do/edu/pucmm/ce.txt
+++ b/lib/domains/do/edu/pucmm/ce.txt
@@ -1,0 +1,2 @@
+Pontificia Universidad Católica Madre y Maestra
+PUCMM


### PR DESCRIPTION
Adding domain ce.pucmm.edu.do for PUCMM (Pontificia Universidad Católica Madre y Maestra), Dominican Republic.

- University website: https://www.pucmm.edu.do
- IT-related courses: https://tep.pucmm.edu.do/carreras-tecnico-superior
- ce.pucmm.edu.do is the official student email domain