### PR TITLE
Add University of Gondar (uog.edu.et) and remove from abused.txt

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1694,7 +1694,6 @@ baraodemaua.edu.br
 bennett.edu.in
 uot.edu.ly
 onlineedu.tu-varna.bg
-uog.edu.et
 udes.edu.co
 uaq.mx
 gu.edu.ly

--- a/lib/domains/et/edu/uog.txt
+++ b/lib/domains/et/edu/uog.txt
@@ -1,0 +1,1 @@
+University of Gondar


### PR DESCRIPTION
This PR adds the official domain for the University of Gondar (uog.edu.et) in Ethiopia and removes it from the abused list. I am requesting a manual review as this is a legitimate public higher education institution. Official website: https://www.uog.edu.et/