### PR TITLE
Add Rmuti (Thailand Nakhonratchasima)

### DIFF
--- a/lib/domains/th/ac/rmuti/mail.txt
+++ b/lib/domains/th/ac/rmuti/mail.txt
@@ -1,0 +1,2 @@
+มหาวิทยาลัยเทคโนโลยีราชมงคลอีสาน
+Rajamangala University of Technology Isan


### PR DESCRIPTION
Add Rmuti (Thailand Nakhonratchasima)
มหาวิทยาลัยเทคโนโลยีราชมงคลอีสาน
Rajamangala University of Technology Isan
