### PR TITLE
Add Anadolu University Open Education Faculty (aof.anadolu.edu.tr)

### DIFF
--- a/lib/domains/tr/edu/anadolu/aof.txt
+++ b/lib/domains/tr/edu/anadolu/aof.txt
@@ -1,0 +1,2 @@
+Anadolu Universitesi Acikogretim Fakultesi
+Anadolu University Open Education Faculty


### PR DESCRIPTION
Added the subdomain for Open Education Faculty students in Turkey.