### PR TITLE
Add Henan Institute of Technology domain

### DIFF
--- a/lib/domains/cn/edu/hait.txt
+++ b/lib/domains/cn/edu/hait.txt
@@ -1,0 +1,2 @@
+河南工学院
+Henan Institute of Technology

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -424,7 +424,6 @@ gzhtcm.edu.cn
 gzhu.edu.cn
 h.edu.kg
 hainu.edu.cn
-hait.edu.cn
 halcones.ual.mx
 hallgato.uni-szie.hu
 hanma.kr


### PR DESCRIPTION
This PR adds support for `hait.edu.cn`, the official domain of 河南工学院 / Henan Institute of Technology.

  Changes:
  - Add `lib/domains/cn/edu/hait.txt`
  - Remove `hait.edu.cn` from `lib/domains/stoplist.txt`

  Evidence:
  - Official website: https://www.hait.edu.cn/
  - The official website links to the mail system at `mail.hait.edu.cn`
  - The university has IT-related long-term education through its School of Computer Science and Technology: https://cs.hait.edu.cn/

  Institution names:
  - 河南工学院
  - Henan Institute of Technology

  Note:
  `hait.edu.cn` was previously listed in `stoplist.txt`, so this PR also requests a review of that stoplist entry.