### PR TITLE
Add Işık University (isik.edu.tr)

### DIFF
--- a/lib/domains/tr/edu/isik.txt
+++ b/lib/domains/tr/edu/isik.txt
@@ -1,0 +1,2 @@
+Işık Üniversitesi
+Işık University


### PR DESCRIPTION
Adds the domain `isik.edu.tr` for **Işık University** (Işık Üniversitesi), a degree-granting foundation (non-profit) university in Istanbul, Turkey — https://www.isik.edu.tr.

The university previously used `isikun.edu.tr` (already in swot at `lib/domains/tr/edu/isikun.txt`) and now issues student/staff email under `isik.edu.tr`, which was not yet covered. This adds `lib/domains/tr/edu/isik.txt` with the same school names as the existing legacy entry:

```
Işık Üniversitesi
Işık University
```

Checked before submitting:
- `isik.edu.tr` is **not** on the stoplist/abuse list.
- `edu.tr` is **not** a blanket-academic TLD, so an explicit entry is required.
- No alumni/student-only subdomain (this is the primary institutional domain).