### PR TITLE
Create lec.txt

### DIFF
--- a/lib/domains/np/edu/lec.txt
+++ b/lib/domains/np/edu/lec.txt
@@ -1,0 +1,2 @@
+Lalitpur Engineering College
+Lalitpur Engineering College


### PR DESCRIPTION
Adds the official domain `lec.edu.np` for Lalitpur Engineering College (LEC), Nepal.

Official website: https://lec.edu.np/

IT-related course proof:
https://lec.edu.np/about-us

The official website lists Bachelor-level programs including Bachelors in Computer Engineering and Bachelors in Computer Application.

Domain proof:
The official website uses the `lec.edu.np` domain and lists official contact emails under `@lec.edu.np`, such as `info@lec.edu.np`.

File added:
`lib/domains/np/edu/lec.txt`

Content:
`Lalitpur Engineering College`