### PR TITLE
Add University of Jos (unijos.edu.ng)

### DIFF
--- a/lib/domains/ng/edu/unijos.txt
+++ b/lib/domains/ng/edu/unijos.txt
@@ -1,0 +1,1 @@
+University of Jos


### PR DESCRIPTION
Adds the domain for University of Jos in Nigeria.