### PR TITLE
Add Bangladesh University of Professionals (student.bup.edu.bd)

### DIFF
--- a/lib/domains/bd/edu/bup/student.txt
+++ b/lib/domains/bd/edu/bup/student.txt
@@ -1,0 +1,1 @@
+Bangladesh University of Professionals


### PR DESCRIPTION
Adds Bangladesh University of Professionals (BUP), a public university in Dhaka, Bangladesh.

- **File added:** `lib/domains/bd/edu/bup/student.txt`
- **Domain:** student.bup.edu.bd

Students at BUP receive their email accounts exclusively on the
`student.bup.edu.bd` subdomain, so this PR adds that subdomain specifically
rather than the top-level `bup.edu.bd`.

### Verification details

1. **Official website:** https://bup.edu.bd

2. **Long-term (>1 year) IT-related programs** (Faculty of Science and Technology):
   - Department of Computer Science & Engineering (CSE): https://bup.edu.bd/department_home/8
   - Department of Information & Communication Technology (ICT): https://bup.edu.bd/department_home/3

3. **Proof the domain is an official student email domain:**
   - BUP issues student email accounts on the `student.bup.edu.bd` domain via Microsoft 365 (screenshot below).
   - ![M365 student mail proof](https://github.com/user-attachments/assets/783bc8f8-4fa7-4036-8764-faa1a7e54872)