### PR TITLE
Add futa.edu.ng for Federal University of Technology Akure

### DIFF
--- a/lib/domains/ng/edu/futa.txt
+++ b/lib/domains/ng/edu/futa.txt
@@ -1,0 +1,1 @@
+Federal University of Technology, Akure


### PR DESCRIPTION
Submitted domain: futa.edu.ng
School: Federal University of Technology Akure (FUTA)
Official website: https://www.futa.edu.ng/
IT-related long-term course reference: https://soc.futa.edu.ng/home/2281
Added file: lib/domains/ng/edu/futa.txt
