### PR TITLE
Add apple.edu.pl and warsawuni.edu.pl

### DIFF
--- a/lib/domains/pl/edu/apple.txt
+++ b/lib/domains/pl/edu/apple.txt
@@ -1,0 +1,1 @@
+Apple Education Poland

--- a/lib/domains/pl/edu/warsawuni.txt
+++ b/lib/domains/pl/edu/warsawuni.txt
@@ -1,0 +1,1 @@
+Warsaw University


### PR DESCRIPTION
Adding domains for Apple Education Poland and Warsaw University