### PR TITLE
Add Samara University of Ethiopia 

### DIFF
--- a/lib/domains/et/edu/su.txt
+++ b/lib/domains/et/edu/su.txt
@@ -1,0 +1,1 @@
+Samara University of Ethiopia (SU).


### PR DESCRIPTION
Please add Samara University (Ethiopia) to the database. 
Official domain: su.edu.et
Official website: http://www.su.edu.et