### PR TITLE
Add National Institute of Technology, Ibaraki College

### DIFF
--- a/lib/domains/jp/ac/ibaraki-ct/gm.txt
+++ b/lib/domains/jp/ac/ibaraki-ct/gm.txt
@@ -1,0 +1,2 @@
+茨城工業高等専門学校
+National Institute of Technology, Ibaraki College


### PR DESCRIPTION
## Summary

This PR adds the official student email domain for National Institute of Technology, Ibaraki College.

## Domain

`gm.ibaraki-ct.ac.jp`

## School name

茨城工業高等専門学校  
National Institute of Technology, Ibaraki College

## Proof

Official website:  
https://www.ibaraki-ct.ac.jp/

Example page on the official school website showing an email address using this domain:  
https://www.ibaraki-ct.ac.jp/info/archives/19170

## Notes

The email domain is used for student accounts at National Institute of Technology, Ibaraki College.