### PR TITLE
Add Loyola Institute of Technology domain

### DIFF
--- a/lib/domains/in/edu/lit.txt
+++ b/lib/domains/in/edu/lit.txt
@@ -1,0 +1,1 @@
+Loyola Institute of Technology


### PR DESCRIPTION
Adds the official email domain for Loyola Institute of Technology, Chennai, India.

Domain: lit.edu.in
File: lib/domains/in/edu/lit.txt

Verification details requested by the repository rules:
- Official website: https://www.lit.edu.in/
- Official contact/domain proof: https://www.lit.edu.in/contact-1/ lists the college address in Chennai - 600123, email principal@lit.edu.in, and website www.lit.edu.in.
- Long-term IT-related courses: https://www.lit.edu.in/ lists B.E. Computer Science and Engineering, B.Tech Information Technology, B.E. Computer Science Engineering (Cyber Security), and B.Tech Artificial Intelligence & Data Science.