### PR TITLE
Add National Open University of Nigeria

### DIFF
--- a/lib/domains/ng/edu/noun.txt
+++ b/lib/domains/ng/edu/noun.txt
@@ -1,0 +1,1 @@
+National Open University of Nigeria


### PR DESCRIPTION
Official Url - nou.edu.ng

IT Programmes - https://foc.nou.edu.ng/

Proof of email domain recognition - https://nou.edu.ng/faqs/ #scroll down to 'i can no longer access my email' 
Although the official institution's domain is 'nou.edu.ng', the email domain extension is '@noun.edu.ng'.