### PR TITLE
Add Kagawa NCT domain

### DIFF
--- a/lib/domains/jp/ac/kagawa-nct.txt
+++ b/lib/domains/jp/ac/kagawa-nct.txt
@@ -1,0 +1,2 @@
+香川高等専門学校
+National Institute of Technology, Kagawa College


### PR DESCRIPTION
## Summary

Add National Institute of Technology, Kagawa College (Kagawa KOSEN) to the Japanese academic domain list.

The school's official website uses `kagawa-nct.ac.jp`, and its public contact page lists institutional email addresses under `t.kagawa-nct.ac.jp`. Adding the parent domain covers those school email subdomains according to SWOT's existing domain matching behavior.

## Proof

- Official English page: https://www.kagawa-nct.ac.jp/english/about/message.html
- Official site policy showing the school domain: https://www.kagawa-nct.ac.jp/site_policy/policy_index.html
- Official contact page showing institutional email subdomain usage: https://www.kagawa-nct.ac.jp/contact/

## Validation

- `./gradlew test`
