### PR TITLE
Add aof.anadolu.edu.tr for Anadolu University Open Education Faculty

### DIFF
--- a/lib/domains/tr/edu/anadolu/aof.txt
+++ b/lib/domains/tr/edu/anadolu/aof.txt
@@ -1,0 +1,2 @@
+Anadolu University Open Education Faculty
+Anadolu Üniversitesi Açıköğretim Fakültesi


### PR DESCRIPTION
Domain: aof.anadolu.edu.tr

This domain is used for active students of Anadolu University Open Education Faculty (AÖF).

Students receive institutional email addresses under this domain and use them for educational services and student accounts.

Official institution:
https://www.anadolu.edu.tr/