### PR TITLE
Add Islamic Azad University to iau.txt

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
Description
Please add the domain iau.ir for Islamic Azad University to the SWOT repository so students can access academic discounts.

University Details
-Official Name: دانشگاه آزاد اسلامی (Islamic Azad University)
-Official Website: https://iau.ac.ir/
-Domain to Add: iau.ir
-File Path in Repository: lib/domains/ir/iau.txt

Proof of Eligibility
-As required by the JetBrains guidelines, here is the proof that this is an accredited institution offering degrees lasting longer than 1 year:
-Official Programs Page: https://iau.ac.ir/ (The main portal details the university's massive network of undergraduate and postgraduate degree programs across Iran).
-Academic Verification: Islamic Azad University is one of the largest comprehensive higher education systems in the region, offering fully accredited 2-year (Associate), 4-year (Bachelor's), and postgraduate (Master's/Ph.D.) degrees.