### PR TITLE
Add University of Tsukuba domain

### DIFF
--- a/lib/domains/jp/ac/tsukuba/u.txt
+++ b/lib/domains/jp/ac/tsukuba/u.txt
@@ -1,0 +1,2 @@
+University of Tsukuba
+筑波大学


### PR DESCRIPTION
### Description

Add the official student email domain for the University of Tsukuba.

### Domain

- u.tsukuba.ac.jp

### Evidence

- https://www.u.tsukuba.ac.jp/
- https://www.u.tsukuba.ac.jp/contact/
- https://www.u.tsukuba.ac.jp/email/

The `@u.tsukuba.ac.jp` domain is the official email domain assigned to students of the University of Tsukuba.