### PR TITLE
Add Islamic Azad University domain

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University


### PR DESCRIPTION
Adds the student email domain "iau.ir" for Islamic Azad University.

Official website: https://iau.ir/en  
LinkedIn: https://linkedin.com/school/islamic-azad-university/
