### PR TITLE
Add Sharif University of Technology

### DIFF
--- a/lib/domains/edu/sharif.txt
+++ b/lib/domains/edu/sharif.txt
@@ -1,0 +1,2 @@
+دانشگاه صنعتی شریف
+Sharif University of Technology


### PR DESCRIPTION
This PR adds the official student email domain for Sharif University of Technology.

Domain: sharif.edu
Institution: Sharif University of Technology / دانشگاه صنعتی شریف

Official university website:
https://www.sharif.edu/
https://en.sharif.edu/

Long-term IT-related program proof:
https://en.sharif.ir/en/programs
This official programs page lists the Department of Computer Engineering with B.Sc., M.Sc., and PhD degrees.

Additional long-term IT-related course proof:
https://en.sharif.ir/en/web/sharif-en/w/undergraduate-computer-engineering
This official page lists the Computer Science undergraduate program with a length of 4 years / 8 semesters.

Official email-domain proof:
https://edu.sharif.edu/login.do
The official Sharif Educational System page asks users to enter their Sharif email for educational notifications.

Additional email proof:
https://webmail.sharif.edu/
Official Sharif webmail service.

I can also provide a screenshot from my Sharif educational/student portal showing that my student email uses the @sharif.edu domain if needed.