### PR TITLE
Add iau.ac.ir domain

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,2 @@
+Islamic Azad University
+.group


### PR DESCRIPTION
Added the general domain for all IAU branches.

iau.ac.ir is an alias for the iau.ir email addresses addressed in the following pull request: https://github.com/JetBrains/swot/pull/40340