### PR TITLE
Add iau.ir for Islamic Azad University

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University

--- a/lib/domains/ir/ac/sbu.txt
+++ b/lib/domains/ir/ac/sbu.txt
@@ -1,1 +1,0 @@
-Shahid Beheshti University

--- a/lib/domains/ir/ac/sbu.txt
+++ b/lib/domains/ir/ac/sbu.txt
@@ -1,0 +1,1 @@
+Shahid Beheshti University


### PR DESCRIPTION
This pull request adds the official student email domain for Islamic Azad University in Iran.

Students are issued official email addresses in the format:

[[student_id@iau.ir](mailto:student_id@iau.ir)](mailto:student_id@iau.ir)

Official university website:
https://iau.ir/

The @iau.ir domain is currently used for official student accounts and university services.