### PR TITLE
Add Islamic Azad University (iau.ir)

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University


### PR DESCRIPTION
Adding domain iau.ir for Islamic Azad University (all branches).

- Official website: https://iau.ir/
- Student email domain: @iau.ir (confirmed via official webmail and accounts system)
- Proof of official student email: https://mail.iau.ac.ir/ and https://accounts.iau.ir/
- Long-term IT programs: Computer Engineering / Software Engineering offered at multiple branches (e.g. Tehran, Tabriz, etc.)

This domain is used by students across all Islamic Azad University branches.