### PR TITLE
Add Shahid Beheshti University student email domain

### DIFF
--- a/lib/domains/ir/ac/sbu.txt
+++ b/lib/domains/ir/ac/sbu.txt
@@ -1,0 +1,1 @@
+Shahid Beheshti University

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -628,7 +628,6 @@ mail.nwpu.edu.cn
 mail.rit.edu
 mail.rmutt.ac.th
 mail.rru.ac.th
-mail.sbu.ac.ir
 mail.scuec.edu.cn
 mail.sustc.edu.cn
 mail.thitcholuoc.edu.vn
@@ -854,7 +853,6 @@ santamariasaude.edu.pt
 santceloni.lasalle.cat
 sau16.org
 sbjacksonville.com
-sbu.ac.ir
 school3.mk.ua
 scnu.edu.cn
 scpc.edu.in


### PR DESCRIPTION
This pull request adds the official student email domain for Shahid Beheshti University.

Domain:
mail.sbu.ac.ir

Institution:
Shahid Beheshti University

Official university website:
https://www.sbu.ac.ir/
https://en.sbu.ac.ir/

Official university ICT page confirming the student email domain:
https://ictc.sbu.ac.ir/email

The official SBU ICT page states that undergraduate and master's students receive their Beheshti email accounts through webmail.sbu.ac.ir under the mail.sbu.ac.ir domain.

I noticed that mail.sbu.ac.ir is currently listed in lib/domains/stoplist.txt, so this PR removes only mail.sbu.ac.ir from the stoplist and adds it as a verified student email domain.

I am not requesting to add the upper-level sbu.ac.ir domain. This PR only targets mail.sbu.ac.ir, which is officially documented for undergraduate and master's students.

Evidence:
- Shahid Beheshti University official website
- Official SBU ICT email page
- Official student email domain: mail.sbu.ac.ir