### PR TITLE
Add Islamic Azad University (iau.ir)

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
Institution Information:
Name: Islamic Azad University
Domain: iau.ir
Official Website: https://iau.ir/en
Wikipedia: https://en.wikipedia.org/wiki/Islamic_Azad_University

While the university uses `account.iau.ac.ir` as its central authentication login portal, the actual student email addresses are provisioned under the bare `@iau.ir` domain suffix. 
<img width="589" height="162" alt="image" src="https://github.com/user-attachments/assets/39892af0-4e72-449e-b107-6484366d9385" />
