### PR TITLE
Add Institute for Cognitive Science Studies domain (icss.ac.ir)

### DIFF
--- a/lib/domains/ac/ir/icss.txt
+++ b/lib/domains/ac/ir/icss.txt
@@ -1,0 +1,1 @@
+Institute for Cognitive Science Studies

--- a/lib/domains/ir/icss.txt
+++ b/lib/domains/ir/icss.txt
@@ -1,0 +1,1 @@
+Institute for Cognitive Science Studies


### PR DESCRIPTION
Adds support for icss.ac.ir domain for Institute for Cognitive Science Studies.

Example email domain: student@icss.ac.ir