### PR TITLE
add HUT to ir

### DIFF
--- a/lib/domains/ir/ac/hut.txt
+++ b/lib/domains/ir/ac/hut.txt
@@ -1,0 +1,1 @@
+Hamedan University of Technology


### PR DESCRIPTION
Hi, 

Added hut.ac.ir domain to this. This domain belongs to Hamedan University of Technology. 

Thanks
