### PR TITLE
Add Marie Cederschiöld University (mchs.se)

### DIFF
--- a/lib/domains/se/mchs.txt
+++ b/lib/domains/se/mchs.txt
@@ -1,0 +1,1 @@
+Marie Cederschiöld University


### PR DESCRIPTION
School official website: https://www.mchs.se
Domain mchs.se is the official email domain for staff and students.
Proof: https://www.mchs.se/engelska/marie-cederschiold-university/internationalisation.html