### PR TITLE
Add Quantum Horizon Bishkek Digital University (qhbd.edu.kg)

### DIFF
--- a/lib/domains/kg/edu/qhbd.txt
+++ b/lib/domains/kg/edu/qhbd.txt
@@ -1,0 +1,1 @@
+Quantum Horizon Bishkek Digital University


### PR DESCRIPTION
## New academic domain

- **Domain:** `qhbd.edu.kg`
- **Institution:** Quantum Horizon Bishkek Digital University
- **Country:** Kyrgyzstan 🇰🇬
- **File:** `lib/domains/kg/edu/qhbd.txt`

The domain `qhbd.edu.kg` is the official student/staff email domain for Quantum Horizon Bishkek Digital University (量子地平线比什凯克数字大学), located in Bishkek, Kyrgyzstan.