### PR TITLE
Add Islamic Azad University

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University


### PR DESCRIPTION
Add Islamic Azad University domain (iau.ir)
University official main website: [https://iau.ir/en](https://iau.ir/en)
Please take a look at the document mentioned in [this](https://github.com/JetBrains/swot/pull/40330#issuecomment-4822220928) issue which addresses the compliance of adding `iau.ir` domain with applicable sanctions and regulations.
