### PR TITLE
add iust.ac.ir

### DIFF
--- a/lib/domains/ir/ac/iust.txt
+++ b/lib/domains/ir/ac/iust.txt
@@ -1,0 +1,2 @@
+دانشگاه علم و صنعت ایران
+Iran University of Science and Technology

--- a/lib/domains/ir/ac/iust.txt
+++ b/lib/domains/ir/ac/iust.txt
@@ -1,2 +1,1 @@
-دانشگاه علم و صنعت ایران
 Iran University of Science and Technology


### PR DESCRIPTION
- Official website: https://www.iust.ac.ir
- CS department (long-term IT course): https://ce.iust.ac.ir
- Student email domain proof: comp.iust.ac.ir is the official email domain for CS students at Iran University of Science and Technology