### PR TITLE
Add Islamic Azad University (iau.ir)

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University


### PR DESCRIPTION
## Summary
- Add `iau.ir` for Islamic Azad University (دانشگاه آزاد اسلامی)
- File: `lib/domains/ir/iau.txt`

## Verification
- Official website: https://www.iau.ir
- The university offers IT-related programs including computer science and software engineering across its branches
- `iau.ir` is the official email domain used by Islamic Azad University students and staff

## Test plan
- [x] Created `lib/domains/ir/iau.txt` with the official university name
- [x] Domain is not listed in `lib/domains/abused.txt`
- [ ] JetBrains team to verify domain eligibility during review
