### PR TITLE
Add Sharif University of Technology (sharif.edu)

### DIFF
--- a/lib/domains/edu/sharif.txt
+++ b/lib/domains/edu/sharif.txt
@@ -1,0 +1,1 @@
+Sharif University of Technology


### PR DESCRIPTION
Adds `sharif.edu` for **Sharif University of Technology**, a public research university in Tehran, Iran.

- **Official website:** https://www.sharif.edu/
- **Email domain:** Student and staff emails use `sharif.edu` and its subdomains (e.g. `student.sharif.edu`, `ee.sharif.edu`).
- **IT-related courses (>1 year):** Department of Computer Engineering — https://ce.sharif.edu/

This domain is the official student email domain recognized by the university.