### PR TITLE
Add comp.iust.ac.ir domain

### DIFF
--- a/lib/domains/ir/ac/iust/comp.txt
+++ b/lib/domains/ir/ac/iust/comp.txt
@@ -1,0 +1,2 @@
+Iran University of Science and Technology
+IUST


### PR DESCRIPTION
Please add the computer engineering subdomain for Iran University of Science and Technology: @comp.iust.ac.ir