### PR TITLE
Add Herat University - hu.edu.af

### DIFF
--- a/lib/domains/af/edu/hu.txt
+++ b/lib/domains/af/edu/hu.txt
@@ -1,0 +1,1 @@
+Herat University


### PR DESCRIPTION
Adding Herat University, Afghanistan.
Domain: hu.edu.af
Website: https://hu.edu.af