### PR TITLE
Add Alzahra University to the list

### DIFF
--- a/lib/domains/ir/ac/alzahra.txt
+++ b/lib/domains/ir/ac/alzahra.txt
@@ -1,0 +1,1 @@
+Alzahra University


### PR DESCRIPTION
Adds alzahra.ac.ir for Alzahra University, a public university in Iran.

Official website: https://alzahra.ac.ir/
Email domain: Student and staff emails use alzahra.ac.ir
IT-related courses (>1 year): Department of Computer Engineering — https://alzahra.ac.ir/ (page showing the program/courses).
This domain is the official student email domain recognized by the university.