### PR TITLE
Add Islamic Azad University domains

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,2 @@
+Islamic Azad University
+.group

--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+Islamic Azad University
+.group


### PR DESCRIPTION
This PR adds the official email domains for Islamic Azad University.

Domains:
- iau.ac.ir
- iau.ir

Official website:
https://iau.ir/fa

IT-related long-term course:
https://tonekabon.iau.ir/fa/department/13/%DA%AF%D8%B1%D9%88%D9%87-%D9%85%D9%87%D9%86%D8%AF%D8%B3%DB%8C-%D8%A8%D8%B1%D9%82-%D9%88-%DA%A9%D8%A7%D9%85%D9%BE%DB%8C%D9%88%D8%AA%D8%B1

Email login:
https://mail.iau.ac.ir

Support url:
https://mailhelp.iau.ac.ir/

Notes:
Islamic Azad University has multiple branches across Iran. The student email addresses can use @iau.ac.ir and @iau.ir. The mail login is available at mail.iau.ac.ir.


<img width="1920" height="1040" alt="iau2" src="https://github.com/user-attachments/assets/ece33d2b-360b-4cc3-976b-dd1fba49636f" />

<img width="1920" height="1040" alt="iau" src="https://github.com/user-attachments/assets/043a8e40-9c34-482f-81e7-c97d839be3de" />

