### PR TITLE
Update Jiangsu Ocean University domain entry

### DIFF
--- a/lib/domains/cn/edu/jou.txt
+++ b/lib/domains/cn/edu/jou.txt
@@ -1,2 +1,2 @@
-Jiangsu Ocean University
 江苏海洋大学
+Jiangsu Ocean University


### PR DESCRIPTION
This updates the existing `jou.edu.cn` entry for Jiangsu Ocean University so that the native-language name appears first, matching the repository guidance that recommends using the official/native name on the first line and other known names on following lines.

Context: downstream student verification services that rely on this database are currently not recognizing `jou.edu.cn` even though the domain has existed in swot since 2021. This small update keeps the same accepted domain while refreshing the entry in a standards-compliant way.

Domain: `jou.edu.cn`
Institution: 江苏海洋大学 / Jiangsu Ocean University
Official website: https://www.jou.edu.cn/
Existing entry path: `lib/domains/cn/edu/jou.txt`

Thank you!