### PR TITLE
Add iau.ac.ir (Islamic Azad University)

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
Adding main domain `iau.ac.ir` for Islamic Azad University.

This is one of the largest universities in Iran with hundreds of thousands of students across many branches.

Official website: https://iau.ir/
Email system: https://mail.iau.ac.ir/

The university offers long-term IT and Computer Science programs.

Please let me know if any additional information or proof is needed.