### PR TITLE
Add Shahid Beheshti University (sbu.ac.ir)

### DIFF
--- a/lib/domains/ir/ac/sbu.txt
+++ b/lib/domains/ir/ac/sbu.txt
@@ -1,2 +1,2 @@
 Shahid Beheshti University
-دانشگاه شهید بهشتی
+

--- a/lib/domains/ir/ac/sbu.txt
+++ b/lib/domains/ir/ac/sbu.txt
@@ -1,0 +1,2 @@
+Shahid Beheshti University
+دانشگاه شهید بهشتی


### PR DESCRIPTION
This pull request adds the official domain for Shahid Beheshti University.

The university uses the sbu.ac.ir domain for official services, and students are assigned email addresses under this domain (e.g. @mail.sbu.ac.ir).