### PR TITLE
Remove Dalian University of Technology from the stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -303,7 +303,6 @@ davidson.k12.nc.us
 dent.tanta.edu.eg
 dilatatfmus.ru
 dkps.uniburgas.bg
-dlut.edu.cn
 dmu.edu.et
 doc.frt.utn.edu.ar
 dongeui.ms.kr


### PR DESCRIPTION
The university official website is: https://www.dlut.edu.cn/
Well the English website is: https://en.dlut.edu.cn/
And here's a URL of a page on the official website where a long-term (>1 year) IT related course: https://ss.dlut.edu.cn/info/1281/7121.htm
A URL of a page showing that the university recognizes the domain which you are submitting as an official email domain: https://its.dlut.edu.cn/index/jsfw/fwzn/dzyxfw/yxfwsm.htm

Apologies. Although I noticed that our school is listed in lib/domains/stoplist.txt, the materials I provided do confirm that our school exists and has a certain level of teaching quality. I believe one or two email addresses from our school may have been leaked, but this has indeed caused considerable trouble and confusion for our students. Would it be possible to re-evaluate our school's eligibility? I would be most grateful.