### PR TITLE
Add Universidad Latina de Costa Rica domain

### DIFF
--- a/lib/domains/net/ulatina.txt
+++ b/lib/domains/net/ulatina.txt
@@ -1,0 +1,1 @@
+Universidad Latina de Costa Rica


### PR DESCRIPTION
Adding the ulatina.net domain for the Universidad Latina de Costa Rica to the university database.