### PR TITLE
Add digital4business.eu (Digital4Business Master's programme)

### DIFF
--- a/lib/domains/eu/digital4business.txt
+++ b/lib/domains/eu/digital4business.txt
@@ -1,0 +1,2 @@
+Digital4Business
+Joint Professional Master's Degree in Advanced Digital Technologies for Business


### PR DESCRIPTION
This PR adds the email domain `digital4business.eu` for Digital4Business.

- Institution: Digital4Business — Joint Professional Master's Degree in Advanced Digital Technologies for Business
- Type: Internationally accredited, fully online Master's programme in advanced digital technologies (IT / computer science related), with a curriculum longer than one year.
- Delivered by: a consortium of four European Higher Education Institutions (Linköping University, NOVA IMS, National College of Ireland, and University of Bologna).
- Student email: students receive a dedicated `@digital4business.eu` address for the duration of their studies.

File added: `lib/domains/eu/digital4business.txt` containing the institution name.

Website: https://digital4business.eu

