### PR TITLE
Add iau.ir for Islamic Azad University

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
Hi,

This PR adds `iau.ir`, which is the main and official domain of Islamic Azad University (IAU) in Iran. 

Currently, only subdomains/specific branches are listed, but the university has migrated its centralized student and staff email systems directly to the primary `iau.ir` domain. Adding this file will allow students using the official centralized email system to be verified.

Official Website: https://iau.ir

Thank you!