### PR TITLE
Add official student email domain for eyc.ac.ir

### DIFF
--- a/lib/domains/ir/ac/eyc.txt
+++ b/lib/domains/ir/ac/eyc.txt
@@ -1,0 +1,4 @@
+University of Eyvanekey
+دانشگاه ایوان کی
+https://www.eyc.ac.ir/intro-en.html
+https://mail.eyc.ac.ir/auth/login


### PR DESCRIPTION
I am adding the official student email domain of my educational institution to the database.

Domain added:
eyc.ac.ir

Additional information:

Official website: https://eyc.ac.ir/
Proof that this domain is used for official student emails: https://mail.eyc.ac.ir/auth/login

This domain is used by enrolled students for their official university email addresses.

Thank you for reviewing my request.