### PR TITLE
Add iau.ir for Islamic Azad University

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University


### PR DESCRIPTION
## Summary

This PR adds the `iau.ir` domain for Islamic Azad University in Iran.

Islamic Azad University issues official student email addresses using the `@iau.ir` domain. I am an enrolled Computer Science student, and my official student email address is:

```
sadeq.khavari@iau.ir
```

Students access and manage these accounts through the university's official mail service:

https://mail.iau.ac.ir

The repository already contains many historical campus-specific domains for Islamic Azad University, but it does not contain the centralized `iau.ir` domain that is currently issued to students.

## Evidence

- Official mail portal:
  https://mail.iau.ac.ir

- Public documentation describing the university email service:
  https://www.heyvagroup.com/shownews/11797/سرویس-رایانامه-دانشگاه-آزاد-اسلامی.html

- Attached screenshot from the authenticated university mail settings showing an official `@iau.ir` student account.

<img width="1711" height="1011" alt="evidence" src="https://github.com/user-attachments/assets/68eb98ea-b61d-48a4-932d-c350fc751e89" />
