### PR TITLE
Add iau.ir domain for Islamic Azad University

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
## Description

This pull request adds the `iau.ir` email domain used by Islamic Azad University for enrolled students.

### Official university website

https://iau.ir/

### Official student email portal

https://mail.iau.ac.ir/

### Proof

The `@iau.ir` domain is used to issue official email accounts to enrolled students through the university's official mail system.

If additional verification is required, I can provide proof privately.