### PR TITLE
Add iau.ir domain for Islamic Azad University, Central Tehran Branch

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,1 +1,0 @@
-Islamic Azad University

--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University

--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University, Central Tehran Branch


### PR DESCRIPTION
## University

Islamic Azad University, Central Tehran Branch

## Official website

https://ctb.iau.ir/

## Domain

@iau.ir

## Reason

I am a student at Islamic Azad University, Central Tehran Branch.

My official student email address uses the `@iau.ir` domain. This domain is currently not recognized by services that rely on the JetBrains SWoT database, such as Zed Education.

Please add support for the `iau.ir` domain for student verification.

Thank you!