### PR TITLE
Add IUST domain

### DIFF
--- a/lib/domains/ir/ac/iust.txt
+++ b/lib/domains/ir/ac/iust.txt
@@ -1,0 +1,1 @@
+Iran University of Science and Technology


### PR DESCRIPTION
add Iran University of Science and Technology, the main university site domain is iust.ac.ir as the domain i try to add here as student of this university.