### PR TITLE
Add math.uk.ac.ir for Shahid Bahonar University of Kerman

### DIFF
--- a/lib/domains/ir/ac/math.txt
+++ b/lib/domains/ir/ac/math.txt
@@ -1,0 +1,3 @@
+Shahid Bahonar University of Kerman
+University of Kerman
+math.uk.ac.ir subdomainS


### PR DESCRIPTION
This adds the math.uk.ac.ir subdomain used by mathematics students at Shahid Bahonar University of Kerman.

The main domain uk.ac.ir is already in the list.