### PR TITLE
Add MLR Institute of Technology domain

### DIFF
--- a/lib/domains/in/ac/mlrinstitutions.txt
+++ b/lib/domains/in/ac/mlrinstitutions.txt
@@ -1,0 +1,1 @@
+MLR Institute of Technology


### PR DESCRIPTION
Adding MLR Institute of Technology (https://mlrinstitutions.ac.in) to the academic whitelist for Zed/JetBrains verification.