### PR TITLE
Add IUST (Iran University of Science and Technology)

### DIFF
--- a/lib/domains/ir/ac/iust.txt
+++ b/lib/domains/ir/ac/iust.txt
@@ -1,0 +1,1 @@
+Iran University of Science and Technology


### PR DESCRIPTION
Added the domain of iust for Iran University of Science and Technology (https://www.iust.ac.ir/)