### PR TITLE
[codex] Add Shanghai Polytechnic University domain

### DIFF
--- a/lib/domains/cn/edu/sspu.txt
+++ b/lib/domains/cn/edu/sspu.txt
@@ -1,0 +1,3 @@
+上海第二工业大学
+Shanghai Polytechnic University
+Shanghai Second Polytechnic University

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -919,7 +919,6 @@ spud.edu.ph
 sqxy.edu.cn
 ssis.ac.in
 sspeterandpaulsschool.co.uk
-sspu.edu.cn
 sstu-edu.ru
 st-thomasmore.southend.sch.uk
 st.gxu.edu.cn


### PR DESCRIPTION
## Summary

Adds the main academic email domain for Shanghai Polytechnic University (上海第二工业大学): `sspu.edu.cn`.

This also removes `sspu.edu.cn` from `lib/domains/stoplist.txt`; otherwise the new `sspu.edu.cn` entry and the existing `stu.sspu.edu.cn` entry remain blocked by the stoplist lookup.

## Evidence

- Official website: https://www.sspu.edu.cn/
- Official email page: https://www.sspu.edu.cn/dzyx/list.htm
  - Staff email: `mail.sspu.edu.cn`
  - Student email, class of 2023 and later: `mail.sspu.edu.cn`
  - Student email, class of 2022 and earlier: `mail.stu.sspu.edu.cn`
- Long-term IT-related programs: https://jxxy.sspu.edu.cn/2039/list.htm lists Computer Science and Technology, Software Engineering, Network Engineering, Data Science and Big Data Technology, and related undergraduate programs.
- Four-year IT-related undergraduate example: https://jxxy.sspu.edu.cn/2023/0828/c5556a96370/page.htm

## Validation

- `./gradlew test --rerun-tasks`
- `./gradlew run`
- Manual JVM check against compiled `swot.SwotKt`:
  - `student@mail.sspu.edu.cn` -> academic=true
  - `student@mail.stu.sspu.edu.cn` -> academic=true
  - `sspu.edu.cn` -> academic=true
