### PR TITLE
Add The Nippon Dental University Tokyo domain

### DIFF
--- a/lib/domains/jp/ac/ndu/tky.txt
+++ b/lib/domains/jp/ac/ndu/tky.txt
@@ -1,0 +1,2 @@
+日本歯科大学生命歯学部
+The Nippon Dental University School of Life Dentistry at Tokyo


### PR DESCRIPTION
This PR adds the official student email domain for The Nippon Dental University School of Life Dentistry at Tokyo.

Domain:
tky.ndu.ac.jp

Official website:
https://www.tky.ndu.ac.jp/

Proof that this domain is provided to enrolled students:
https://www.tky.ndu.ac.jp/campuslife/mail.html

The official page states that all students are provided with an email account using the university domain “@tky.ndu.ac.jp”.

Proof of long-term curriculum / IT-related education:
https://www.tky.ndu.ac.jp/faculty/general/

The official page states that students study general education subjects from the 1st to 2nd year, including information science.

Note:
This PR intentionally adds tky.ndu.ac.jp rather than the parent domain ndu.ac.jp, because the official student email page specifically documents @tky.ndu.ac.jp as the email domain distributed to students of the Tokyo School of Life Dentistry.