### PR TITLE
Add student subdomain for Utsunomiya University

### DIFF
--- a/lib/domains/jp/ac/utsunomiya-u/s.txt
+++ b/lib/domains/jp/ac/utsunomiya-u/s.txt
@@ -1,0 +1,1 @@
+Utsunomiya University


### PR DESCRIPTION
Added the student subdomain for **Utsunomiya University** (`s.utsunomiya-u.ac.jp`).

The existing subdomain for this university were previously registered in #40038. This PR adds the missing student-specific subdomain.

Official university website: https://www.utsunomiya-u.ac.jp/