### PR TITLE
Add Anadolu University Open Education System text file

### DIFF
--- a/lib/domains/tr/edu/anadolu/aof.txt
+++ b/lib/domains/tr/edu/anadolu/aof.txt
@@ -1,0 +1,1 @@
+Anadolu University Open Education System


### PR DESCRIPTION
Adding Anadolu University Open Education System (AÖF) domain

Domain: aof.anadolu.edu.tr

University official website: https://www.anadolu.edu.tr/
IT-related programs: https://www.anadolu.edu.tr/programlar

Anadolu University Open Education System (AÖF) provides long-term 
(1+ year) IT-related education programs and issues official email 
addresses with the aof.anadolu.edu.tr domain to its students.