### PR TITLE
Add request for aof.anadolu.edu.tr

### DIFF
--- a/lib/domains/tr/edu/aof.anadoluf.txt
+++ b/lib/domains/tr/edu/aof.anadoluf.txt
@@ -1,0 +1,1 @@
+Anadolu Üniversitesi Açıköğretim Fakültesi


### PR DESCRIPTION
- Official website: [Anadolu University AOF Home Page](https://aof.anadolu.edu.tr/anasayfa/Default.aspx)
- A URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university: [Anadolu University AOF Computer Programming Course Web Page](https://www.anadolu.edu.tr/acikogretim/turkiye-programlari/acikogretim-fakultesi-onlisans-programlari-2-yillik/bilgisayar-programciligi)
- A screenshot showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students
<img width="1912" height="360" alt="image" src="https://github.com/user-attachments/assets/ceb5e5b2-6d6d-4827-90d3-26be2dc33f06" />