### PR TITLE
Add Cascadia College — cascadia.edu

### DIFF
--- a/lib/domains/us/wa/cascadia.txt
+++ b/lib/domains/us/wa/cascadia.txt
@@ -1,0 +1,1 @@
+Cascadia College


### PR DESCRIPTION
Add Cascadia College domain: cascadia.edu

Official institution name: Cascadia College
Official website: https://www.cascadia.edu/

This PR adds `cascadia.edu` for Cascadia College. I understand this domain is currently listed in `lib/domains/abused.txt`; Cascadia College appears to have tightened account/security practices, so I’m requesting re-review and removal from the abused list. I have contact the IT department and they have confirmed to taken more security measures. 

Supporting evidence:

Long-term IT-related programs/courses:

* AAST Application Development: https://www.cascadia.edu/academic-programs/science-technology-engineering-and-mathematics/web-application-programming-technology.aspx
* Bachelor of Science in Computer Science: https://www.cascadia.edu/academic-programs/science-technology-engineering-and-mathematics/bscs.aspx
* Computer Science: https://www.cascadia.edu/academic-programs/science-technology-engineering-and-mathematics/computer-science.aspx

Proof of student email domain:

* Cascadia Accessing Accounts page: https://www.cascadia.edu/student-resources/computing-services/access-accounts.aspx 
<img width="538" height="258" alt="image" src="https://github.com/user-attachments/assets/31dcbcf6-0079-463e-b6ce-325c7e95771e" />


The official account page states that students log in using their Kodiak Account username with `@student.cascadia.edu` for student email/Office365. Since SWOT’s README says adding `cascadia.edu` includes subdomains, this should cover `student.cascadia.edu`.

I understand the caution around domains that have previously appeared in `abused.txt`. If any additional documentation or verification would be helpful, please let me know—I'm happy to work with Cascadia College's IT department to provide it.

Thank you for your time and for all the work that goes into maintaining the SWOT repository!