### PR TITLE
Reinstate rupp.edu.kh (Royal University of Phnom Penh)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -656,7 +656,6 @@ mail.dream.edu.kg
 powerbi.edu.kg
 itc.edu.kh
 rule.edu.kh
-rupp.edu.kh
 bbu.edu.kh
 water.itc.edu.kh
 itc.edu.khmoestudents.edu.kn

--- a/lib/domains/kh/edu/rupp.txt
+++ b/lib/domains/kh/edu/rupp.txt
@@ -1,0 +1,1 @@
+Royal University of Phnom Penh


### PR DESCRIPTION
This PR re-adds `lib/domains/kh/edu/rupp.txt` (Royal University of Phnom Penh) and removes `rupp.edu.kh` from `lib/domains/abused.txt`.

I'm aware the domain was moved to the abuse list in November 2024 (ead9c13), so this is explicitly a **request for reconsideration** rather than a routine addition.

Context:

- The Royal University of Phnom Penh (https://www.rupp.edu.kh) is Cambodia's oldest and largest public university, founded in 1960.
- I am a currently enrolled student there with an official student email on this domain (format: `name.surname.NNNN@rupp.edu.kh`), and I'm happy to provide proof of enrollment or any other verification the maintainers would find useful.
- Being on the abuse list currently blocks all genuine RUPP students from email-based student verification.

If reinstatement isn't possible at this time, I'd appreciate guidance on what the university or its students could do to get the domain trusted again (e.g. confirmation from RUPP's IT department about how student accounts are issued and deactivated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)