### PR TITLE
Add Sun Moon University (sunmoon.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/sunmoon.txt
+++ b/lib/domains/kr/ac/sunmoon.txt
@@ -1,0 +1,1 @@
+SunMoon University


### PR DESCRIPTION
### Add domain: sunmoon.ac.kr

  Adds `lib/domains/kr/ac/sunmoon.txt` for **Sun Moon University** (선문대학교),
  an accredited 4-year university in Asan, South Korea.

  **File added**
  - Path: `lib/domains/kr/ac/sunmoon.txt`
  - Content: `Sun Moon University`

  **Eligibility (per contribution rules)**
  - Accredited physical university with student attendance
  - Offers long-term (4-year) IT-related degree programs, e.g. Dept. of Computer Engineering / Software.
  - `@sunmoon.ac.kr` is the official email domain issued to enrolled students.
  - Higher-education institution (not primary/secondary only).

  **References**
  - Official site: https://www.sunmoon.ac.kr
  - IT-related program (Computer Engineering / Software): https://cs.sunmoon.ac.kr/cs/main.do
  - My student email domain: `@sunmoon.ac.kr`