### PR TITLE
Add email.swu.edu.cn (Southwest University student email domain)

### DIFF
--- a/lib/domains/cn/edu/swu/email.txt
+++ b/lib/domains/cn/edu/swu/email.txt
@@ -1,0 +1,2 @@
+email.swu.edu.cn
+Southwest University


### PR DESCRIPTION
Added email.swu.edu.cn to the cn/edu directory.

Southwest University uses @email.swu.edu.cn as the standard email format for all students. The parent domain swu.edu.cn is already in the database.