### PR TITLE
Add Farhangian University (cfu.ac.ir)

### DIFF
--- a/lib/domains/ir/ac/cfu.txt
+++ b/lib/domains/ir/ac/cfu.txt
@@ -1,0 +1,1 @@
+Farhangian University


### PR DESCRIPTION
This pull request adds the official email domain of Farhangian University (cfu.ac.ir).

Students of the university receive email addresses under this domain.