### PR TITLE
Add unesa.txt with Universitas Negeri Surabaya

### DIFF
--- a/lib/domains/id/ac/unesa.txt
+++ b/lib/domains/id/ac/unesa.txt
@@ -1,0 +1,1 @@
+Universitas Negeri Surabaya


### PR DESCRIPTION
Please add the official domain for The State University of Surabaya. Official website: [https://unesa.ac.id](https://unesa.ac.id)