### PR TITLE
Add iau.ir domain

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
This pull request adds the domain "iau.ir" for Islamic Azad University (IAU) to the Swot database.

**Details:**
- Domain: iau.ir
- University Name: Islamic Azad University
- Country: Iran (IR)
- File Path: lib/domains/ir/iau.txt

**Verification:**
This domain belongs to a legitimate higher education institution in Iran with numerous campuses across the country. The email format used by the university follows the pattern: [studentID]@iau.ir.

**Reason for Addition:**
Students from this university need to verify their academic status for educational services and tools that rely on the Swot database for student verification (such as the Zed code editor education plan).

**Checklist:**
- [x] The domain is not in the stoplist
- [x] This is an academic institution
- [x] The file follows the correct naming convention
- [x] The university name is correctly spelled

Please let me know if you need any additional information or documentation to verify this domain.

Thank you for considering this request!