### PR TITLE
Add Islamic Azad University (iau.ir)

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,3 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University
+IAU


### PR DESCRIPTION
Add Islamic Azad University (iau.ir)

This domain is the official email domain for the entire Islamic Azad University system (دانشگاه آزاد اسلامی) across all branches in Iran.

- Official website: https://iau.ir/ or https://www.iau.ac.ir/
- Student/Staff email: *@iau.ir
- Used by over 1.5 million students, faculty, and staff
- Confirmed via official mail service: mail.iau.ir / mail.iau.ac.ir

Educational programs include Computer Engineering, Software Engineering, and many other fields.