### PR TITLE
Create ranelagh.txt

### DIFF
--- a/lib/domains/uk/org/ranelagh.txt
+++ b/lib/domains/uk/org/ranelagh.txt
@@ -1,0 +1,1 @@
+Ranelagh School


### PR DESCRIPTION
Add Ranelagh School at https://www.ranelagh.org.uk/

Computer Science is offered at both GCSE and A-level - both 2 years. See https://www.ranelagh.org.uk/Exam-Results/

The organisation is currently migrating from ranelagh.bonitas.org.uk to ranelagh.org.uk. 