### PR TITLE
Create udec.txt for Universidad de Concepción

### DIFF
--- a/lib/domains/cl/udec.txt
+++ b/lib/domains/cl/udec.txt
@@ -1,0 +1,2 @@
+Universidad de Concepción
+University of Concepción


### PR DESCRIPTION
## Institution

Universidad de Concepción is a recognized Chilean university founded in 1919.

Official university website:
https://www.udec.cl/

Institutional information:
https://www.udec.cl/sobre-la-udec/

## Long-term IT-related programme

Ingeniería Civil Informática is a 10-semester undergraduate degree offered by Universidad de Concepción:

https://admision.udec.cl/ingenieria-civil-informatica/

## Evidence that students receive @udec.cl email accounts

The official Universidad de Concepción account policy states that institutional personal accounts are provided to undergraduate and postgraduate students, as well as faculty and staff.

It also explicitly states that these accounts include an email address in the form:

nombre@udec.cl

Official account policy:
https://www8.udec.cl/scu/scu.html

The university's current Outlook Web service page also lists UdeC students among the authorized users of the institutional email service:

https://vraeaweb.udec.cl/servicios/outlook-web/

The @udec.cl domain is an official institutional email domain used by enrolled students and university personnel.