### PR TITLE
Add University Of South Carolina, Beaufort

### DIFF
--- a/lib/domains/edu/uscb.txt
+++ b/lib/domains/edu/uscb.txt
@@ -1,0 +1,1 @@
+University Of South Carolina, Beaufort


### PR DESCRIPTION
University Of South Carolina, Beaufort

Computer science faculty link: [https://www.uscb.edu/academics/computer-science-math/computer-science/masters.html](https://www.uscb.edu/academics/computer-science-math/computer-science/masters.html)