### PR TITLE
Add edu.txt for TOBB ETÜ

### DIFF
--- a/lib/domains/tr/edu/etu.txt
+++ b/lib/domains/tr/edu/etu.txt
@@ -1,0 +1,1 @@
+TOBB University of Economics and Technology


### PR DESCRIPTION
TOBB ETÜ stands for TOBB University of Economics and Technology. Uses @etu.edu.tr domain. 