### PR TITLE
Add Izmir Demokrasi University

### DIFF
--- a/lib/domains/tr/edu/idu.txt
+++ b/lib/domains/tr/edu/idu.txt
@@ -1,0 +1,1 @@
+İzmir Demokrasi Üniversitesi


### PR DESCRIPTION
Add Izmir Demokrasi University (idu.edu.tr) to the list of supported academic domains.