### PR TITLE
Remove Bandirma Onyedi Eylül University domains from abused list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1661,8 +1661,6 @@ u-erre.mx
 mailsv.tmu.edu.vn
 tmu.edu.vn
 mmamc.tu.edu.np
-ogr.bandirma.edu.tr
-bandirma.edu.tr
 utmatamoros.edu.mx
 uniuyo.edu.ng
 wise.edu.jo


### PR DESCRIPTION
These are official student domains of Bandırma Onyedi Eylül Üniversitesi (state university in Turkey). They were incorrectly added to the abused list. The university domains are already present in lib/domains/tr/edu/banu.txt.