### PR TITLE
Remove Bandirma Onyedi Eylul University domains from abused list

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1661,8 +1661,6 @@ u-erre.mx
 mailsv.tmu.edu.vn
 tmu.edu.vn
 mmamc.tu.edu.np
-ogr.bandirma.edu.tr
-bandirma.edu.tr
 utmatamoros.edu.mx
 uniuyo.edu.ng
 wise.edu.jo


### PR DESCRIPTION
Remove `ogr.bandirma.edu.tr` and `bandirma.edu.tr` from the abused domains list.