### PR TITLE
Adding domain suryadatta.edu.in for Suryadatta Institute of Management  and Mass Communication (SIMMC), Pune, India.

### DIFF
--- a/lib/domains/edu/simmc.txt
+++ b/lib/domains/edu/simmc.txt
@@ -1,0 +1,1 @@
+Suryadatta Institute of Management and Mass Communication (SIMMC)

--- a/lib/domains/edu/simmc.txt
+++ b/lib/domains/edu/simmc.txt
@@ -1,1 +1,0 @@
-Suryadatta Institute of Management and Mass Communication (SIMMC)

--- a/lib/domains/in/edu/suryadatta.txt
+++ b/lib/domains/in/edu/suryadatta.txt
@@ -1,0 +1,1 @@
+Suryadatta Institute of Management and Mass Communication (SIMMC)


### PR DESCRIPTION
Adding domain suryadatta.edu.in for Suryadatta Institute of Management 
and Mass Communication (SIMMC), Pune, India.

- Official website: https://www.suryadatta.org
- SIMMC institute page: https://www.suryadatta.org/institute/suryadatta-institute-of-management-and-mass-communication/
- MCA course (2 year IT program): https://www.suryadatta.org/courses/masters-of-computer-application-mca/
- The domain suryadatta.edu.in is the official student email domain 
  (student email format: studentname.YYYYMMDDXXX@simmc.edu.in)

Note: The student email uses simmc.edu.in subdomain, but suryadatta.edu.in 
is the parent institution's resolvable domain with valid MX and A records.