### PR TITLE
Add aof.anadolu.edu.tr for Anadolu University Open Education Faculty

### DIFF
--- a/lib/domains/tr/edu/aof.txt
+++ b/lib/domains/tr/edu/aof.txt
@@ -1,0 +1,3 @@
+Anadolu Üniversitesi Açıköğretim Fakültesi
+Anadolu University Open Education Faculty
+Anadolu University


### PR DESCRIPTION
Adding official student email subdomain aof.anadolu.edu.tr

- Official website: https://aof.anadolu.edu.tr
- This domain is actively used by enrolled students at Anadolu University's Açıköğretim Fakültesi.
- Main anadolu.edu.tr domain already exists.