### PR TITLE
Add The Friends' School domain

### DIFF
--- a/lib/domains/au/edu/tas/friends.txt
+++ b/lib/domains/au/edu/tas/friends.txt
@@ -1,0 +1,1 @@
+The Friends' School

--- a/lib/domains/au/edu/tas/friends/student.txt
+++ b/lib/domains/au/edu/tas/friends/student.txt
@@ -1,0 +1,1 @@
+The Friends' School

--- a/lib/domains/au/edu/tas/friends/teacher.txt
+++ b/lib/domains/au/edu/tas/friends/teacher.txt
@@ -1,0 +1,1 @@
+The Friends' School


### PR DESCRIPTION
This PR adds the email domains used by The Friends' School in Australia, Tasmania.

Institution:
The Friends' School

Official website:
https://www.friends.tas.edu.au/

The domain `student.friends.tas.edu.au` is used for student email accounts.
The domain `teacher.friends.tas.edu.au` is used for teacher email accounts.
The domain `friends.tas.edu.au` is used for other school staff.