### PR TITLE
Add Islamic Azad University to iau.txt

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
Please add the official domain for Islamic Azad University (IAU) in Iran.

- Domain: iau.ir
- School Name: Islamic Azad University