### PR TITLE
Add aof.anadolu.edu.tr subdomain for Anadolu University

### DIFF
--- a/lib/domains/tr/edu/anadolu/anadolu.txt
+++ b/lib/domains/tr/edu/anadolu/anadolu.txt
@@ -1,0 +1,4 @@
+Anadolu Üniversitesi
+Anadolu University
+Açıköğretim Fakültesi
+Open Education Faculty

--- a/lib/domains/tr/edu/anadolu/aof.anadolu.txt
+++ b/lib/domains/tr/edu/anadolu/aof.anadolu.txt
@@ -1,0 +1,2 @@
+Anadolu Üniversitesi Açıköğretim Fakültesi
+Anadolu University Open Education Faculty

--- a/lib/domains/tr/edu/aof.txt
+++ b/lib/domains/tr/edu/aof.txt
@@ -1,3 +1,0 @@
-Anadolu Üniversitesi Açıköğretim Fakültesi
-Anadolu University Open Education Faculty
-Anadolu University

--- a/lib/domains/tr/edu/aof.txt
+++ b/lib/domains/tr/edu/aof.txt
@@ -1,0 +1,3 @@
+Anadolu Üniversitesi Açıköğretim Fakültesi
+Anadolu University Open Education Faculty
+Anadolu University


### PR DESCRIPTION
Adding the correct subdomain `aof.anadolu.edu.tr` for Anadolu University Open Education Faculty students.

- Official website: https://aof.anadolu.edu.tr
- This is the active student email domain (metegun@aof.anadolu.edu.tr).
- DNS resolves correctly.
- Main domain anadolu.edu.tr already exists in the repository.