### PR TITLE
Add students.undip.ac.id domain

### DIFF
--- a/lib/domains/id/ac/undip/students.txt
+++ b/lib/domains/id/ac/undip/students.txt
@@ -1,0 +1,1 @@
+Universitas Diponegoro

--- a/src/test/kotlin/swot/SwotTest.kt
+++ b/src/test/kotlin/swot/SwotTest.kt
@@ -43,6 +43,8 @@ class SwotTest : TestCase() {
         assertEquals (true , isAcademic("lee@mail.harvard.edu"))
 
         assertEquals(false, isAcademic("imposter@si.edu"))
+        assertEquals(true, isAcademic("student@students.undip.ac.id"))
+        assertEquals(false, isAcademic("alumni@alumni.undip.ac.id"))
         assertEquals(false, isAcademic("lee@mdu.edu.rs"))
 
         // Iran sanctions are lifted


### PR DESCRIPTION
## Domain Addition Request

Please add `students.undip.ac.id` to the allowed domains list. The root domain `undip.ac.id` was blacklisted in `abused.txt`, but `students.undip.ac.id` is the dedicated, verified email domain for enrolled students.

- **Institution Name:** Universitas Diponegoro (UNDIP)
- **Official Website:** https://www.undip.ac.id/
- **IT-Related Program Curriculum:** https://if.fsm.undip.ac.id/ (Official site of Departemen Informatika, Fakultas Sains dan Matematika)
- **Domain Verification Reference:** The domain `students.undip.ac.id` is used exclusively for student portals and academic email communication.