### PR TITLE
Add iau.ir domain

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+Islamic Azad University
+دانشگاه آزاد اسلامی


### PR DESCRIPTION
## University Name

Islamic Azad University (IAU)

## Domain

iau.ir

## Evidence

Official website:
https://iau.ir

The `iau.ir` domain is used by Islamic Azad University. Please add it to the SWoT database so educational services that rely on SWoT can verify eligible university users.