### PR TITLE
Update city.edu.my to current official name (City University Malaysia)

### DIFF
--- a/lib/domains/my/edu/city.txt
+++ b/lib/domains/my/edu/city.txt
@@ -1,1 +1,1 @@
-City University College of Science and Technology
+City University Malaysia


### PR DESCRIPTION
Updates the institution name for the existing city.edu.my entry.

- Institution: City University Malaysia
- Domain: city.edu.my
- Old name in file: "City University College of Science and Technology" (pre-2016)
- Status: Full university status granted by the Ministry of Higher Education (MOHE) in 2016
- Official website: https://www.city.edu.my/
- IT courses: https://www.city.edu.my/ (Faculty of Information Technology — Bachelor of Computer Science (Hons) in Software Engineering, Bachelor of IT (Hons), Bachelor of Computer Science (Hons) in AI, Master of IT, Master of AI, PhD in IT)