### PR TITLE
Add Caleb University (calebuniversity.edu.ng) [re: #40580]

### DIFF
--- a/lib/domains/ng/calebuniversity.txt
+++ b/lib/domains/ng/calebuniversity.txt
@@ -1,0 +1,1 @@
+Caleb University

--- a/lib/domains/ng/calebuniversity.txt
+++ b/lib/domains/ng/calebuniversity.txt
@@ -1,1 +1,1 @@
-Caleb University
+@calebuniversity.edu.ng

--- a/lib/domains/ng/calebuniversity.txt
+++ b/lib/domains/ng/calebuniversity.txt
@@ -1,1 +1,1 @@
-@calebuniversity.edu.ng
+caleb university


### PR DESCRIPTION
Please verify calebuniversity.edu.ng, not calebuniversity.ng. The correct domain resolves successfully: https://www.calebuniversity.edu.ng