### PR TITLE
Add iau.ir domain for Islamic Azad University

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,1 +1,1 @@
-Islamic Azad University, Najafabad Branch
+Islamic Azad University

--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University, Najafabad Branch


### PR DESCRIPTION
### Add domain for Islamic Azad University (iau.ir)

**University Name:**
Islamic Azad University (دانشگاه آزاد اسلامی)

**Email Domain:**
iau.ir

**Evidence:**

1. **Official University Website:**
   [https://www.iau.ir/en]


2. **Proof that the university issues email addresses with the iau.ir domain:**
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/232b00b9-224e-4b24-ad55-df2542357af6" />

   *My university email: hessam.asadimadiseh@iau.ir*

**File Added:**
`lib/domains/ir/iau.txt`

Please note that this domain is used by all branches of Islamic Azad University across Iran.

Please review. Thank you!