### PR TITLE
Add alexu.edu.eg domain for Alexandria University

### DIFF
--- a/lib/domains/eg/edu/lib/domains/eg/edu/alexu.txt
+++ b/lib/domains/eg/edu/lib/domains/eg/edu/alexu.txt
@@ -1,0 +1,1 @@
+Alexandria University


### PR DESCRIPTION
This PR adds the official email domain used by Alexandria University in Egypt.

University: Alexandria University
Official website: https://www.alexu.edu.eg
Official student email domain: alexu.edu.eg