### PR TITLE
add csupueblo.edu to list

### DIFF
--- a/lib/domains/edu/csupueblo.txt
+++ b/lib/domains/edu/csupueblo.txt
@@ -1,0 +1,1 @@
+Colorado State University, Pueblo


### PR DESCRIPTION
https://www.csupueblo.edu/
https://www.csupueblo.edu/computer-information-systems/index.html

for some reason there isnt a clear message that the csupueblo.edu (really its pack.csupueblo.edu) as the main student email. Here's a screenshot of me getting a real email to it, and here's a link saying the login (colostate.edu) is not the email address. https://www.csupueblo.edu/information-technology/help-desk/microsoft-365.html
<img width="340" height="203" alt="Screenshot 2026-07-16 at 8 33 28 PM" src="https://github.com/user-attachments/assets/75835744-8242-46e4-b49d-7e2ce964ea3f" />

