### PR TITLE
Add Inha Technical College alternative domain (itc.ac.kr)

### DIFF
--- a/lib/domains/kr/ac/itc.txt
+++ b/lib/domains/kr/ac/itc.txt
@@ -1,0 +1,2 @@
+인하공업전문대학
+Inha Technical College


### PR DESCRIPTION
### School Information
- **School Name:** Inha Technical College
- **Domain to add:** itc.ac.kr
- **Official Website:** https://www.inhatc.ac.kr/

### Description
Inha Technical College currently uses `inhatc.ac.kr` as its primary domain (which is already registered in SWOT). However, the university also provides and uses `itc.ac.kr` for student email addresses and legacy systems. Please add `itc.ac.kr` to allow students using this domain to verify their academic status.