### PR TITLE
Adding Central European Labour Studies Institute (CELSI) domain

### DIFF
--- a/lib/domains/sk/celsi.txt
+++ b/lib/domains/sk/celsi.txt
@@ -1,0 +1,2 @@
+Stredoeurópsky inštitút pre výskum práce (CELSI)
+Central European Labour Studies Institute


### PR DESCRIPTION
Information

    Institution Name: Central European Labour Studies Institute (CELSI)
    Domain to add: celsi.sk
    Official Website: https://www.celsi.sk/