### PR TITLE
Add unimugo.txt with university name Universitas Muhammadiyah Gombong

### DIFF
--- a/lib/domains/id/ac/unimugo.txt
+++ b/lib/domains/id/ac/unimugo.txt
@@ -1,0 +1,1 @@
+Universitas Muhammadiyah Gombong, Indonesia

--- a/lib/domains/id/ac/unimugo.txt
+++ b/lib/domains/id/ac/unimugo.txt
@@ -1,1 +1,3 @@
 Universitas Muhammadiyah Gombong, Indonesia
+UNIMUGO
+Muhammadiyah Gombong University


### PR DESCRIPTION
This pull request adds `Universitas Muhammadiyah Gombong` (UNIMUGO) to the list of academic domains.

Academic institution addition:

* Added `Universitas Muhammadiyah Gombong, Indonesia` and its English name and abbreviation to `lib/domains/id/ac/unimugo.txt`.