### PR TITLE
Add citeinstitute.org domain for CITE Technical Institute

### DIFF
--- a/lib/domains/org/citeinstitute.txt
+++ b/lib/domains/org/citeinstitute.txt
@@ -1,0 +1,1 @@
+CITE Technical Institute


### PR DESCRIPTION
Add citeinstitute.org for CITE Technical Institute

Official website: https://cite.edu.ph/

We use citeinstitute.org as the email domain for students and teachers of CITE Technical Institute (Philippines). The institute offers technical and IT-related programs.