### PR TITLE
Add comunidad.unam.mx as an official UNAM email domain

### DIFF
--- a/lib/domains/mx/unam/comunidad.txt
+++ b/lib/domains/mx/unam/comunidad.txt
@@ -1,0 +1,2 @@
+Universidad Nacional Autónoma de México
+National Autonomous University of Mexico


### PR DESCRIPTION
## Summary

This pull request adds the `comunidad.unam.mx` email domain used by the Universidad Nacional Autónoma de México (UNAM).

## Official University Website

- https://www.unam.mx/

## IT-related Degree

UNAM offers long-term degree programs related to Computer Science and Information Technology, including:

- Bachelor’s Degree in Data Science:
  https://oferta.unam.mx/ciencia-de-datos.html

## Proof of the email domain

Official UNAM pages confirming the use of `@comunidad.unam.mx`:

- https://www.comunidad.unam.mx/
- https://ayuda.telecom.unam.mx/hd/fall_serv/correo/correo.ssp

The support documentation states that `@comunidad.unam.mx` is an official email service provided by UNAM.

## Repository change

This PR adds:

`lib/domains/mx/unam/comunidad.txt`

with the following content:

Universidad Nacional Autónoma de México
National Autonomous University of Mexico