### PR TITLE
Create iau.txt

### DIFF
--- a/lib/domains/ir/ac/iau.txt
+++ b/lib/domains/ir/ac/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
## Adding the main IAU domain (iau.ir)

There are already many Islamic Azad University (IAU) branch domains listed in
this repository, but the main domain (`iau.ir`) itself is not included.

Individual branches do not issue separate email domains to their students or
staff. Instead, all official IAU email addresses are issued under the unified
main domain, with the default format:
nationalID@iau.ir
(using the person's national ID number as the local part).

Additionally, users have the option to define a custom alias for their
address instead of the default national-ID-based format, for example:
parsa.mohamadi@iau.ir
**Official website:** https://www.iau.ir