### PR TITLE
Create tecnocomfenalco.txt

### DIFF
--- a/lib/domains/co/edu/tecnocomfenalco.txt
+++ b/lib/domains/co/edu/tecnocomfenalco.txt
@@ -1,0 +1,1 @@
+Fundación Universitaria Tecnológico Comfenalco


### PR DESCRIPTION
## Institution

Fundación Universitaria Tecnológico Comfenalco

## Domain

tecnocomfenalco.edu.co

## Reason

The institution is already registered in SWoT under the domain
`tecnologicocomfenalco.edu.co`.

However, the university also issues official institutional email
addresses using the domain:

@tecnocomfenalco.edu.co

This pull request adds the additional academic domain used by the same
institution for students, faculty and staff.

## Official website

https://tecnologicocomfenalco.edu.co