### PR TITLE
Add Islamic Azad University names in iau.txt

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,2 @@
+دانشگاه آزاد اسلامی
+Islamic Azad University


### PR DESCRIPTION
University Name: Islamic Azad University (دانشگاه آزاد اسلامی)
Domain: iau.ir
Official Website: https://iau.ir/
Mail Service: https://account.iau.ac.ir/login?service=https://mail.iau.ac.ir&redirectPath=/nui/validate
