### PR TITLE
Add Fundación Universitaria Tecnológico Comfenalco

### DIFF
--- a/lib/domains/co/edu/tecnocomfenalco.txt
+++ b/lib/domains/co/edu/tecnocomfenalco.txt
@@ -1,0 +1,1 @@
+Fundación Universitaria Tecnológico Comfenalco


### PR DESCRIPTION
## Institution
Fundación Universitaria Tecnológico Comfenalco

## Domain
tecnocomfenalco.edu.co

## Evidence

Official website:
https://tecnologicocomfenalco.edu.co/

Institutional email domain:
@tecnocomfenalco.edu.co

The domain is used for institutional email accounts of the university.