### PR TITLE
Add cemk.ac.in domain for College of Engineering & Management, Kolaghat

### DIFF
--- a/lib/domains/in/ac/cemk.txt
+++ b/lib/domains/in/ac/cemk.txt
@@ -1,0 +1,1 @@
+College of Engineering & Management, Kolaghat


### PR DESCRIPTION
Domain is : cemk.ac.in

College official : https://www.cemkolaghat.in/