### PR TITLE
Add G H Raisoni Skill Tech University (ghrstu.edu.in)

### DIFF
--- a/lib/domains/in/edu/ghrstu.txt
+++ b/lib/domains/in/edu/ghrstu.txt
@@ -1,0 +1,1 @@
+G H Raisoni Skill Tech University


### PR DESCRIPTION
Adds **G H Raisoni Skill Tech University** (GHRSTU), Nagpur, Maharashtra, India.

- Domain: `ghrstu.edu.in`
- Official website: https://ghrstu.edu.in/
- GHRSTU is a private university established in 2024 under the Maharashtra State Act and approved by the UGC (University Grants Commission of India). It is part of the Raisoni Group of Institutions: https://en.wikipedia.org/wiki/G_H_Raisoni_University
- Student email addresses are issued on this domain (e.g. `firstname.lastname.program@ghrstu.edu.in`).