### PR TITLE
Add students.uin-suska.ac.id for Universitas Islam Negeri Sultan Syarif Kasim Riau

### DIFF
--- a/lib/domains/id/ac/uin-suska/students.txt
+++ b/lib/domains/id/ac/uin-suska/students.txt
@@ -1,0 +1,1 @@
+Universitas Islam Negeri Sultan Syarif Kasim Riau


### PR DESCRIPTION
## Description

This PR adds the official student email domain for Universitas Islam Negeri Sultan Syarif Kasim Riau.

**Domain**
- students.uin-suska.ac.id

**Official website**
- https://www.uin-suska.ac.id/

This domain is used for student email accounts issued by the university.