### PR TITLE
Add SRM Madurai College for Engineering and Technology

### DIFF
--- a/lib/domains/in/edu/srmmcet.txt
+++ b/lib/domains/in/edu/srmmcet.txt
@@ -1,0 +1,1 @@
+SRM Madurai College for Engineering and Technology


### PR DESCRIPTION
Adds the official email domain for SRM Madurai College for Engineering and Technology.

Domain: srmmcet.edu.in