### PR TITLE
Add puc.ac.bd for Premier University  

### DIFF
--- a/lib/domains/bd/ac/puc.txt
+++ b/lib/domains/bd/ac/puc.txt
@@ -1,0 +1,2 @@
+Premier University
+Premier University, Chittagong  


### PR DESCRIPTION
Adding the official student email domain (puc.ac.bd) for Premier University

Official university website: 
https://puc.ac.bd/

URL showing Computer Science And Engineering Courses (Bachelors and Master's Degree):
https://puc.ac.bd/Faculty/Index/13

Screenshot of my Student Portal as proof of this email domain:
<img width="1350" height="640" alt="image" src="https://github.com/user-attachments/assets/6c034ed6-e36a-496e-b2ed-c9cb9773049d" />

