### PR TITLE
Add missing institution name for student.beykent.edu.tr

### DIFF
--- a/lib/domains/tr/edu/beykent/student.txt
+++ b/lib/domains/tr/edu/beykent/student.txt
@@ -1,1 +1,2 @@
-
+Beykent Üniversitesi
+Beykent University


### PR DESCRIPTION
The student subdomain of beykent.edu.tr (Beykent University / Beykent Üniversitesi) is missing an institution name.