### PR TITLE
Add missing institution name for mipa.idu.ac.id

### DIFF
--- a/lib/domains/id/ac/idu/mipa.txt
+++ b/lib/domains/id/ac/idu/mipa.txt
@@ -1,0 +1,2 @@
+Universitas Pertahanan Republik Indonesia
+Indonesia Defense University


### PR DESCRIPTION
The MIPA (science) faculty subdomain of idu.ac.id (Universitas Pertahanan Republik Indonesia / Indonesia Defense University) is missing an institution name.