### PR TITLE
Add Islamic Azad University iau.ir domain

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
This PR adds the official email domain of Islamic Azad University.
Students use @iau.ir email addresses for university services.
