### PR TITLE
Add budai-rfg.txt for II. Rákóczi Ferenc Gimnázium

### DIFF
--- a/lib/domains/edu/budai-rfg.txt
+++ b/lib/domains/edu/budai-rfg.txt
@@ -1,0 +1,1 @@
+II. Rákóczi Ferenc Gimnázium


### PR DESCRIPTION
Its a domain what is NOT .edu. It is budai-rfg.hu
HUNGARIAN DOMAIN