### PR TITLE
Add Al-Zaytoonah University of Jordan

### DIFF
--- a/lib/domains/jo/edu/zuj.txt
+++ b/lib/domains/jo/edu/zuj.txt
@@ -1,2 +1,0 @@
-جامعة الزيتونة الاردنية
-Al-Zaytoonah University of Jordan

--- a/lib/domains/jo/edu/zuj.txt
+++ b/lib/domains/jo/edu/zuj.txt
@@ -1,0 +1,2 @@
+Al-Zaytoonah University of Jordan
+جامعة الزيتونة الأردنية


### PR DESCRIPTION
University Name:
Al-Zaytoonah University of Jordan

Official website:
https://www.zu.edu.jo

Student email domain:
@std-zuj.edu.jo

The university provides official student email addresses under this domain.