### PR TITLE
 Muffakham Jah College of Engineering and Technology - Domain added

### DIFF
--- a/lib/domains/in/ac/mjcet.txt
+++ b/lib/domains/in/ac/mjcet.txt
@@ -1,0 +1,1 @@
+Muffakham Jah College of Engineering and Technology


### PR DESCRIPTION
This adds Muffakham Jah College of Engineering and Technology to the domains list 