### PR TITLE
Add ITLA domain

### DIFF
--- a/lib/domains/do/edu/itla.txt
+++ b/lib/domains/do/edu/itla.txt
@@ -1,0 +1,1 @@
+Instituto Tecnológico de Las Américas


### PR DESCRIPTION
Add the official email domain for Instituto Tecnológico de Las Américas (ITLA), Dominican Republic

- Official website: https://itla.edu.do/
- Email domain: itla.edu.do

