### PR TITLE
Add Institut Saint-Luc Tournai

### DIFF
--- a/lib/domains/be/islt.txt
+++ b/lib/domains/be/islt.txt
@@ -1,0 +1,1 @@
+Institut Saint-Luc Tournai


### PR DESCRIPTION
Add the official email domain of Institut Saint-Luc Tournai, Belgium.

Institution: Institut Saint-Luc Tournai
Domain: islt.be
Country: Belgium
Type: Secondary school

Official website:
https://islt.be/

Evidence that islt.be is the institution's official email domain:
https://islt.be/contacts/

The official contact page lists multiple institutional addresses using
the @islt.be domain, including the secretariat, direction and staff.

Evidence that the institution provides secondary education:
https://islt.be/notre-enseignement/

The school's official website identifies Institut Saint-Luc as a
secondary school ("enseignement secondaire").