### PR TITLE
Add WMO Arts and Science College, Muttil (wmocollege.ac.in)

### DIFF
--- a/lib/domains/in/ac/wmocollege.txt
+++ b/lib/domains/in/ac/wmocollege.txt
@@ -1,0 +1,1 @@
+WMO Arts and Science College, Muttil


### PR DESCRIPTION
## Summary

This pull request adds the official academic email domain for WMO Arts and Science College, Muttil, Kerala, India.

### Domain

- `wmocollege.ac.in`

### Official website

https://www.wmocollege.ac.in/

### Evidence

- The institution uses `@wmocollege.ac.in` as its official institutional email domain.
- Official website: https://www.wmocollege.ac.in/
- Undergraduate programmes: https://wmocollege.ac.in/under-graduate-programme
- Department of Computer Science: https://wmocollege.ac.in/department/computer-science

The institution offers long-term undergraduate degree programmes in computing, including **Bachelor of Computer Application (BCA)** and **Bachelor of Computer Application (Honours)**. The Department of Computer Science provides the BCA programme with a curriculum covering programming, operating systems, computer networks, databases, artificial intelligence, machine learning, internships, and project work.