### PR TITLE
Remove habsboys.txt (no longer used)

### DIFF
--- a/lib/domains/uk/org/habsboys.txt
+++ b/lib/domains/uk/org/habsboys.txt
@@ -1,1 +1,0 @@
-Haberdashers' Aske's Boys' School


### PR DESCRIPTION
## Description
Removes the obsolete domain habsboys.org.uk.

## Details
Domain Removed: habsboys.org.uk

Institution: Haberdashers' Boys' School

## Reason for Change
The school no longer uses habsboys.org.uk for student and staff email addresses, having fully transitioned to habselstree.org.uk.

## Proof
* Primary Website: https://www.habselstree.org.uk/boys/

* Contact Page: https://www.habselstree.org.uk/boys/contact-us/

EDIT: PR to add new domain #40709