### PR TITLE
Add yazd.ac.ir

### DIFF
--- a/lib/domains/ir/ac/yazd.txt
+++ b/lib/domains/ir/ac/yazd.txt
@@ -1,0 +1,1 @@
+Yazd University


### PR DESCRIPTION
## Summary

This pull request adds the official academic email domain for **Yazd University, Yazd, Iran**.

### Domain

* `yazd.ac.ir`

### Official website

https://yazd.ac.ir/

### Evidence

* Yazd University uses `yazd.ac.ir` as its official institutional email domain.
* Student email addresses use the `stu.yazd.ac.ir` subdomain, which is covered by the parent domain `yazd.ac.ir`.
* Official website: https://yazd.ac.ir/
* The university has a **Department of Computer Engineering** and offers long-term degree programmes in computer engineering and related fields.
* Academic publications from Yazd University demonstrate the use of `@stu.yazd.ac.ir` for university-affiliated student/researcher email addresses.

### Institution and academic programme

Yazd University is a higher-education institution offering undergraduate and graduate degree programmes. Its academic offerings include **Computer Engineering**, satisfying the requirement for a long-term IT-related programme.

The submitted parent domain is `yazd.ac.ir` rather than `stu.yazd.ac.ir` because the JetBrains/swot repository rules state that adding a domain automatically covers its subdomains. Therefore, `yazd.ac.ir` covers student addresses under `stu.yazd.ac.ir`.
