### PR TITLE
Add prc.ac.th (The Prince Royal's College)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1067,7 +1067,6 @@ nu.ac.th
 o365.rmutp.ac.th
 petkasem.ac.th
 pkru.ac.th
-prc.ac.th
 psu.ac.th
 rittiya.ac.th
 rmu.ac.th

--- a/lib/domains/th/ac/prc.txt
+++ b/lib/domains/th/ac/prc.txt
@@ -1,0 +1,2 @@
+โรงเรียนปรินส์รอยแยลส์วิทยาลัย
+The Prince Royal's College


### PR DESCRIPTION
Adds `lib/domains/th/ac/prc.txt` for **The Prince Royal's College** (โรงเรียนปรินส์รอยแยลส์วิทยาลัย), Chiang Mai, Thailand.

I'm a student at this school and use an `@prc.ac.th` address.

### This PR also removes `prc.ac.th` from `abused.txt`

To be upfront about the scope: `prc.ac.th` is currently on the stoplist. The file was originally added in e044b93 (Feb 2023) and removed in 9aec568 ("removing abused domains", Jul 2024), at which point the domain was moved to `lib/domains/abused.txt`. So this PR is really a request to **reconsider the abuse listing**, not just a new-domain submission — please treat it as such, and feel free to close it if the listing should stand.

### Details

- Official website: https://www.prc.ac.th (English: https://english.prc.ac.th)
- Location: 117 Kaew Nawarat Rd, Wat Ket, Mueang Chiang Mai, Chiang Mai 50000, Thailand
- `prc.ac.th` is the school's official domain and the domain used for student email accounts.

Happy to provide additional verification (a screenshot of my student email account, school ID, or documentation of the IT/computer-science coursework offered) if that helps with the review — just let me know what you need.
