### PR TITLE
Add Haberdashers' Elstree Schools

### DIFF
--- a/lib/domains/uk/org/habselstree.txt
+++ b/lib/domains/uk/org/habselstree.txt
@@ -1,0 +1,4 @@
+Haberdashers' Elstree Schools
+Haberdashers' Boys' School
+Haberdashers' Girls' School
+.group


### PR DESCRIPTION
* **Domain name:** habselstree.org.uk
* **Official Website:** https://habselstree.org.uk

Adding domain for Haberdashers' Elstree Schools (Haberdashers' Boys' School & Haberdashers' Girls' School).