### PR TITLE
feat: Add sufix UCB

### DIFF
--- a/lib/domains/br/ucb.txt
+++ b/lib/domains/br/ucb.txt
@@ -1,1 +1,1 @@
-Universidade Católica de Brasília
+Universidade Católica de Brasília - (UCB)


### PR DESCRIPTION
## Summary

This pull request adds the official academic email domain for **Universidade Católica de Brasília (UCB), Brasília, Brazil**, and adjusts the institution name to include the **UCB** prefix for better identification.

### Domain

- `catolica.edu.br`

### Official website

[https://ucb.catolica.edu.br/](https://ucb.catolica.edu.br/)

### Changes

- Added the official academic domain `catolica.edu.br`.
- Adjusted the institution name to include the **UCB** prefix, identifying it as **UCB - Universidade Católica de Brasília**.

### Evidence

- Universidade Católica de Brasília (UCB) uses `catolica.edu.br` as its institutional domain.
- The university's official website is hosted at `ucb.catolica.edu.br`, which is a subdomain of `catolica.edu.br`.
- The university offers several long-term higher-education programmes in Information Technology and Computer Science.
- UCB offers a **Bachelor's degree in Software Engineering**, with a curriculum focused on software development, programming, databases, computer networks, DevOps, software engineering, data structures, back-end development, and related subjects.
- UCB also offers a **Bachelor's degree in Computer Science**, with a duration of **4 years**.
- UCB offers a **Technology degree in Systems Analysis and Development**, with a duration of **5 semesters**.
- UCB's official documentation also explicitly identifies Computer Science, Systems Analysis and Development, and Software Engineering as its computing programmes.

### Institution and academic programmes

**UCB - Universidade Católica de Brasília** is a higher-education institution in Brazil offering undergraduate and graduate degree programmes.

Its academic offerings include multiple long-term IT-related programmes, including:

- **Software Engineering** — Bachelor's degree
- **Computer Science** — Bachelor's degree, 4 years
- **Systems Analysis and Development** — Technology degree, 5 semesters

These programmes satisfy the requirement for a long-term IT-related academic programme.

The submitted domain is `catolica.edu.br` rather than `ucb.catolica.edu.br` because the institutional website and domain hierarchy use `catolica.edu.br` as the parent domain. Adding the parent domain also covers its subdomains according to the JetBrains/swot repository rules.

### Official references

- University website: [https://ucb.catolica.edu.br/](https://ucb.catolica.edu.br/)
- Software Engineering: [https://ucb.catolica.edu.br/cursos/presencial/engenharia-de-software](https://ucb.catolica.edu.br/cursos/presencial/engenharia-de-software)
- Computer Science: [https://ucb.catolica.edu.br/cursos/presencial/ciencia-computacao](https://ucb.catolica.edu.br/cursos/presencial/ciencia-computacao)
- Systems Analysis and Development: [https://ucb.catolica.edu.br/cursos/presencial/analise-desenvolvimento-sistemas](https://ucb.catolica.edu.br/cursos/presencial/analise-desenvolvimento-sistemas)