### PR TITLE
Added Rajkiya Engineering College kannauj

### DIFF
--- a/lib/domains/in/ac/reck.txt
+++ b/lib/domains/in/ac/reck.txt
@@ -1,0 +1,1 @@
+Rajkiya Engineering College, Kannauj


### PR DESCRIPTION
Adding Rajkiya Engineering College, Kannauj (reck.ac.in) to the university domain list for student verification.