### PR TITLE
Add studenti.uniroma1.it domain

### DIFF
--- a/lib/domains/it/uniroma1/studenti.txt
+++ b/lib/domains/it/uniroma1/studenti.txt
@@ -1,0 +1,1 @@
+Sapienza, University of Rome


### PR DESCRIPTION
Added missing student domain for Sapienza University of Rome (studenti.uniroma1.it).