### PR TITLE
Add hps.edu.vn domain

### DIFF
--- a/hps
+++ b/hps
@@ -1,0 +1,1 @@
+Trường Đào tạo Nghề HPS


### PR DESCRIPTION
Adding domain hps.edu.vn for a vocational training school in Vietnam.

- Domain: hps.edu.vn
- Institution: Trường Đào tạo Nghề HPS
- Country: Vietnam

This domain is used for official student email addresses.