### PR TITLE
Lords Institute of Engineering and Technology - Domain added

### DIFF
--- a/lib/domains/in/ac/lords.txt
+++ b/lib/domains/in/ac/lords.txt
@@ -1,0 +1,1 @@
+Lords Institute of Engineering and Technology


### PR DESCRIPTION
This adds Lords Institute of Engineering and Technology to the domains list