### PR TITLE
Add domain for Ho Chi Minh City University of Food Industry (Vietnam)

### DIFF
--- a/lib/domains/vn/edu/hufi.txt
+++ b/lib/domains/vn/edu/hufi.txt
@@ -1,0 +1,1 @@
+Ho Chi Minh City University of Food Industry


### PR DESCRIPTION
Hello,

I would like to add the domain for my university in Vietnam. 

* **University Name:** Ho Chi Minh City University of Industry and Trade (HUIT)
* **Former Name:** Ho Chi Minh City University of Food Industry (HUFI)
* **Domain:** hufi.edu.vn
* **Website:** https://huit.edu.vn/

**Note for Reviewers:** The university has updated its official English name to HUIT, but the student email system still currently utilizes the legacy `@hufi.edu.vn` domain. 

Thank you!