### PR TITLE
Add Universitas Pelita Harapan (uph.edu)

### DIFF
--- a/lib/domains/edu/uph.txt
+++ b/lib/domains/edu/uph.txt
@@ -1,0 +1,1 @@
+Universitas Pelita Harapan


### PR DESCRIPTION
Adding Universitas Pelita Harapan (UPH), Indonesia.

- Website: https://www.uph.edu
- Domain: uph.edu (staff), student.uph.edu (students)