### PR TITLE
Add Osaka Institute of Technology

### DIFF
--- a/lib/domains/jp/ac/oit.txt
+++ b/lib/domains/jp/ac/oit.txt
@@ -1,0 +1,1 @@
+Osaka Institute of Technology


### PR DESCRIPTION
University Website: https://www.oit.ac.jp/
Official domain for Osaka Institute of Technology.