### PR TITLE
Add iunp.edu.rs (International University of Novi Pazar)

### DIFF
--- a/lib/domains/rs/edu/iunp.txt
+++ b/lib/domains/rs/edu/iunp.txt
@@ -1,0 +1,1 @@
+International University of Novi Pazar


### PR DESCRIPTION
Adding domain iunp.edu.rs used by the International University of Novi Pazar (Serbia). Related: existing entry for uninp.edu.rs (lib/domains/rs/edu/uninp.txt).