### PR TITLE
Remove duplicate name from UFTB entries

### DIFF
--- a/lib/domains/bd/ac/uftb.txt
+++ b/lib/domains/bd/ac/uftb.txt
@@ -1,2 +1,1 @@
 University of Frontier Technology, Bangladesh
-University of Frontier Technology, Bangladesh

--- a/lib/domains/bd/ac/uftb/iot.txt
+++ b/lib/domains/bd/ac/uftb/iot.txt
@@ -1,2 +1,1 @@
 University of Frontier Technology, Bangladesh
-University of Frontier Technology, Bangladesh


### PR DESCRIPTION
Deduplicates the school name in \lib/domains/bd/ac/uftb.txt\ and \lib/domains/bd/ac/uftb/iot.txt\. Fixes the duplicate \University of Frontier Technology, Bangladesh\ lines.