### PR TITLE
Add pcenagpur.eud.in domain

### DIFF
--- a/lib/domains/in/edu/pcenagpur.txt
+++ b/lib/domains/in/edu/pcenagpur.txt
@@ -1,0 +1,3 @@
+Lokmanya Tilak Jankalyan Shikshan Sanstha's Priyadarshini College of Engineering
+Priyadarshini College of Engineering,Nagpur
+Priyadarshini College of Engineering


### PR DESCRIPTION
Domain: pcenagpur.eud.in

Official institution name: Lokmanya Tilak Jankalyan Shikshan Sanstha's Priyadarshini College of Engineering Nagpur(https://pcenagpur.edu.in/)

Official website URL: https://pcenagpur.edu.in/

Proof of long-term IT-related course (> 1 year): https://pcenagpur.edu.in/it_about_department

Proof that pcenagpur.eud.in is official student email domain:
<img width="597" height="1303" alt="student_Domain_usage_proof" src="https://github.com/user-attachments/assets/d8bd6ee2-6aec-4800-bf18-d1e5771fe7a1" />
