### PR TITLE
Add Government Engineering College, Patan (gecpatan.ac.in, gecpat.gujgov.edu.in

### DIFF
--- a/lib/domains/in/ac/gecpatan.txt
+++ b/lib/domains/in/ac/gecpatan.txt
@@ -1,0 +1,1 @@
+Government Engineering College, Patan

--- a/lib/domains/in/edu/gujgov/gecpat.txt
+++ b/lib/domains/in/edu/gujgov/gecpat.txt
@@ -1,0 +1,1 @@
+Government Engineering College, Patan


### PR DESCRIPTION
Official college site: https://gecpatan.ac.in/
About page confirming it's a government institution: https://gecpatan.ac.in/Institute/AboutUs
Both email formats you use (student ID@ and course-code@ style)