### PR TITLE
Add North Idaho College to nic.txt

### DIFF
--- a/lib/domains/edu/nic.txt
+++ b/lib/domains/edu/nic.txt
@@ -1,0 +1,1 @@
+North Idaho College


### PR DESCRIPTION
Adding North Idaho College to the edu domain list.

* Official Website: https://www.nic.edu/
* Proof of long-term IT programs: https://www.nic.edu/programs/computer-information-technology/ (AAS in Computer Information Technology / Network Support)
* Domain proof: nic.edu is the primary domain for faculty and staff, and students are issued @students.nic.edu addresses (covered by this root domain addition).