### PR TITLE
Add Guru Nanak Dev Engineering College (gndec.ac.in)

### DIFF
--- a/lib/domains/in/ac/gndec.txt
+++ b/lib/domains/in/ac/gndec.txt
@@ -1,0 +1,1 @@
+Guru Nanak Dev Engineering College


### PR DESCRIPTION
Adds [Guru Nanak Dev Engineering College](https://www.gndec.ac.in) (gndec.ac.in) to the India academic domains.

- Official website: https://www.gndec.ac.in
- Long-term IT/engineering programs (B.Tech CSE/ECE/IT, M.Tech, Ph.D): https://www.gndec.ac.in
- Student email evidence: GNDEC issues @gndec.ac.in email accounts to students; the college portal (https://erp.gndec.ac.in) uses the college email for student logins.