### PR TITLE
Add ncwu.edu.cn for North China University of Water Resources and Ele…

### DIFF
--- a/lib/domains/cn/edu/ncwu.txt
+++ b/lib/domains/cn/edu/ncwu.txt
@@ -1,0 +1,1 @@
+North China University of Water Resources and Electric Power


### PR DESCRIPTION
…ctric Power

This PR adds the domain ncwu.edu.cn for North China University of Water Resources and Electric Power. The domain is used by students and faculty (e.g., stu.ncwu.edu.cn). It is not in the stoplist or abuse list. Please review and merge. Thank you.