### PR TITLE
Add Blue Ridge Community and Technical College

### DIFF
--- a/lib/domains/edu/blueridgectc.txt
+++ b/lib/domains/edu/blueridgectc.txt
@@ -1,0 +1,1 @@
+Blue Ridge Community and Technical College


### PR DESCRIPTION
Adds the official domain for Blue Ridge Community and Technical College.

- Official college website: https://www.blueridgectc.edu/
- Long-term IT-related program: https://www.blueridgectc.edu/academic-programs/associates-degree-programs/technology/cyber-security/ (Associate Degree in Cyber Security)
- Official student email proof: https://www.blueridgectc.edu/wp-content/uploads/2018/06/Student-Accounts-Log-Ons.pdf

The official student email documentation states that all students receive addresses under `@my.blueridgectc.edu`. Per the repository instructions, adding the parent `blueridgectc.edu` domain also covers that student subdomain.