### PR TITLE
Add Nepal Polytechnic Institute (NPI)

### DIFF
--- a/lib/domains/np/edu/npi.txt
+++ b/lib/domains/np/edu/npi.txt
@@ -1,0 +1,3 @@
+Nepal Polytechnic Institute (NPI)
+Bharatpur, Chitwan, Nepal
+https://npi.edu.np/


### PR DESCRIPTION
Add Nepal Polytechnic Institute (NPI), Bharatpur, Chitwan, Nepal to the domain list for npi.edu.np.

Official website: https://npi.edu.np/