### PR TITLE
Add Institute of Technology of Cambodia

### DIFF
--- a/lib/domains/kh/edu/itc.txt
+++ b/lib/domains/kh/edu/itc.txt
@@ -1,0 +1,1 @@
+Institute of Technology of Cambodia


### PR DESCRIPTION
Adding the official domain for the Institute of Technology of Cambodia to the database.