### PR TITLE
Add Marian Engineering College

### DIFF
--- a/lib/domains/in/ac/marian.txt
+++ b/lib/domains/in/ac/marian.txt
@@ -1,0 +1,1 @@
+Marian Engineering College


### PR DESCRIPTION
Adds Marian Engineering College to the academic domain list for the marian.ac.in email domain.

- Domain: marian.ac.in
- Institution: Marian Engineering College
- File added: lib/domains/in/ac/marian.txt