### PR TITLE
Add bvcits.edu.in - Bonam Venkata Chalamayya Institute of Technology & Science, Amalapuram

### DIFF
--- a/lib/domains/in/edu/bvcits.txt
+++ b/lib/domains/in/edu/bvcits.txt
@@ -1,0 +1,1 @@
+Bonam Venkata Chalamayya Institute of Technology & Science


### PR DESCRIPTION
Adding the domain `bvcits.edu.in` for **Bonam Venkata Chalamayya Institute of Technology & Science** (BVCITS), located in Amalapuram, East Godavari, Andhra Pradesh, India.

**University official website:** https://www.bvcits.edu.in

**IT-related courses (long-term, 1+ year):**
- B.Tech Computer Science & Engineering (4-year)
- - B.Tech CSE - Artificial Intelligence & Machine Learning (4-year)
- - B.Tech CSE - Artificial Intelligence & Data Science (4-year)
- - B.Tech Information Technology (4-year)
- - M.Tech Computer Science Engineering
- - Master of Computer Applications (MCA)
**Domain verification:** `bvcits.edu.in` is the official institutional domain used for student email addresses. The institution is NAAC 'A' Grade accredited and affiliated with JNTUK (Jawaharlal Nehru Technological University Kakinada).

**Courses page:** https://www.bvcits.edu.in