### PR TITLE
Add Manipal Academy of Higher Education (manipalacademyonline.edu.in)

### DIFF
--- a/lib/domains/in/edu/manipalacademyonline.txt
+++ b/lib/domains/in/edu/manipalacademyonline.txt
@@ -1,0 +1,1 @@
+Manipal Academy of Higher Education


### PR DESCRIPTION
Adds the Directorate of Online Education domain of Manipal Academy of Higher Education (MAHE), issued to online degree students (e.g. 26154220152@manipalacademyonline.edu.in).