### PR TITLE
Add R. D. National College information

### DIFF
--- a/lib/domains/in/ac/rdnational.txt
+++ b/lib/domains/in/ac/rdnational.txt
@@ -1,0 +1,2 @@
+R. D. National College
+Rishi Dayaram and Seth Hassaram National College and Seth Wassiamull Assomull Science College


### PR DESCRIPTION
Official website: https://rdnational.ac.in/ (also mirrored at rdnational.net)
Proof of a 1+ year IT-related course: the college's BSc IT program was established in 2001, and its BSc Computer Science program was introduced by the University of Mumbai back in 1999-2000 — both 3-year degree programs. Link to the department pages: [BSc IT](https://rdnational.ac.in/pages/depts/science/it.html) and [BSc Computer Science](https://rdnational.ac.in/pages/depts/science/cs.html)
<img width="1366" height="768" alt="Screenshot (80)" src="https://github.com/user-attachments/assets/69069853-24f8-449e-95a4-dd37e4b64501" />
