### PR TITLE
Add kalvium.community

### DIFF
--- a/lib/domains/community/kalvium.txt
+++ b/lib/domains/community/kalvium.txt
@@ -1,0 +1,1 @@
+Kalvium (Affiliated with University Of Mysore)


### PR DESCRIPTION
Official Website: https://kalvium.community
Proof of student domain recognition: Kalvium uses @kalvium.community for enrolled students.