### PR TITLE
Add Aria University information in aria.txt

### DIFF
--- a/lib/domains/af/edu/aria.txt
+++ b/lib/domains/af/edu/aria.txt
@@ -1,0 +1,2 @@
+دانشگاه آریا
+Aria University


### PR DESCRIPTION
Add Aria University -- aria.edu.af

This pull request adds the official email domain of Aria University in Afghanistan.

Institution

* University: Aria University (دانشگاه آریا)
* Domain: aria.edu.af
* Official website: https://aria.edu.af
* Official Facebook page: https://www.facebook.com/profile.php?id=100068215601672

IT-related program

Aria University offers higher-education programs in Computer Science, satisfying the requirement for a long-term IT-related course.

Official student email domain

Aria University has documented the use of aria.edu.af email addresses for its students, professors, and employees. This demonstrates that @aria.edu.af is an official university email domain rather than a personal or unrelated domain.

Supporting evidence:

* Aria University electronic education documentation: https://pubhtml5.com/ctkt/lbve/basic/
* The documentation identifies official university email addresses using the aria.edu.af domain and states that these addresses were provided to students.

The university’s Facebook page is also included as supporting evidence of its official and active public presence.

Thank you for reviewing this submission.