### PR TITLE
Add aof.anadolu.edu.tr (Anadolu University Open Education Faculty)

### DIFF
--- a/lib/domains/tr/edu/anadolu/aof.txt
+++ b/lib/domains/tr/edu/anadolu/aof.txt
@@ -1,0 +1,2 @@
+Anadolu Üniversitesi Açıköğretim Fakültesi
+Anadolu University Open Education Faculty


### PR DESCRIPTION
This adds `aof.anadolu.edu.tr`, the email domain issued to students of the Open Education Faculty (Açıköğretim Fakültesi) of Anadolu University, a state university in Eskişehir, Turkey.

- The parent domain `anadolu.edu.tr` is already listed in `lib/domains/tr/edu/anadolu.txt`. Open Education Faculty students receive their institutional email under this separate subdomain, which some verification systems check as an exact entry.
- The Open Education Faculty is a degree-granting faculty of Anadolu University: https://www.anadolu.edu.tr/en/open-education/open-education-system
- Email addresses under this domain are issued only to enrolled students.