### PR TITLE
Add Universidade Federal do Norte do Tocantins

### DIFF
--- a/lib/domains/br/edu/ufnt.txt
+++ b/lib/domains/br/edu/ufnt.txt
@@ -1,0 +1,1 @@
+Universidade Federal do Norte do Tocantins


### PR DESCRIPTION
Adds the official email domain ufnt.edu.br for the Universidade Federal do Norte do Tocantins (UFNT). Official website: https://ufnt.edu.br/ | Long-term IT-related course: Software Engineering (4 years): https://ufnt.edu.br/engenhariadesoftware/ | Proof that enrolled undergraduate students receive institutional email addresses ending in @ufnt.edu.br: https://portal.ufnt.edu.br/aluno/login/instrucoes.action