### PR TITLE
Change School's domain to new one

### DIFF
--- a/lib/domains/academy/coastandvale/sc.txt
+++ b/lib/domains/academy/coastandvale/sc.txt
@@ -1,1 +1,0 @@
-Scalby School

--- a/lib/domains/uk/org/scalbyacademy.txt
+++ b/lib/domains/uk/org/scalbyacademy.txt
@@ -1,0 +1,1 @@
+Scalby Academy


### PR DESCRIPTION
Correct Scalby School's domain to sc.coastandvale.academy to scalbyacademy.org.uk after academy merger.