### PR TITLE
Add Yüksek İhtisas Üniversitesi

### DIFF
--- a/lib/domains/tr/edu/yuksekihtisas.txt
+++ b/lib/domains/tr/edu/yuksekihtisas.txt
@@ -1,0 +1,1 @@
+Yüksek İhtisas Üniversitesi


### PR DESCRIPTION
Please add Yüksek İhtisas Üniversitesi to the academic domain list.

University: Yüksek İhtisas Üniversitesi
Domain: yuksekihtisas.edu.tr

Official website:
[https://yuksekihtisasuniversitesi.edu.tr/](https://yuksekihtisasuniversitesi.edu.tr/)

IT-related program:
The university offers a Computer Programming (Bilgisayar Programcılığı) program.
[https://aday.yuksekihtisasuniversitesi.edu.tr/iletisim](https://aday.yuksekihtisasuniversitesi.edu.tr/iletisim)

Proof that the domain belongs to the university:
[https://yuksekihtisasuniversitesi.edu.tr/iletisim](https://yuksekihtisasuniversitesi.edu.tr/iletisim)

The university's official contact directory publicly lists multiple institutional addresses using @yuksekihtisas.edu.tr, including Student Affairs and the Information Technology Department.

My mail address: tayfur.yildiz@yuksekihtisas.edu.tr