### PR TITLE
Add Chulalongkorn University

### DIFF
--- a/lib/domains/th/ac/chula/student.txt
+++ b/lib/domains/th/ac/chula/student.txt
@@ -1,0 +1,3 @@
+จุฬาลงกรณ์มหาวิทยาลัย
+Chulalongkorn University
+CU


### PR DESCRIPTION
Added domain email for only Chulalongkorn's students
Website: https://www.chula.ac.th/
Location: Bangkok, Thailand