### PR TITLE
Glasgow Caledonian University Added student domain

### DIFF
--- a/lib/domains/uk/ac/caledonian/student.txt
+++ b/lib/domains/uk/ac/caledonian/student.txt
@@ -1,0 +1,1 @@
+Glasgow Caledonian University


### PR DESCRIPTION
Glasgow Caledonian University now have caledonian.ac.uk for Student Emails. Staff and admin-related addresses still use the gcu.ac.uk domain, which is why I have not removed that.

Here's is a note from the university website stating that caledonian.ac.uk is used for student emails:
https://www.gcu.ac.uk/currentstudents/support/it/email
