### PR TITLE
Add Alpha Group of Institutions to domains list

### DIFF
--- a/lib/domains/in/edu/alphagroup.txt
+++ b/lib/domains/in/edu/alphagroup.txt
@@ -1,0 +1,1 @@
+Alpha Group of Institutions


### PR DESCRIPTION
## Educational institution

Alpha Group of Institutions

## Domain

alphagroup.edu

## Official website

https://www.alphagroup.edu/

## Verification

The domain alphagroup.edu is used by Alpha Group of Institutions for official institutional email addresses.

The institution offers long-term IT-related programs, including Computer Science Engineering and Information Technology.

Please verify and add alphagroup.edu to the educational domains list.