### PR TITLE
Add Alpha Group of Institutions to domains list

### DIFF
--- a/lib/domains/edu/alphagroup.txt
+++ b/lib/domains/edu/alphagroup.txt
@@ -1,0 +1,1 @@
+Alpha Group of Institutions

--- a/lib/domains/in/edu/alphagroup.txt
+++ b/lib/domains/in/edu/alphagroup.txt
@@ -1,0 +1,1 @@
+Alpha Group of Institutions

--- a/lib/domains/in/edu/alphagroup.txt
+++ b/lib/domains/in/edu/alphagroup.txt
@@ -1,1 +1,0 @@
-Alpha Group of Institutions


### PR DESCRIPTION
Educational institution

Alpha Group of Institutions

Domain

"alphagroup.edu"

Official website

https://www.alphagroup.edu/

Verification

My official student email address uses the "@alphagroup.edu" domain.

The institution offers long-term IT-related programs, including Computer Science Engineering and Information Technology.

Official course information:
https://alphagroup.edu/engineering/computer-science-engineering.php

The requested domain is "alphagroup.edu", not "alphagroup.edu.in".

Please verify and add "alphagroup.edu" to the educational domains list.