### PR TITLE
Add Rajkiya Engineering College Banda to domains

### DIFF
--- a/lib/domains/in/ac/recbanda.txt
+++ b/lib/domains/in/ac/recbanda.txt
@@ -1,0 +1,1 @@
+Rajkiya Engineering College Banda


### PR DESCRIPTION
This PR adds Rajkiya Engineering College Banda to the SWoT database.

Domain: recbanda.ac.in

The domain is used for official student email accounts at Rajkiya Engineering College Banda.