### PR TITLE
Add eng.asu.edu.eg domain for Faculty of Engineering Ain Shams University

### DIFF
--- a/lib/domains/eg/edu/asu/eng.txt
+++ b/lib/domains/eg/edu/asu/eng.txt
@@ -1,0 +1,1 @@
+Faculty of Engineering Ain Shams University


### PR DESCRIPTION
## University Information

**University Official Website:**
https://eng.asu.edu.eg

**1+ Year IT-Related Course Offering:**
Faculty of Engineering - Computer Engineering and Software Systems Program:
https://eng.asu.edu.eg/en/page/97/computer-engineering-and-software-systems

This is a comprehensive 4-year undergraduate program covering software engineering, computer science, and related IT disciplines including:
- Software Engineering
- Computer Programming
- Database Systems
- Distributed Computing
- Operating Systems
- Computer Networks
- Artificial Intelligence
- Cloud Computing
- Web and Mobile Application Development

**Official Email Domain Proof:**
The image below shows official Outlook inbox with the `@eng.asu.edu.eg` email domain being used for enrolled students:

<img width="2553" height="1204" alt="image" src="https://github.com/user-attachments/assets/0bcf730b-000d-4622-9ffa-cfb829521e4e" />

The account `18Q3583@eng.asu.edu.eg` confirms that the eng.asu.edu.eg domain is the official academic email domain for Faculty of Engineering students at Ain Shams University.

**Additional Context:**
Faculty email domains at Ain Shams University follow the pattern: `@[faculty].asu.edu.eg`
- Examples: `@med.asu.edu.eg` (Medicine), `@cis.asu.edu.eg` (Computer & Information Sciences)

**Note:** The broader `asu.edu.eg` domain was previously abused (listed in abused.txt), so this PR specifically adds the Faculty of Engineering subdomain `eng.asu.edu.eg` which provides a more specific and secure email domain for engineering students.