### PR TITLE
Add Alamein International University (aiu.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/aiu.txt
+++ b/lib/domains/eg/edu/aiu.txt
@@ -1,0 +1,1 @@
+Alamein International University


### PR DESCRIPTION
Add Alamein International University under lib/domains/eg/edu/aiu.txt for verification of aiu.edu.eg (requested for Zed Student plan).

Domain: aiu.edu.eg
School: Alamein International University
Reference: https://aiu.edu.eg/ - Presidential Decree 435/2020, New Alamein City, Egypt.