### PR TITLE
Remove jadara.edu.jo from stoplist

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -504,7 +504,6 @@ itsqmet.edu.ec
 itu.ac.tzbjtu.edu.cn
 iumafis.edu.co
 iut.edu.kg
-jadara.edu.jo
 jasukg.me
 jj.edu.kg
 jmu.edu.cn


### PR DESCRIPTION
- Institution Name: Jadara University
- Official Website: https://www.jadara.edu.jo
- Domain: jadara.edu.jo
- Country: Jordan
- Details: Accredited university offering higher education degrees in IT, Computer Science, and Software Engineering.