### PR TITLE
Add Institut Teknologi PLN (itpln.ac.id)

### DIFF
--- a/lib/domains/id/ac/itpln.txt
+++ b/lib/domains/id/ac/itpln.txt
@@ -1,0 +1,1 @@
+Institut Teknologi PLN


### PR DESCRIPTION
## Institution

Institut Teknologi PLN (ITPLN)

## Domain

itpln.ac.id

## Evidence

- Official university website:
  https://itpln.ac.id/

- Official ITPLN FAQ/student information confirming the institutional email domain:
  https://infopmb.itpln.ac.id/faq/

- Official S1 Teknik Informatika program information:
  https://infopmb.itpln.ac.id/s1-teknik-informatika/

  The S1 Teknik Informatika program is an 8-semester undergraduate program and therefore exceeds the one-year minimum requirement.

- Official ITPLN accreditation information:
  https://itpln.ac.id/accreditation.html

## Verification

The `itpln.ac.id` domain is an official institutional email domain used by Institut Teknologi PLN students.

This PR adds the domain so that students using an `@itpln.ac.id` email address can be recognized by services relying on the JetBrains SWoT repository.