### PR TITLE
Add Kafrelsheikh University

### DIFF
--- a/lib/domains/eg/edu/kfs.txt
+++ b/lib/domains/eg/edu/kfs.txt
@@ -1,0 +1,1 @@
+Kafrelsheikh University


### PR DESCRIPTION
Adds the official domain of **Kafrelsheikh University** (Egypt) — `kfs.edu.eg`.

- New file: `lib/domains/eg/edu/kfs.txt` containing `Kafrelsheikh University`
- Official name verified from the university's own website: https://www.kfs.edu.eg
- Student/staff emails are issued under subdomains of the registrable domain (e.g. `user@com.kfs.edu.eg`, `president@kfs.edu.eg`) — this single entry covers all of them
- Not on the stoplist or abuse list; not an alumni domain