### PR TITLE
Add Faculty of Engineering entry to eng.txt

### DIFF
--- a/lib/domains/eg/edu/asu/eng.txt
+++ b/lib/domains/eg/edu/asu/eng.txt
@@ -1,0 +1,1 @@
+Faculty of Engineering, Ain Shams University


### PR DESCRIPTION
Adds the student email domain eng.asu.edu.eg for the Faculty of Engineering, Ain Shams University.

This domain is used for student email addresses at the Faculty of Engineering, Ain Shams University.