### PR TITLE
Add European University of Tirana

### DIFF
--- a/lib/domains/al/edu/uet.txt
+++ b/lib/domains/al/edu/uet.txt
@@ -1,0 +1,2 @@
+Universiteti Europian i Tiranës
+European University of Tirana


### PR DESCRIPTION
This PR adds the academic domain uet.edu.al for the European University of Tirana (Universiteti Europian i Tiranës) in Albania.

The university's official website is: https://uet.edu.al/

UET is an accredited higher education institution offering Bachelor and Master programs, including programs in Information Technology and Informatics Engineering.