### PR TITLE
Add Shin Ansan University

### DIFF
--- a/lib/domains/kr/ac/sau.txt
+++ b/lib/domains/kr/ac/sau.txt
@@ -1,0 +1,2 @@
+신안산대학교
+Shin Ansan University


### PR DESCRIPTION
Add Shin Ansan University (신안산대학교) for the sau.ac.kr academic email domain.

The university provides @sau.ac.kr email accounts to enrolled students.
Supporting evidence can be provided if required.