### PR TITLE
Add o365.cku.ac.kr domain

### DIFF
--- a/lib/domains/kr/ac/cku/o365.txt
+++ b/lib/domains/kr/ac/cku/o365.txt
@@ -1,0 +1,2 @@
+가톨릭관동대학교
+Catholic Kwandong University


### PR DESCRIPTION
Add o365.cku.ac.kr domain. For Catholic Kwandong University.

