### PR TITLE
Add Yazd University email domain

### DIFF
--- a/lib/domains/ir/ac/yazd.txt
+++ b/lib/domains/ir/ac/yazd.txt
@@ -1,0 +1,1 @@
+Yazd University


### PR DESCRIPTION
University: Yazd University

Official website:
https://www.yazd.ac.ir

Student email domain:
stu.yazd.ac.ir

Main domain:
yazd.ac.ir

Example student email:
student@stu.yazd.ac.ir

The university issues student email addresses under the subdomain stu.yazd.ac.ir, which belongs to the main domain yazd.ac.ir.