### PR TITLE
Add cis.txt for Ain Shams University details

### DIFF
--- a/lib/domains/eg/edu/asu/alsun/cis.txt
+++ b/lib/domains/eg/edu/asu/alsun/cis.txt
@@ -1,0 +1,2 @@
+Ain Shams University
+Faculty of Computer and Information Sciences


### PR DESCRIPTION
Add cis.asu.edu.eg as an educational email domain for Ain Shams University Faculty of Computer and Information Sciences.

Official university website:
https://www.asu.edu.eg/

Official faculty website:
https://cis.asu.edu.eg/

The institution offers long-term IT-related undergraduate programs in Computer Science and related fields.

The submitted domain cis.asu.edu.eg is used for official university email accounts for enrolled students at the Faculty of Computer and Information Sciences.

Student email example:
20241700296@cis.asu.edu.eg