### PR TITLE
Add University of the Visayas to domain list

### DIFF
--- a/lib/domains/ph/edu/uv.txt
+++ b/lib/domains/ph/edu/uv.txt
@@ -1,0 +1,1 @@
+University of the Visayas


### PR DESCRIPTION
School: University of the Visayas
Domain: uv.edu.ph
Official website: https://www.uv.edu.ph/