### PR TITLE
Add thaimooc.ac.th

### DIFF
--- a/lib/domains/th/ac/thaimooc.txt
+++ b/lib/domains/th/ac/thaimooc.txt
@@ -1,0 +1,2 @@
+โครงการมหาวิทยาลัยไซเบอร์ไทย
+Thailand Cyber University


### PR DESCRIPTION
Adding the domain thaimooc.ac.th for Thailand Cyber University Project (TCU) Ministry of Higher Education, Ratchathewi District, Bangkok

- Website: https://thaimooc.ac.th

ThaiMOOC is Thailand's largest hub for courses, for improve cyber tech in thailand.