### PR TITLE
Add SHUATS student email domain

### DIFF
--- a/lib/domains/in/edu/shiats.txt
+++ b/lib/domains/in/edu/shiats.txt
@@ -1,0 +1,1 @@
+Sam Higginbottom University of Agriculture, Technology and Sciences


### PR DESCRIPTION
This PR adds the Sam Higginbottom University of Agriculture, Technology and Sciences (SHUATS) student email domain.

Student email domain:
26bba003@shiats.edu.in