### PR TITLE
Add Universitas Indonesia (ui.ac.id)

### DIFF
--- a/lib/domains/id/ac/ui.txt
+++ b/lib/domains/id/ac/ui.txt
@@ -1,0 +1,2 @@
+Universitas Indonesia
+University of Indonesia


### PR DESCRIPTION
Add the \ui.ac.id\ domain for **Universitas Indonesia** (University of Indonesia). It is the official email domain issued to enrolled students and staff via the university's SSO accounts (e.g. \riffudin@ui.ac.id\).

To help with the verification process:

- **University official website:** https://www.ui.ac.id
- **IT-related course (longer than 1 year):** Bachelor of Computer Science (S1 Ilmu Komputer, 4-year / 144 SKS program) at the Faculty of Computer Science (Fasilkom UI): https://cs.ui.ac.id/sarjana-ilmu-komputer/
- **Proof that the domain is the official student/staff email domain:** official IT service guide from DSTI UI: https://dsti.ui.ac.id/menggunakan-email-ui/ (email with the \@ui.ac.id\ domain is provided to all active Civitas Academica UI); webmail at https://webmail.ui.ac.id