### PR TITLE
Add ndlp.txt for National Digital Learning Platform

### DIFF
--- a/lib/domains/th/go/ndlp.txt
+++ b/lib/domains/th/go/ndlp.txt
@@ -1,0 +1,1 @@
+National Digital Learning Platform


### PR DESCRIPTION
Add National Digital Learning Platform in Thailand

- Website: https://ndlp.go.th

A digital platform under the Ministry of Education's "Anywhere Anytime Learning" policy, which aims to provide all Thai children with equal access to quality learning resources, regardless of their location in the country.