### PR TITLE
Add iau.ir domain for Islamic Azad University

### DIFF
--- a/lib/domains/ir/iau.txt
+++ b/lib/domains/ir/iau.txt
@@ -1,0 +1,1 @@
+Islamic Azad University


### PR DESCRIPTION
This PR adds the domain iau.ir to the school database.

- Official website: https://www.iau.ir/
- Domain is used for student and staff email addresses.
- The university offers long-term IT and computer science programs (including Bachelor's, Master's, and PhD).
- Subdomains like student.iau.ir are automatically covered by this addition.