### PR TITLE
Add STI College Global City

### DIFF
--- a/lib/domains/ph/edu/sti/globalcity.txt
+++ b/lib/domains/ph/edu/sti/globalcity.txt
@@ -1,0 +1,1 @@
+STI College Global City


### PR DESCRIPTION
Adds the `globalcity.sti.edu.ph` campus domain to SWOT so that student email addresses from STI College Global City (e.g. `astor.336439@globalcity.sti.edu.ph`) are recognized as academic.

- New file: `lib/domains/ph/edu/sti/globalcity.txt`
- Contents: `STI College Global City`

Follows the existing STI campus convention in `lib/domains/ph/edu/sti/`.