### PR TITLE
Add Federal University of Technology Akure (futa.edu.ng)

### DIFF
--- a/lib/domains/ng/edu/futa.txt
+++ b/lib/domains/ng/edu/futa.txt
@@ -1,0 +1,1 @@
+Federal University of Technology Akure


### PR DESCRIPTION
Add FUTA to the swot database.

**Domain:** `futa.edu.ng` (covers `@futa.edu.ng` and all subdomains like `@st.futa.edu.ng`, `@student.futa.edu.ng`)

**File:** `lib/domains/ng/edu/futa.txt`
**Contents:** `Federal University of Technology Akure`

**University official website:** https://www.futa.edu.ng (also https://futa.edu.ng)

**IT-related long-term courses (>1 year):**
- B.Tech. Computer Science - https://csc.futa.edu.ng/ (5-year programme, School of Computing)
- B.Tech. Software Engineering - https://sen.futa.edu.ng/
- B.Tech. Information Systems - https://ifs.futa.edu.ng/
- B.Eng. Computer Engineering - https://cpe.futa.edu.ng/ (via SEET)
- All are 5-year B.Tech/B.Eng programmes.

**Proof that `futa.edu.ng` is the official student email domain:**
- FUTA Student Portal (FIRARS) shows student email login info: https://firars.futa.edu.ng/app/student/ugdashboard - students retrieve their `@futa.edu.ng` address and password there and access via "FUTA Webmail" (live.futa.edu.ng)
- FUTA webmail portal: http://live.futa.edu.ng (Microsoft 365 login, domain futa.edu.ng)
- Example format: `surname+matric@futa.edu.ng` (e.g., olapadepmt113014@futa.edu.ng) - documented by student guide: https://www.linkedin.com/posts/oluwagbengaakingbodi_futa-emailaccess-universitylife-activity-7231696303469023234-ie8B
- Email format aggregated: https://www.signalhire.com/companies/federal-university-of-technology-akure/email-format (lists @futa.edu.ng formats)
- University Wikipedia: https://en.wikipedia.org/wiki/Federal_University_of_Technology_Akure confirms website www.futa.edu.ng

**Institution type:** Federal government-owned university established 1981, physical campus in Akure, Ondo State, Nigeria. Recognized by NUC. 31,000+ students.

**Checklist:**
- [x] Domain used by educational institution offering IT-related long-term course
- [x] Single .txt file with official name on first line
- [x] Not a stoplisted/abused domain
