### PR TITLE
Add Wenzhou University of Technology (wzut.edu.cn)

### DIFF
--- a/lib/domains/cn/edu/wzut.txt
+++ b/lib/domains/cn/edu/wzut.txt
@@ -1,0 +1,1 @@
+Wenzhou University of Technology


### PR DESCRIPTION
Add Wenzhou University of Technology (温州理工学院)

- Domain: wzut.edu.cn
- English name: Wenzhou University of Technology (official, per school charter)
- Official website: https://www.wzut.edu.cn  /  https://en.wzut.edu.cn
- Public undergraduate university in Wenzhou, Zhejiang, China (established 2021, formerly Wenzhou University Oujiang College)
- Note: .edu.cn domains generally cannot be verified via whois; please confirm via the official website above.

Proof for faster review (per 'How to add the domain quicker'):
- Long-term (>1 year) IT-related programmes (4-year BEng): official programmes page https://en.wzut.edu.cn/art/art_1096/art_66520.html (Computer Science and Technology, Data Science and Big Data Technology, Internet of Things Engineering, Computing Engineering - all 4 years)
- Official email domain confirmation: school mail system login uses @wzut.edu.cn https://mail.wzut.edu.cn/

Data file added: lib/domains/cn/edu/wzut.txt
