### PR TITLE
Adding Government College of Engineering and Textile Technology Serampore entry

### DIFF
--- a/lib/domains/in/ac/gcetts.txt
+++ b/lib/domains/in/ac/gcetts.txt
@@ -1,0 +1,1 @@
+Government College of Engineering & Textile Technology, Serampore


### PR DESCRIPTION
Adding domain for Government College of Engineering & Textile Technology, Serampore.

- Official Website: https://gcetts.ac.in/
- Proof of long-term IT courses: The college offers a 4-year B.Tech in Information Technology (https://gcetts.ac.in/departments.html?d=IT).
- Domain usage: Students are officially provided with the @gcetts.ac.in domain.