### PR TITLE
Add Shandong Normal University student email domain

### DIFF
--- a/lib/domains/cn/edu/sdnu/stu.txt
+++ b/lib/domains/cn/edu/sdnu/stu.txt
@@ -1,0 +1,2 @@
+Shandong Normal University
+山东师范大学(学生邮箱)


### PR DESCRIPTION
Add the dedicated student email domain `stu.sdnu.edu.cn` of **Shandong Normal University (山东师范大学)**, China.

Example email: `2024304038@stu.sdnu.edu.cn`

The parent domain `sdnu.edu.cn` is already registered (`lib/domains/cn/edu/sdnu.txt`); this PR registers the student email subdomain explicitly, following the existing convention (cf. `lib/domains/cn/edu/cjlu/stu.txt`, `lib/domains/cn/edu/aynu/stu.txt`).

Evidence:

- Official student mail portal: http://mail.stu.sdnu.edu.cn/
- University homepage with a 学生邮箱 (student mailbox) link: https://www.sdnu.edu.cn/
- Official notice on opening campus email service for 2025 freshmen: https://www.sdnu.edu.cn/tzgg/cktzgggd/27.htm
- Email system announcement describing student login at `mail.stu.sdnu.edu.cn`: https://qlshx.sdnu.edu.cn/info/10435/129139.htm
