### PR TITLE
Restore California State University, Northridge

### DIFF
--- a/lib/domains/edu/csun.txt
+++ b/lib/domains/edu/csun.txt
@@ -1,0 +1,1 @@
+California State University, Northridge


### PR DESCRIPTION
Restore csun.edu as an official email domain of California State University, Northridge.