### PR TITLE
Add Shandong University of Finance and Economics (sdufe.edu.cn)

### DIFF
--- a/lib/domains/cn/edu/sdufe.txt
+++ b/lib/domains/cn/edu/sdufe.txt
@@ -1,0 +1,2 @@
+Shandong University of Finance and Economics
+山东财经大学


### PR DESCRIPTION
## Summary

Add the domain `sdufe.edu.cn` for **Shandong University of Finance and Economics** (山东财经大学).

- New file: `lib/domains/cn/edu/sdufe.txt`
- First line: `Shandong University of Finance and Economics`
- Second line: `山东财经大学` (native name)

## Verification

**1. Official website**

The submitted domain is the university's primary domain, hosting the official site `www.sdufe.edu.cn` and its subdomains.

**2. Long-term (>1 year) IT-related courses**

The School of Computer and Artificial Intelligence offers four-year bachelor's programs in Computer Science and Technology, Digital Media Technology and Artificial Intelligence (both CS and Digital Media Technology are national first-class undergraduate programs), plus master's and doctoral programs:
- https://cs.sdufe.edu.cn/xygk/xyjj.htm — college overview, undergraduate/masters/doctoral programs in computer science
- https://yjszs.sdufe.edu.cn/info/1089/2406.htm — graduate admissions, 3-year full-time CS master's programs

**3. Official email domain proof**

The university officially provides every enrolled student with a free lifelong email account under the `mail.sdufe.edu.cn` domain (format: `studentID@mail.sdufe.edu.cn`):
- https://www.sdufe.edu.cn/info/1068/4512.htm — official notice (in Chinese) announcing the lifelong student email service on the `sdufe.edu.cn` domain
- https://nic.sdufe.edu.cn/info/1025/1496.htm — network & IT office email service page

As `mail.sdufe.edu.cn` is a subdomain of the submitted `sdufe.edu.cn`, it is automatically covered by adding the parent domain, per the README guidance.
