### PR TITLE
Add gcoea.ac.in (Government College of Engineering, Amravati)

### DIFF
--- a/lib/domains/in/ac/gcoea.txt
+++ b/lib/domains/in/ac/gcoea.txt
@@ -1,0 +1,2 @@
+Government College of Engineering, Amravati
+GCOEA


### PR DESCRIPTION
Adding gcoea.ac.in for Government College of Engineering, Amravati (GCOEA), a public engineering college in Amravati, Maharashtra, India, established in 1964.

- Official website: https://gcoea.ac.in
- Offers a 4-year B.Tech in Computer Science & Engineering (long-term, IT-related course): https://gcoea.ac.in (Departments section)
- Affiliated to Sant Gadge Baba Amravati University, AICTE approved
- I am a current student with an official college email on this domain (screenshot attached)
<img width="507" height="151" alt="Screenshot 2026-08-22 190653" src="https://github.com/user-attachments/assets/34aec450-bb1a-4757-add1-5e7a5a79023f" />
