### PR TITLE
Add Clarence Fitzroy Bryant College (cfbc.edu.kn)

### DIFF
--- a/lib/domains/kn/edu/cfbc.txt
+++ b/lib/domains/kn/edu/cfbc.txt
@@ -1,0 +1,1 @@
+Clarence Fitzroy Bryant College


### PR DESCRIPTION
## Institution Details

- **Institution:** Clarence Fitzroy Bryant College (CFBC)
- **Country:** Saint Kitts and Nevis
- **Domain:** `cfbc.edu.kn`
- **Official website:** https://cfbc.edu.kn/

## Verification

### Long-term IT-related programme

CFBC offers a two-year Associate in Applied Science degree in Information Technology:

https://cfbc.edu.kn/information-technology/

The programme includes courses such as Computer Science, Software Engineering,
Structured Programming, Fundamentals of Networks, Web Page Design, and Data Security.

### Student email domain

CFBC provides enrolled students with institution-issued email accounts under
the `@my.cfbc.edu.kn` subdomain, while institutional staff use addresses under
`@cfbc.edu.kn`.

The official CFBC Current Student portal references students' "CFBC email":

https://cfbcsonis.jenzabarcloud.com/studsect.cfm

I have attached a redacted screenshot of my institution-issued Google account.
The account uses the `@my.cfbc.edu.kn` student subdomain and Google identifies
the account as "Managed by cfbc.edu.kn".

<img width="504" height="338" alt="CFBC student Google account showing my.cfbc.edu.kn and managed by cfbc.edu.kn" src="https://github.com/user-attachments/assets/fcfd270d-1073-43ec-8b1b-16df6bb398af" />

Per the repository's domain rules, adding the parent `cfbc.edu.kn` domain also
covers the `my.cfbc.edu.kn` student subdomain.

### Physical institution

CFBC is a physical tertiary education institution with multiple campuses in
Saint Kitts and Nevis:

https://cfbc.edu.kn/campuses/

### Additional verification

The Saint Kitts and Nevis Ministry of Education directory lists Clarence Fitzroy
Bryant College and personnel using the `@cfbc.edu.kn` domain:

https://education.gov.kn/directory/