### PR TITLE
Add Wakayama Medical University

### DIFF
--- a/lib/domains/jp/ac/wakayama-med.txt
+++ b/lib/domains/jp/ac/wakayama-med.txt
@@ -1,0 +1,2 @@
+和歌山県立医科大学
+Wakayama Medical University


### PR DESCRIPTION
This PR adds the official student email domain for Wakayama Medical University.

### Domain

`wakayama-med.ac.jp`

### Official website

https://www.wakayama-med.ac.jp/

### Proof that this domain is provided to enrolled students

https://www.wakayama-med.ac.jp/gakunai/mail_new_gakusei.html

The university's official student email documentation states that university email addresses use the `@wakayama-med.ac.jp` domain and provides instructions for undergraduate and graduate students whose email addresses are issued by the university.

### Proof of long-term IT-related education

https://www.wakayama-med.ac.jp/dept/daigakuin-sougou/taisei/index.html

Wakayama Medical University's Graduate School of Medical and Pharmaceutical Sciences offers a Medical Data Science Course in its master's and doctoral programs. The standard study periods are two years for the master's program and three years for the doctoral program.

The curriculum includes medical data science education covering R, regression and analysis of variance, basic programming techniques, and the use of medical information:

https://www.wakayama-med.ac.jp/dept/daigakuin-sougou/senkou/hakase2y/katei.html
