### PR TITLE
Remove st.vvu.edu.gh from stoplist - official student domain of Valley View University

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -1296,7 +1296,6 @@ kwcollege.nl
 isbatuniversity.com
 axiscolleges.in
 futureskills.co.nz
-st.vvu.edu.gh
 o365.nitp.ac.in
 colegiocalasanz.edu.ni
 adenformations.com


### PR DESCRIPTION
Valley View University (vvu.edu.gh) is already approved in lib/domains/gh/edu/vvu.txt but its official student subdomain st.vvu.edu.gh is incorrectly in stoplist, causing isAcademic() to return false for xxx@st.vvu.edu.gh.

Proof:
- Official website: https://vvu.edu.gh/
- Student email proof: https://vvu.edu.gh/student-email.php shows @st.vvu.edu.gh on Google Workspace (mail.google.com/a/st.vvu.edu.gh)
- IT courses >1 year: https://vvu.edu.gh/course_details.php?id=4 (BSc Information Technology, 4 Years) and https://vvu.edu.gh/course_details.php?id=59 (BSc Computer Science, 4 Years) Overview: https://vvu.edu.gh/academic_programs_overview.php

Fix: remove st.vvu.edu.gh from stoplist - vvu.edu.gh coverage then correctly includes st.vvu.edu.gh per README (subdomains included).