### PR TITLE
Add stu.ouc.edu.cn

### DIFF
--- a/lib/domains/cn/edu/ouc/stu.txt
+++ b/lib/domains/cn/edu/ouc/stu.txt
@@ -1,0 +1,2 @@
+中国海洋大学
+Ocean University of China


### PR DESCRIPTION
Add (https://stu.ouc.edu.cn/)
Extended description:
Add Ocean University of China student subdomain
IT-related program page:
https://it.ouc.edu.cn/2026/0402/c21608a523679/page.htm
Proof that stu.ouc.edu.cn is an official student email domain:
http://nic.ouc.edu.cn/2018/0105/c4688a132953/pagem.htm