### PR TITLE
Add Universidad Autónoma de Nuevo León extra domain

### DIFF
--- a/lib/domains/mx/edu/uanl.txt
+++ b/lib/domains/mx/edu/uanl.txt
@@ -1,0 +1,1 @@
+Universidad Autónoma de Nuevo León


### PR DESCRIPTION
uanl.mx was added before but not uanl.edu.mx