### PR TITLE
Add Polytechnic University of the Philippines student email domain

### DIFF
--- a/lib/domains/ph/edu/pup/iskolarngbayan.txt
+++ b/lib/domains/ph/edu/pup/iskolarngbayan.txt
@@ -1,0 +1,1 @@
+Polytechnic University of the Philippines


### PR DESCRIPTION
Adds the official student email domain iskolarngbayan.pup.edu.ph
for Polytechnic University of the Philippines.

University: Polytechnic University of the Philippines
Domain: iskolarngbayan.pup.edu.ph
Official website: https://www.pup.edu.ph/

This domain is used for official PUP student email accounts.