### PR TITLE
Add student email subdomain stu.sicau.edu.cn for Sichuan Agricultural University

### DIFF
--- a/lib/domains/cn/edu/sicau/stu.txt
+++ b/lib/domains/cn/edu/sicau/stu.txt
@@ -1,0 +1,1 @@
+Sichuan Agricultural University


### PR DESCRIPTION
The parent domain `sicau.edu.cn` is already listed, but the verification system checks the exact domain, so student emails `@stu.sicau.edu.cn` are rejected with "This domain is not yet part of the open source database".

- Official website: https://www.sicau.edu.cn
- `stu.sicau.edu.cn` is the email domain assigned to enrolled students of Sichuan Agricultural University
- Similar student-subdomain PRs have been merged before (e.g. #40890, #40479)