### PR TITLE
Add North China Electric Power University

### DIFF
--- a/lib/domains/cn/edu/ncepu.txt
+++ b/lib/domains/cn/edu/ncepu.txt
@@ -1,0 +1,2 @@
+华北电力大学
+North China Electric Power University


### PR DESCRIPTION
Add North China Electric Power University (华北电力大学).

- Official university website:
  https://www.ncepu.edu.cn/

- Official page for the Computer Science and Technology program:
  https://cs.ncepu.edu.cn/jxgz/bks/jxwj/249c5d49fd7b4d68a030030f1232b8c6.htm

  The university offers a four-year undergraduate program in Computer Science and Technology, satisfying the requirement for a long-term (>1 year) IT-related course.

- Official student email service information:
  https://its.ncepu.edu.cn/wxfw/bjxb/yzfw/index.htm

  According to the university's official IT service page, email service is provided to all currently enrolled students and faculty members. Email addresses use the format student/staff ID @ncepu.edu.cn.

Therefore, `ncepu.edu.cn` is an official email domain used by enrolled students of North China Electric Power University.