### PR TITLE
Add Kings college of engineering

### DIFF
--- a/lib/domains/in/edu/kingsengg.txt
+++ b/lib/domains/in/edu/kingsengg.txt
@@ -1,0 +1,1 @@
+Kings college of engineering


### PR DESCRIPTION
This pull request adds the `kingsengg.edu.in` domain for Kings College of Engineering.

The domain is used for official student email addresses, including:

`iicse001@kingsengg.edu.in`

This will allow eligible students of Kings College of Engineering to be recognized by services using the JetBrains SWoT database for student verification.