### PR TITLE
Add October 6 University student email domain

### DIFF
--- a/lib/domains/eg/edu/o6u.txt
+++ b/lib/domains/eg/edu/o6u.txt
@@ -1,0 +1,2 @@
+جامعة 6 أكتوبر
+October 6 University


### PR DESCRIPTION
This pull request adds the official student email domain of October 6 University:

Domain:
o6u.edu.eg

Official university website:
https://o6u.edu.eg/

IT-related long-term course:
https://o6u.edu.eg/dpages.aspx?FactId=14&id=1013

Official proof that o6u.edu.eg is used for student email:
https://o6u.edu.eg/uploads/IsCS/updates2023/Student%20Guide%281%29.pdf?FactId=14&id=920

The university offers long-term higher-education programs related to Information Technology and Computer Science, and the official student guide confirms the use of the o6u.edu.eg email domain.