### PR TITLE
Add University of Makati student email domain

### DIFF
--- a/lib/domains/ph/edu/jru.txt
+++ b/lib/domains/ph/edu/jru.txt
@@ -1,0 +1,3 @@
+José Rizal University
+Jose Rizal University
+JRU

--- a/lib/domains/ph/edu/umak.txt
+++ b/lib/domains/ph/edu/umak.txt
@@ -1,0 +1,1 @@
+University of Makati


### PR DESCRIPTION
Adds the official academic email domain for the University of Makati.

University: University of Makati
Domain: umak.edu.ph
Official website: https://www.umak.edu.ph/

The domain is used for official University of Makati email accounts.