### PR TITLE
Added University of Batangas

### DIFF
--- a/lib/domains/ph/edu/ub.txt
+++ b/lib/domains/ph/edu/ub.txt
@@ -1,0 +1,3 @@
+University of Batangas
+University Domain: ub.edu.ph
+IT Page Url: https://ub.edu.ph/ubbc/information-and-communications-technology/


### PR DESCRIPTION
This pull request adds the official student email domain of University of Batangas

**University Domain:
 ub.edu.ph**

**IT - Related University Page: 
https://ub.edu.ph/ubbc/information-and-communications-technology/**

