### PR TITLE
Add José Rizal University information

### DIFF
--- a/lib/domains/ph/edu/jru.txt
+++ b/lib/domains/ph/edu/jru.txt
@@ -1,0 +1,3 @@
+José Rizal University
+Jose Rizal University
+JRU


### PR DESCRIPTION
Adds the official email domain jru.edu for José Rizal University (JRU). 

University: José Rizal University
Domain: jru.edu
Official website: https://jru.edu
Proof of domain ownership: 
- Official website uses jru.edu (https://jru.edu)
- Official contact email support@jru.edu, as listed on JRU's Facebook page  (https://www.facebook.com/JoseRizalUniversity/)
- Listed under Philippine Association of Colleges and Universities (PACU)  directory with the same domain (https://www.pacu.org.ph/team/jose-rizal-university/)