### PR TITLE
Add Tecnológico de Antioquia (tdea.edu.co)

### DIFF
--- a/lib/domains/co/edu/tdea.txt
+++ b/lib/domains/co/edu/tdea.txt
@@ -1,0 +1,2 @@
+Tecnológico de Antioquia
+TdeA


### PR DESCRIPTION
Adds **Tecnológico de Antioquia (TdeA)** — Institución Universitaria in Medellín, Colombia.

## Official website
https://www.tdea.edu.co/

## Long-term IT-related programs (>1 year)
https://tdea.edu.co/facultades/facultad-de-ingenieria/

- **Ingeniería en Software** — 9 semesters — SNIES 106476
- **Tecnología en Gestión Informática** (virtual) — 6 semesters — SNIES 109518
- **Maestría en Gestión de Tecnología de la Información** — SNIES 105966
- **Especialización en Seguridad de la Información** — SNIES 102735
- **Técnica Profesional en Sistemas** — 4 semesters — SNIES 10171 (acreditada Alta Calidad)

## Proof that tdea.edu.co is the institution's official email domain
1. https://www.tdea.edu.co/ — institutional footer lists official `@tdea.edu.co` addresses (notificacion.archivo@tdea.edu.co, notificacionesjudiciales@tdea.edu.co, atencionalcliente@tdea.edu.co, juridica@tdea.edu.co, auxiliar.financiera@tdea.edu.co, atencion.admisiones1@tdea.edu.co) and states that student credentials are "enviados a tu correo" institucional.
2. https://tdea.edu.co/facultades/facultad-de-ingenieria/ — public faculty directory lists 20+ faculty members' official `@tdea.edu.co` emails (e.g. dsoto@tdea.edu.co, fvargas@tdea.edu.co, sgomezja@tdea.edu.co, rbotero@tdea.edu.co) and program-coordination addresses (fac.ingenieria@tdea.edu.co, coor.informatica@tdea.edu.co).
3. https://virtual.tdea.edu.co/ — official Moodle-based virtual campus operated by the "Unidad de Virtualidad del Tecnológico de Antioquia", with `virtual@tdea.edu.co` as its contact address.

## Accreditation
TdeA is a recognized Institución Universitaria under the Colombian Ministry of Education (Decreto 1295 de 2010), with 26,752 enrolled students and 13 high-quality accredited programs.