### PR TITLE
Add HUFLIT student email domain

### DIFF
--- a/lib/domains/vn/edu/huflit/st.txt
+++ b/lib/domains/vn/edu/huflit/st.txt
@@ -1,0 +1,2 @@
+Trường Đại học Ngoại ngữ - Tin học Thành phố Hồ Chí Minh
+Ho Chi Minh City University of Foreign Languages - Information Technology (HUFLIT)


### PR DESCRIPTION
Adds the official HUFLIT student email subdomain st.huflit.edu.vn.

Verification:
- Official university website: https://huflit.edu.vn/
- Information Technology program: https://huflit.edu.vn/en/dai-hoc/cntt-en/ — Bachelor’s degree, full-time, 3.5 years.
- Official student-email FAQ: https://huflit.edu.vn/en/experience-at-huflit/frequently-asked-questions/ — student email format is student-id@st.huflit.edu.vn.