### PR TITLE
Add East China University of Political Science and Law

### DIFF
--- a/lib/domains/cn/ecupl.txt
+++ b/lib/domains/cn/ecupl.txt
@@ -1,0 +1,2 @@
+华东政法大学
+East China University of Political Science and Law


### PR DESCRIPTION
Add East China University of Political Science and Law (华东政法大学).

Domain: `ecupl.edu.cn`

* Official university website:
  https://www.ecupl.edu.cn/

* IT-related long-term program:

  East China University of Political Science and Law offers a long-term undergraduate program in Computer Science and Technology, including a Network and Information Security direction.

* Official student email service:

  ECUPL provides institutional email accounts to enrolled students. Student email addresses use the `@ecupl.edu.cn` domain.

Therefore, `ecupl.edu.cn` is an official educational email domain used by East China University of Political Science and Law.
