### PR TITLE
Add utpl.edu.ec (Universidad Técnica Particular de Loja)

### DIFF
--- a/lib/domains/ec/edu/utpl.txt
+++ b/lib/domains/ec/edu/utpl.txt
@@ -1,0 +1,1 @@
+Universidad Técnica Particular de Loja


### PR DESCRIPTION
Adds `lib/domains/ec/edu/utpl.txt` for utpl.edu.ec, the domain of Universidad Técnica Particular de Loja, a private university in Loja, Ecuador.

Official site: https://www.utpl.edu.ec