### PR TITLE
Add taalim.ma - Ministère de l'Éducation Nationale / Lycée Moulay Al Hassan Tanger (CPGE)

### DIFF
--- a/lib/domains/ma/taalim.txt
+++ b/lib/domains/ma/taalim.txt
@@ -1,0 +1,3 @@
+Ministère de l'Éducation Nationale, du Préscolaire et des Sports - Maroc
+Lycée Moulay Al Hassan - Tanger
+.group


### PR DESCRIPTION
## Add `taalim.ma` — Moroccan Ministry of National Education / Lycée Moulay Al Hassan - Tanger

**Domain added:** `taalim.ma` (`lib/domains/ma/taalim.txt`)

### Why this domain should be included
`X123456789@taalim.ma` is the official student email issued by the **Moroccan Ministry of National Education, Preschool and Sports (Ministère de l'Éducation Nationale, du Préscolaire et des Sports - Maroc)** to every public school student. The local part is the national **Massar code** (`[A-Z]` + 9 digits), e.g. `A123456789@taalim.ma`, `M123456789@taalim.ma`, `J123456789@taalim.ma` — the letter varies by academy/year, not only `A`.

The domain is shared across thousands of lycées nationwide (hence `.group` on line 3), and is **retained for all post-bac programs hosted inside lycées** — most importantly **CPGE and BTS (2-year, >1 year, IT-related)**. This is not a primary/secondary-only use.

### Proof that `taalim.ma` is an official academic email domain
- Official Ministry website: https://www.men.gov.ma
- Massar / Taalim portal: https://massar.men.gov.ma — https://taalim.ma
- All public Moroccan students receive `CodeMassar@taalim.ma` (e.g. `X#########@taalim.ma`) for Microsoft 365 / Google Workspace (Outlook `outlook.office365.com`). Screenshot of inbox (`X...@taalim.ma` on `taalim.ma`) can be provided on request — owner has provided proof image.
- Ministry documentation shows `taalim.ma` as the designated student email domain for the entire public system.

### Proof of long-term IT-related courses (>1 year) using `taalim.ma`

> JetBrains requires: *long-term course (≥1 year) related to IT, plus recognized physical attendance / accredited institution.* All below are 2-year post-bac programs **hosted in lycées** where students keep their `X...@taalim.ma` until graduation and need professional dev tools for programming.

**1. CPGE (Classes Préparatoires aux Grandes Écoles) — 2 years — Lycée Moulay Al Hassan - Tanger and nationwide:**
- MPSI/MP, PCSI/PSI, TSI streams — mandatory **Informatique** (Python, algorithms, SQL, Linux) throughout both years per national CPGE syllabus.
- Ministry CPGE page: https://www.men.gov.ma/Fr/Pages/CPGE.aspx
- National CPGE portal: https://www.cpge.ac.ma
- Lycée Moulay Al Hassan - Tanger is listed as a CPGE centre (Tanger-Tétouan-Al Hoceima academy). Students are bac+2 and keep `taalim.ma`.

**2. BTS (Brevet de Technicien Supérieur) — 2 years — also hosted in lycées with `taalim.ma`:**
- **BTS Développement des Systèmes d'Information (DSI)** — pure IT: Java, C#, PHP, networks, databases, web/mobile dev (2 years).
- **BTS Systèmes et Réseaux Informatiques / Systèmes Electroniques** — IT + networks.
- Ministry BTS page: https://www.men.gov.ma/Fr/Pages/BTS.aspx
- Dozens of lycées nationwide deliver these BTS under the same `taalim.ma` domain (e.g. Lycée Technique, Lycée Al Khawarizmi etc.). Graduates receive `BTS` diploma bac+2.

Both CPGE and BTS are **recognized physical post-bac programs with student attendance**, clearly beyond primary/secondary, and their curriculum is IT-centric and ≥1 year.

### File content
```
Ministère de l'Éducation Nationale, du Préscolaire et des Sports - Maroc
Lycée Moulay Al Hassan - Tanger
.group
```
Line 3 `.group` as domain is shared by a group of schools (national).

### Checklist
- [x] Domain is not on stoplist / abused.txt
- [x] File has `.txt` extension, correct hierarchy `ma/taalim.txt`
- [x] First line is official institution name, `.group` added for shared domain
- [x] Domain covers all subdomains automatically (no need for `massar.taalim.ma` etc.)

Thanks for reviewing! Happy to provide Massar enrollment certificate / `taalim.ma` inbox screenshot / CPGE/BTS enrollment proof if needed.
