### PR TITLE
Add Hunan University of Arts and Science (huas.edu.cn)

### DIFF
--- a/lib/domains/cn/edu/huas.txt
+++ b/lib/domains/cn/edu/huas.txt
@@ -1,0 +1,2 @@
+湖南文理学院
+Hunan University of Arts and Science


### PR DESCRIPTION
## University

**Hunan University of Arts and Science (湖南文理学院)**

## Domain

`huas.edu.cn`

The university uses `huas.edu.cn` for faculty and `st.huas.edu.cn` for students. According to the SWOT repository rules, adding the parent domain also covers its subdomains.

## Official university website

https://www.huas.edu.cn/

## Long-term IT-related programs

The university's College of Computer and Electrical Engineering offers undergraduate programs including Computer Science and Technology and Software Engineering.

Official program page:

https://jdxy.huas.edu.cn/info/1002/5689.htm

The page lists computer-science courses including programming, data structures, computer networks, operating systems, database systems, software engineering, and algorithm design.

## Student email domain proof

Official university email portal:

https://mail.huas.edu.cn/

The official login page explicitly identifies:

- `huas.edu.cn` — faculty
- `st.huas.edu.cn` — students

This confirms that `st.huas.edu.cn` is the university's official student email domain.

Thank you for reviewing this request.