### PR TITLE
Add Karpagam Institute of Technology (karpagamtech.ac.in)

### DIFF
--- a/lib/domains/in/ac/karpagamtech.txt
+++ b/lib/domains/in/ac/karpagamtech.txt
@@ -1,0 +1,1 @@
+Karpagam Institute of Technology


### PR DESCRIPTION
This pull request adds a new domain to the list of academic institutions.

Institution domain update:

* Added `Karpagam Institute of Technology` to `lib/domains/in/ac/karpagamtech.txt`.

Verification:

- Official university website: https://karpagamtech.ac.in/
- Information Technology program: https://karpagamtech.ac.in/academics/computer-science-engineering/ — Bachelor’s degree, full-time, 4 years.
- Official student-email FAQ: https://karpagamtech.ac.in/contact-us/  
- student email format is [student-id@karpagamtech.ac.in](mailto:student-id@karpagamtech.ac.in]).