### PR TITLE
Add stu.ecnu.edu.cn for East China Normal University

### DIFF
--- a/lib/domains/cn/edu/ecnu/stu.txt
+++ b/lib/domains/cn/edu/ecnu/stu.txt
@@ -1,0 +1,1 @@
+East China Normal University


### PR DESCRIPTION
Student email subdomain used by ECNU was missing from the database.