### PR TITLE
Add Hudson County Community College (live.hccc.edu)

### DIFF
--- a/lib/domains/edu/hccc/live.txt
+++ b/lib/domains/edu/hccc/live.txt
@@ -1,0 +1,1 @@
+Hudson County Community College


### PR DESCRIPTION
- Institution name: Hudson County Community College
- Official website: https://www.hccc.edu
- Domain: live.hccc.edu (student email domain)