### PR TITLE
Update iput.ac.jp: add Tokyo campus

### DIFF
--- a/lib/domains/jp/ac/iput.txt
+++ b/lib/domains/jp/ac/iput.txt
@@ -1,2 +1,4 @@
 大阪国際工科専門職大学
 International Professional University of Technology in Osaka
+東京国際工科専門職大学
+International Professional University of Technology in Tokyo


### PR DESCRIPTION
Add domain: iput.ac.jp

University: 東京国際工科専門職大学 (International Professional University of Technology in Tokyo)

Official website: https://www.iput.ac.jp/tokyo/
Main site: https://www.iput.ac.jp/

Student email domain example: @tks.iput.ac.jp (e.g. student number@tks.iput.ac.jp)

IT-related long-term courses:
- Information Technology department: https://www.iput.ac.jp/tokyo/faculty/
- Digital Entertainment department: https://www.iput.ac.jp/tokyo/faculty/

This is an accredited professional university in Japan offering IT / AI / Game development programs.