### PR TITLE
Re-evaluate mail.dlut.edu.cn for Dalian University of Technology

### DIFF
--- a/lib/domains/cn/edu/dlut/mail.txt
+++ b/lib/domains/cn/edu/dlut/mail.txt
@@ -1,0 +1,2 @@
+大连理工大学
+Dalian University of Technology


### PR DESCRIPTION
## Request to re-evaluate `mail.dlut.edu.cn`

Dalian University of Technology is already present in SWOT as `dlut.edu.cn`, but the domain is currently included in the stoplist because of past abuse.

The university currently uses:

`@mail.dlut.edu.cn`

as its official student email domain.

Official references:
- University website: https://www.dlut.edu.cn/
- English website: https://en.dlut.edu.cn/
- Official university IT page describing the email service:
  https://its.dlut.edu.cn/index/jsfw/fwzn/dzyxfw/yxfwsm.htm
- Official student mail portal:
  https://mail.dlut.edu.cn/

I understand that previous requests were rejected because the domain had been abused in the past. This PR is therefore not claiming that the previous decision was incorrect; it is asking whether the current status of the student-only `mail.dlut.edu.cn` subdomain can be reviewed again.

This has an impact beyond JetBrains licensing because downstream services also use the SWOT database for academic email verification. For example, Zed's student verification currently rejects valid Dalian University of Technology student addresses because the parent domain is stoplisted.

If the domain still cannot be trusted, I understand that this PR may be declined. I would appreciate a re-evaluation based on the university's current official student email service.