### PR TITLE
Add The University of Hong Kong

### DIFF
--- a/lib/domains/hk/hku/connect.txt
+++ b/lib/domains/hk/hku/connect.txt
@@ -1,0 +1,2 @@
+香港大學
+The University of Hong Kong


### PR DESCRIPTION
Adding the official student email domain for The University of Hong Kong (HKU).

University website:
https://www.hku.hk/

IT-related programme:
https://cs.hku.hk/programmes/course-offered

HKU offers a 4-year undergraduate Computer Science curriculum.

Official student email domain:
https://handbook.hku.hk/ug/part-time-2026-27/registration/electronic-communication.html

HKU states that students are provided with and officially communicated through `@connect.hku.hk` email accounts.

Additional confirmation from HKU Information Technology Services:
https://its.hku.hk/kb/what-is-the-email-address-email-alias-user-name-and-password-of-my-hku-connect-email-account/

The submitted domain is specifically `connect.hku.hk`, which is the official student email domain.