### PR TITLE
Add Chhatrapati Shivaji Maharaj University  [ csmu.ac.in ]

### DIFF
--- a/lib/domains/in/ac/csmu.txt
+++ b/lib/domains/in/ac/csmu.txt
@@ -1,0 +1,1 @@
+Chhatrapati Shivaji Maharaj University

--- a/lib/domains/in/edu/csmu.txt
+++ b/lib/domains/in/edu/csmu.txt
@@ -1,0 +1,1 @@
+Chhatrapati Shivaji Maharaj University

--- a/lib/domains/in/edu/csmu.txt
+++ b/lib/domains/in/edu/csmu.txt
@@ -1,1 +1,0 @@
-Chhatrapati Shivaji Maharaj University


### PR DESCRIPTION
Add Chhatrapati Shivaji Maharaj University

Domain: `csmu.ac.in`

* Official university website:
  https://csmu.ac.in/

* IT-related long-term program:

  Chhatrapati Shivaji Maharaj University offers a undergraduate program in Computer Science and Technology
https://csmu.ac.in/programmes-offered/

* Official student email service:

   institutional email accounts to enrolled students. Student email addresses use the `@csmu.ac.in` domain.

Therefore, `csmu.ac.in` is an official educational email domain used by Chhatrapati Shivaji Maharaj University.