### PR TITLE
retry to add jadara university domain

### DIFF
--- a/lib/domains/std/jadara/edu/jo/jadara_university.txt
+++ b/lib/domains/std/jadara/edu/jo/jadara_university.txt
@@ -1,0 +1,2 @@
+Jadara University
+JU


### PR DESCRIPTION
## University Email Domain and Official Website

The official university email domain follows the format: `student_id@std.jadara.edu.jo`

The following image, taken from the university's official **e-learning website**, demonstrates the student email domain format: **Jadara University E-Learning Website:** https://elearning.jadara.edu.jo/

<img width="948" height="473" alt="elearning_pic-1" src="https://github.com/user-attachments/assets/c14f5808-1881-4439-99bc-debcf081e4eb" />
<img width="949" height="473" alt="elearning_pic-2" src="https://github.com/user-attachments/assets/16693d41-db5b-43a0-9198-d6c97e27376d" />


For additional verification and official information, the university's official website is:

**Jadara University:** https://jadara.edu.jo/

<img width="950" height="473" alt="formal_website" src="https://github.com/user-attachments/assets/91b8130b-b051-4ec6-86c3-5720a34e7f57" />
