### PR TITLE
Add Universidad de Guayaquil (ug.edu.ec)

### DIFF
--- a/lib/domains/ec/edu/ug.txt
+++ b/lib/domains/ec/edu/ug.txt
@@ -1,0 +1,3 @@
+Universidad de Guayaquil
+University of Guayaquil
+


### PR DESCRIPTION
Add ug.edu.ec for Universidad de Guayaquil

Official university website: https://www.ug.edu.ec/

IT-related program: Software Engineering / Ingeniería de Software

The Universidad de Guayaquil offers Ingeniería de Software, a long-term higher education program related to Information Technology and software development.

The submitted domain ug.edu.ec is used as an official institutional email domain for students and the university.