### PR TITLE
Add uanl.edu.mx domain for Universidad Autónoma de Nuevo León

### DIFF
--- a/lib/domains/mx/edu/uanl.txt
+++ b/lib/domains/mx/edu/uanl.txt
@@ -1,0 +1,1 @@
+Universidad Autónoma de Nuevo León


### PR DESCRIPTION
Adding uanl.edu.mx — Universidad Autónoma de Nuevo León

This PR adds the email domain uanl.edu.mx, used by active students, professors, and researchers of the Universidad Autónoma de Nuevo León (UANL), a public university in Monterrey, Nuevo León, Mexico.

Official website: https://www.uanl.mx/
Proof that uanl.edu.mx is the official domain for students/faculty: https://dti.uanl.mx/correo-universitario/
Long-term (>1 year) IT-related program offered by the institution: [Licenciado en Tecnologías de Información](https://facpya.uanl.mx/licenciado-en-tecnologias-de-informacion/) — a 9-semester (4.5-year) accredited undergraduate program at FACPyA (Facultad de Contaduría Pública y Administración), covering programming, systems analysis and design, databases, and networks.

File added: lib/domains/mx/edu/uanl.txt