### PR TITLE
Add Changzhou University (cczu.edu.cn); release smail.cczu.edu.cn from stoplist

### DIFF
--- a/lib/domains/cn/edu/cczu.txt
+++ b/lib/domains/cn/edu/cczu.txt
@@ -1,0 +1,2 @@
+常州大学
+Changzhou University

--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -890,7 +890,6 @@ skei.edu.in
 skhhcps.edu.hk
 skillup.edu.sv
 skylineschool.edu.vn
-smail.cczu.edu.cn
 smail.xtu.edu.cn
 smc.edu.kg
 smkcendana.sch.id


### PR DESCRIPTION
Appeal to add Changzhou University (常州大学) and release `smail.cczu.edu.cn` from the stoplist

## Changes
- `lib/domains/cn/edu/cczu.txt` (new): add main domain `cczu.edu.cn` → **Changzhou University** (常州大学)
- `lib/domains/stoplist.txt`: remove `smail.cczu.edu.cn`

## Why
`cczu.edu.cn` is the domain of **Changzhou University**, a public university in Jiangsu, China offering long-term undergraduate and graduate programs including IT-related courses (computer science, software engineering, etc.), so it satisfies the repository's inclusion criteria.

Regarding `smail.cczu.edu.cn`:
- It is the university's **official student email domain** (faculty use `@cczu.edu.cn`; enrolled students use `@smail.cczu.edu.cn`).
- It was added to the stoplist on 2022-05-06 in commit `5c23727c87` ("support request 4000267") following an abuse report.
- The university's mail system is restricted to **enrolled students and staff**: student accounts are activated through the university's unified identity authentication with a student ID, and long-inactive accounts are disabled/deleted. This suggests the earlier abuse vector is no longer open.

## Official references (domain ownership / student-only access)
- Student mail portal: http://mail.smail.cczu.edu.cn/
- University unified-authentication & mail handbook (official PDF): https://nic.cczu.edu.cn/_upload/article/files/cc/7a/35bc12f04b6e83e039131bac4789/cd36d5e9-bbd0-4689-9b08-8db91cf2a264.pdf
- Notice on cleaning up inactive student mail accounts: https://nic.cczu.edu.cn/2025/0107/c1339a383191/page.psp

We kindly ask the maintainers to review the stoplist entry and consider releasing `smail.cczu.edu.cn` so legitimate students can verify themselves through their official student email domain.