### PR TITLE
Add stu.nchu.edu.cn for Nanchang Hangkong University Add student sub‑…

### DIFF
--- a/lib/domains/cn/nchu.txt
+++ b/lib/domains/cn/nchu.txt
@@ -1,0 +1,2 @@
+Nanchang Hangkong University
+stu.nchu.edu.cn


### PR DESCRIPTION
Add student sub‑domain stu.nchu.edu.cn for Nanchang Hangkong University.
This is the official student email domain of Nanchang Hangkong University, China.
Student email format: {student_id}@stu.nchu.edu.cn
