### PR TITLE
Remove email.ncu.edu.cn from stoplist — Nanchang University email migrated to Coremail with student ID verification

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -346,7 +346,6 @@ eksu.edu.ng
 elproschools.edu.in
 email.cufe.edu.cn
 email.cugb.edu.cn
-email.ncu.edu.cn
 email.szu.edu.cn
 emds.edu.pt
 eminescusm.ro


### PR DESCRIPTION
## Request to remove `email.ncu.edu.cn` from the stoplist

### Background

`email.ncu.edu.cn` is currently in the stoplist (`lib/domains/stoplist.txt`), which prevents all students at Nanchang University from using their `@email.ncu.edu.cn` email addresses to apply for JetBrains free educational licenses.

The parent domain `ncu.edu.cn` is already in the repository (`lib/domains/cn/edu/ncu.txt`), so the only thing blocking recognition is this stoplist entry.

### Why it should be removed

**The email system has migrated from Tencent Enterprise Email to Coremail (campus email), with strict student identity verification.**

1. **Old system (Tencent Enterprise Email)**: The `@email.ncu.edu.cn` domain was previously hosted on Tencent Enterprise Email (`exmail.qq.com`). This likely allowed administrators to create accounts for non-students, which is probably why it was added to the stoplist.

2. **New system (Coremail campus email)**: As of July 2026, Nanchang University has migrated the student email system to Coremail. The new login portal is at `http://mail.email.ncu.edu.cn/`.

3. **Strict student verification**: The new system requires **student ID + real name** verification for account activation. The activation page (`http://mail.email.ncu.edu.cn/edu_reg/userActive/index`) has a 3-step process:
   - Step 1: **Identity verification** — requires Student ID and Full Name
   - Step 2: **Phone binding** — phone number verification
   - Step 3: **Set password** — create account password

   Only enrolled students with valid student IDs can activate email accounts. This eliminates the abuse vector that likely caused the domain to be stoplisted.

4. **Migration documentation**: The official migration guide is published at `https://365.kdocs.cn/l/crumIhltZkxQ` (titled "Email Data Migration Guide v2 - Students", updated 2026-07-28), confirming this is an institutional migration.

### Evidence

- **University official website**: https://www.ncu.edu.cn/
- **New email login portal**: http://mail.email.ncu.edu.cn/ (Coremail, Copyright 2026 Nanchang University)
- **Account activation page** (requires Student ID): http://mail.email.ncu.edu.cn/edu_reg/userActive/index
- **IT-related courses**: Nanchang University has multiple IT-related colleges:
  - School of Software: http://soft.ncu.edu.cn/
  - School of Information Engineering: http://ie.ncu.edu.cn/
  - School of Mathematics and Computer Science: http://smcs.ncu.edu.cn/
  - School of Artificial Intelligence: http://sai.ncu.edu.cn/

### Note

The old Tencent email domain alias `email2.ncu.edu.cn` is NOT in the stoplist and currently works for JetBrains applications. However, this domain alias will be deprecated as the migration completes. The new system uses `email.ncu.edu.cn` (Coremail), which is the one being stoplisted. Removing this entry ensures students can continue to apply for JetBrains educational licenses after the migration is complete.