### PR TITLE
Add nchu.edu.cn and stu.nchu.edu.cn for Nanchang Hangkong University

### DIFF
--- a/lib/domains/cn/nchu.txt
+++ b/lib/domains/cn/nchu.txt
@@ -1,0 +1,3 @@
+Nanchang Hangkong University
+nchu.edu.cn
+stu.nchu.edu.cn

--- a/lib/domains/cn/nchu.txt
+++ b/lib/domains/cn/nchu.txt
@@ -1,0 +1,2 @@
+Nanchang Hangkong University
+stu.nchu.edu.cn

--- a/lib/domains/cn/nchu.txt
+++ b/lib/domains/cn/nchu.txt
@@ -1,2 +1,0 @@
-Nanchang Hangkong University
-stu.nchu.edu.cn


### PR DESCRIPTION
Add nchu.edu.cn and stu.nchu.edu.cn for Nanchang Hangkong University.
nchu.edu.cn is the main official domain of Nanchang Hangkong University.
stu.nchu.edu.cn is the official student email sub‑domain for undergraduate students.
Student email format: {student_id}@stu.nchu.edu.cn
