### PR TITLE
add Osaka Seikei University

### DIFF
--- a/lib/domains/jp/ac/osaka-seikei/g.txt
+++ b/lib/domains/jp/ac/osaka-seikei/g.txt
@@ -1,0 +1,2 @@
+大阪成蹊大学
+Osaka Seikei University


### PR DESCRIPTION
Adding Osaka Seikei University (大阪成蹊大学)

University URL: https://univ.osaka-seikei.jp/
Course URL: https://univ.osaka-seikei.jp/department/data_science/ — the Faculty of Data Science, a 4-year undergraduate program.
Proof of email address: https://univ.osaka-seikei.jp/students/pdf/spgmailsetting.pdf — the university's official Gmail setup guide. g.osaka-seikei.ac.jp is the domain of our student Gmail accounts.