### PR TITLE
Add Vietnamese educational domains

### DIFF
--- a/lib/domains/vn/edu/ldg.txt
+++ b/lib/domains/vn/edu/ldg.txt
@@ -1,0 +1,2 @@
+Cổng Thông tin điện tử Sở GDĐT LÂM ĐỒNG
+Lam Dong Department of Education and Training

--- a/lib/domains/vn/edu/sfc.txt
+++ b/lib/domains/vn/edu/sfc.txt
@@ -1,0 +1,2 @@
+TRUNG TÂM NGOẠI NGỮ - TIN HỌC SUNFLOWER
+Sunflower Language and Computer Training Center


### PR DESCRIPTION
This pull request adds the following official educational email domains:

ldg.edu.vn — Lam Dong Department of Education and Training
sfc.edu.vn — Sunflower Language and Computer Training Center
Verification

Official websites:

https://ldg.edu.vn/
https://sfc.edu.vn/

These domains are officially owned and used by the respective educational institutions for students and/or faculty members.

The institutions provide long-term educational programs, including IT-related programs lasting at least one year.