### PR TITLE
Remove Jiangsu University of Technology (JSUT) domain from stoplist

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -513,7 +513,6 @@ joy.edu.kg
 jp.edu.kg
 jsahvc.edu.cn
 jsust.edu.cn
-jsut.edu.cn
 just.edu.tw
 k.kkk.ac.nz
 k.tut.edu.pl


### PR DESCRIPTION
## Summary

- Remove `jsut.edu.cn` from the stoplist.
- Allow the official student email domain `smail.jsut.edu.cn` to follow the repository's existing `edu.cn` domain handling.

## Institution

Jiangsu University of Technology (JSUT) is a full-time university located in Changzhou, Jiangsu, China. It focuses on applied higher education and engineering-oriented talent development. Its Computer Engineering School offers undergraduate programs in Computer Science and Technology, Software Engineering, Artificial Intelligence, Network Engineering, and Data Science and Big Data Technology, with courses including programming, data structures, operating systems, databases, computer networks, and software engineering.

Official website:

[https://www.jsut.edu.cn/](https://www.jsut.edu.cn/) (Simplified Chinese)
[https://english.jsut.edu.cn/](https://english.jsut.edu.cn/) (English)

## Domain

The official JSUT Network Center identifies `@smail.jsut.edu.cn` as the suffix used for students' personal email accounts.

Evidence:

[https://net.jsut.edu.cn/2023/0812/c6711a167849/page.htm](https://net.jsut.edu.cn/2023/0812/c6711a167849/page.htm)

## IT-related programs

The official School of Computer Engineering website is:

[https://jsjxy.jsut.edu.cn/main.htm](https://jsjxy.jsut.edu.cn/main.htm)

The official program introduction page lists undergraduate programs in Computer Science and Technology, Software Engineering, Artificial Intelligence, Network Engineering, and Data Science and Big Data Technology. It also describes courses including programming, data structures, operating systems, databases, computer networks, and software engineering.

Evidence:

[https://zs.jsut.edu.cn/jsjgcxy/list.htm](https://zs.jsut.edu.cn/jsjgcxy/list.htm)

## Implementation notes

The stoplist is checked before the repository's existing `edu.cn` domain inheritance. Removing `jsut.edu.cn` is therefore necessary for `smail.jsut.edu.cn` to be recognized.

This PR intentionally contains only the stoplist change. No allowlist, runtime, compiler, school-name, or test files are added.

## Verification

- `gradlew clean test`
- All tests passed.