### PR TITLE
Added Ulkebøl Skole

### DIFF
--- a/lib/domains/net/skolens.txt
+++ b/lib/domains/net/skolens.txt
@@ -1,0 +1,1 @@
+Ulkebøl Skole


### PR DESCRIPTION
Add Ulkebøl Skole in Sønderborg, Denmark.
Official school website: https://ulkebol.aula.dk/
Student and staff email addresses use the @skolens.net domain.
I am currently enrolled at the school and have an active educational email address on this domain.
If needed for verification, you may contact me at hend0000@skolens.net.