### PR TITLE
Add Universidade Feevale

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1581,6 +1581,7 @@ umt.edu.my
 ipchile.cl
 pucpr.edu.br
 jmi.ac.in
+feevale.br
 alu.uabcs.mx
 uabcs.mx
 unas.edu.pe

--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1581,7 +1581,6 @@ umt.edu.my
 ipchile.cl
 pucpr.edu.br
 jmi.ac.in
-feevale.br
 alu.uabcs.mx
 uabcs.mx
 unas.edu.pe

--- a/lib/domains/br/feevale.txt
+++ b/lib/domains/br/feevale.txt
@@ -1,0 +1,1 @@
+Universidade Feevale


### PR DESCRIPTION
Adds the official student email domain for Universidade Feevale, a Brazilian higher education institution.

**Domain:** `feevale.br`

**Official website:**  
https://www.feevale.br/

**Long-term IT-related course:**  
Computer Science (Bachelor's degree, 8 semesters):  
https://www.feevale.br/graduacao/ciencia-da-computacao

**Proof of student email domain:**  
https://feevale.br/servicos/web/webmail

The official Feevale webmail page states that enrolled students receive an institutional email account using the `@feevale.br` domain, in the format `studentcode@feevale.br`.