### PR TITLE
Add stu.nchu.edu.cn student sub‑domain for Nanchang Hangkong University

### DIFF
--- a/lib/domains/cn/edu/nchu.txt
+++ b/lib/domains/cn/edu/nchu.txt
@@ -1,1 +1,3 @@
 Nanchang Hangkong University
+nchu.edu.cn
+stu.nchu.edu.cn


### PR DESCRIPTION
Add student email sub‑domain stu.nchu.edu.cn for Nanchang Hangkong University.

- Main domain nchu.edu.cn already exists in repository.
- Add student sub‑domain: stu.nchu.edu.cn

This is a valid Chinese mainland edu.cn domain.
SERVFAIL DNS error may come from overseas DNS limitation for CN edu domains.
Official website: https://www.nchu.edu.cn
Student email document: https://nic.nchu.edu.cn/xtyy/content_118546
