### PR TITLE
Add Watumull Institute Of Engineering And Technology to domain list 

### DIFF
--- a/lib/domains/in/edu/watumull.txt
+++ b/lib/domains/in/edu/watumull.txt
@@ -1,0 +1,1 @@
+   Watumull Institute of Electronics Engineering and Computer Technology


### PR DESCRIPTION
Hello! I am a student at this institution and would like to request the addition of our official student email domain to qualify for the JetBrains Student License (and subsequently Zed Pro).

**Proof of Domain Ownership:**
- Official Website URL: https://watumull.edu.in/
- Course Proof: The institute offers a 4-year Bachelor of Engineering degree in Computer Engineering. See academics section: https://watumull.edu.in/
- Email Verification: I have an active student email at balaji.u.chauhan2022@watumull.edu.in (see attached screenshot showing institutional webmail access)

<img width="1917" height="870" alt="image" src="https://github.com/user-attachments/assets/443ba46b-cb4e-4e59-ba8a-fba41155f766" />
Thank you for your time and review!