### PR TITLE
Remove 'cug.edu.cn' from stoplist

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -295,7 +295,6 @@ csiriicb.in
 ctgu.edu.cn
 ctrb.fab.mil.br
 cug.ac.in
-cug.edu.cn
 cumt.edu.cn
 dakahliya3.moe.edu.eg
 davidson.k12.nc.us


### PR DESCRIPTION
Removed 'cug.edu.cn' from the stoplist.
The domain cug.edu.cn is the official student email domain of China University of Geosciences (Wuhan).

The domain already has an entry in:
lib/domains/cn/edu/cug.txt

However, cug.edu.cn is also currently listed in stoplist.txt, which prevents it from being recognized as an educational domain.

The university's official information office confirms that student email accounts use the format student_id@cug.edu.cn.

Official source:
https://wlzx.cug.edu.cn/wlhxxhfw/cyfw1/yxfw.htm