### PR TITLE
Add Jaffna Institute of Science and Technology (jist.edu.lk)

### DIFF
--- a/lib/domains/gr/edu/noah.txt
+++ b/lib/domains/gr/edu/noah.txt
@@ -1,1 +1,0 @@
-Hellenic College Noah

--- a/lib/domains/gr/edu/noah.txt
+++ b/lib/domains/gr/edu/noah.txt
@@ -1,0 +1,1 @@
+Hellenic College Noah

--- a/lib/domains/lk/edu/jist.txt
+++ b/lib/domains/lk/edu/jist.txt
@@ -1,0 +1,1 @@
+Jaffna Institute of Science and Technology


### PR DESCRIPTION
- Institution name: Jaffna Institute of Science and Technology
- Official website: https://jist.edu.lk
- Domain: jist.edu.lk