### PR TITLE
Add stu.cmb.ac.lk domain

### DIFF
--- a/lib/domains/lk/ac/cmb/stu.txt
+++ b/lib/domains/lk/ac/cmb/stu.txt
@@ -1,0 +1,1 @@
+University of Colombo


### PR DESCRIPTION
Adds the student domain (stu.cmb.ac.lk) for the University of Colombo, Sri Lanka.