### PR TITLE
Add Rajarshi School of Management and Technology, Varanasi (rsmt.ac.in)

### DIFF
--- a/lib/domains/in/ac/rsmt.txt
+++ b/lib/domains/in/ac/rsmt.txt
@@ -1,0 +1,1 @@
+Rajarshi School of Management and Technology, Varanasi


### PR DESCRIPTION
### Educational Institution Information

- **Institution Name:** Rajarshi School of Management and Technology (RSMT), Varanasi
- **Domain:** `rsmt.ac.in`
- **Official Website:** https://www.rsmt.ac.in
- **IT-related long-term program (> 1 year):**
  - MCA (Master of Computer Applications - 2 Years): https://www.rsmt.ac.in/mca.html
  - BCA (Bachelor of Computer Applications - 3 Years): https://www.rsmt.ac.in/bca.html
- **Affiliation & Approvals:**
  - AICTE Approved
  - Affiliated with Dr. A.P.J. Abdul Kalam Technical University (AKTU), Lucknow for MCA
  - Affiliated with Mahatma Gandhi Kashi Vidyapith (MGKVP), Varanasi for BCA
- **Address:** UP College Campus, Varanasi, Uttar Pradesh 221002, India