### PR TITLE
Add Higher Institute for Agricultural Cooperation (hiac.edu.eg)

### DIFF
--- a/lib/domains/eg/edu/hiac.txt
+++ b/lib/domains/eg/edu/hiac.txt
@@ -1,0 +1,1 @@
+Higher Institute for Agricultural Cooperation


### PR DESCRIPTION
This pull request adds the following official educational email domain:

hiac.edu.eg — Higher Institute for Agricultural Cooperation

Official website:

https://hiac.edu.eg/

The domain above is officially owned and used by the respective educational institution for students and/or faculty members.

The institution provide long-term educational programs, including IT-related programs lasting at least one year and also agricultural related.