### PR TITLE
Add Al-Balqa Applied University (bau.edu.jo)

### DIFF
--- a/lib/domains/jo/edu/bau.txt
+++ b/lib/domains/jo/edu/bau.txt
@@ -1,0 +1,1 @@
+   Al-Balqa Applied University


### PR DESCRIPTION
Adding BAU university domain for Jordan. Official university website: https://www.bau.edu.jo