### PR TITLE
Add edus college of engineering

### DIFF
--- a/lib/domains/pl/edu/edus.txt
+++ b/lib/domains/pl/edu/edus.txt
@@ -1,0 +1,1 @@
+edus college of engineering


### PR DESCRIPTION
This pull request adds the 'edus.edu.pl' domain for Edus College of Engineering.

The domain is used for official student email addresses, including:

"anasatallah@edus.edu.pl"

This will allow eligible students of Edus College of Engineering to be recognized by services using the JetBrains SWoT database
for student verification.
