### PR TITLE
Add ulo.txt with University of Leiria and Oeste

### DIFF
--- a/lib/domains/pt/ulo.txt
+++ b/lib/domains/pt/ulo.txt
@@ -1,0 +1,1 @@
+University of Leiria and Oeste


### PR DESCRIPTION
Adding ULO.pt, as IPLeiria.pt is transitioning from Polytechnic to University.

- Website: https://ulo.pt