### PR TITLE
Add futa.edu.ng (Federal University of Technology, Akure)

### DIFF
--- a/lib/domains/ng/edu/futa.txt
+++ b/lib/domains/ng/edu/futa.txt
@@ -1,0 +1,1 @@
+Federal University of Technology, Akure


### PR DESCRIPTION
Adds `futa.edu.ng`, the email domain of the Federal University of Technology, Akure.

I'm a student there and my address is on that domain.

FUTA is a federal university in Ondo State, founded in 1981. It runs full degree programmes in computer science and software engineering, all of them four years or longer.

FUT Owerri is already in the list as `futo.txt`, and FUT Minna is there too, so Akure looks like an omission rather than a deliberate exclusion.

I'll add the course page link and proof that the domain is the official student address in a comment below.
