### PR TITLE
Add Santa Fe College domain

### DIFF
--- a/lib/domains/edu/sfcollege.txt
+++ b/lib/domains/edu/sfcollege.txt
@@ -1,0 +1,1 @@
+Santa Fe College


### PR DESCRIPTION
## Institution

Santa Fe College

## Domain

`sfcollege.edu`

## Official website

[[Santa Fe College](https://www.sfcollege.edu/)](https://www.sfcollege.edu/)

## Student email domain

Santa Fe College's official website states that students are assigned an SF email account and that current students are required to use the college's official email ending in `@go.sfcollege.edu` for college communications.

[[Santa Fe College — Administrative Guidelines](https://www.sfcollege.edu/general-counsel/administrative-guidelines.html)](https://www.sfcollege.edu/general-counsel/administrative-guidelines.html)

[[Santa Fe College — Learn Online Now](https://www.sfcollege.edu/cat/instructional-design/learn-online-now.html)](https://www.sfcollege.edu/cat/instructional-design/learn-online-now.html)

## Long-term IT-related program

Santa Fe College offers a Computer Information Technology Associate in Science (A.S.) degree. The official program page states that the degree requires 60 credit hours and includes courses covering computer networking, information security, databases, programming, web authoring, and IT project management.

[[Santa Fe College — Computer Information Technology, A.S.](https://www.sfcollege.edu/academics/programs/3504.html)](https://www.sfcollege.edu/academics/programs/3504.html)

Santa Fe College also describes its Information Technology Education department as offering bachelor's, associate, and certificate-level IT programs in programming, networking, and security.

[[Santa Fe College — Information Technology Education](https://www.sfcollege.edu/academics/cte/ite/)](https://www.sfcollege.edu/academics/cte/ite/)

This PR adds the Santa Fe College educational domain to the SWOT database.