### PR TITLE
Add Thal University domain

### DIFF
--- a/lib/domains/pk/edu/eum.txt
+++ b/lib/domains/pk/edu/eum.txt
@@ -1,0 +1,1 @@
+Emerson University Multan

--- a/lib/domains/pk/edu/tu.txt
+++ b/lib/domains/pk/edu/tu.txt
@@ -1,0 +1,1 @@
+Thal University

--- a/lib/domains/pk/edu/uchenab.txt
+++ b/lib/domains/pk/edu/uchenab.txt
@@ -1,0 +1,1 @@
+University of Chenab

--- a/lib/domains/pk/edu/ukm.txt
+++ b/lib/domains/pk/edu/ukm.txt
@@ -1,0 +1,1 @@
+University of Kamalia

--- a/lib/domains/pk/edu/ul.txt
+++ b/lib/domains/pk/edu/ul.txt
@@ -1,0 +1,1 @@
+University of Layyah

--- a/lib/domains/pk/edu/umw.txt
+++ b/lib/domains/pk/edu/umw.txt
@@ -1,0 +1,1 @@
+The University of Mianwali

--- a/lib/domains/pk/edu/umw.txt
+++ b/lib/domains/pk/edu/umw.txt
@@ -1,1 +1,0 @@
-The University of Mianwali

--- a/lib/domains/pk/edu/uo.txt
+++ b/lib/domains/pk/edu/uo.txt
@@ -1,0 +1,1 @@
+University of Okara

--- a/lib/domains/pk/edu/uoc.txt
+++ b/lib/domains/pk/edu/uoc.txt
@@ -1,0 +1,1 @@
+University of Chakwal

--- a/lib/domains/pk/edu/uoj.txt
+++ b/lib/domains/pk/edu/uoj.txt
@@ -1,0 +1,1 @@
+University of Jhang


### PR DESCRIPTION
## Add `tu.edu.pk` — Thal University

This PR adds the official `tu.edu.pk` domain of Thal University, Bhakkar, Pakistan.

### Institution

* Institution: Thal University, Bhakkar
* Country: Pakistan
* Province/Region: Punjab
* Official domain: `tu.edu.pk`
* Proposed SWOT file: `lib/domains/pk/edu/tu.txt`

### Verification

Thal University is a public-sector university in Bhakkar, Punjab, chartered by the Government of Punjab and recognized by the Higher Education Commission (HEC) of Pakistan.

Official university website:

https://tu.edu.pk/

HEC verification:

https://www.hec.gov.pk/english/universities/Pages/Punjab/Thal-University%2C-Bhakkar.aspx

The HEC university profile identifies Thal University as a recognized university and lists the official website as `https://tu.edu.pk/`. It also lists BS Computer Science, BS Information Technology, and BS Software Engineering among its undergraduate programs.

### IT-related long-term course

Thal University offers a four-year Bachelor of Science in Computer Science program.

Official program page:

https://tu.edu.pk/academics/bs-computer-science

The official university page identifies the BS Computer Science program as a 4-year undergraduate program covering programming, software engineering, databases, networking, and modern computing technologies.

Thal University also offers BS Software Engineering:

https://tu.edu.pk/academics/bs-software-engineering

### Official domain verification

The `tu.edu.pk` domain is used for official university communications and institutional accounts. The Higher Education Commission's National IT Skill Competency Test focal-person directory also lists a Thal University IT official using an `@tu.edu.pk` institutional email address.

HEC IT directory:

https://nsct.hec.gov.pk/FocalPersonList

The university's official website also uses `@tu.edu.pk` addresses for its university departments and IT staff.

### File

```text
lib/domains/pk/edu/tu.txt
```

Contents:

```text
Thal University
```

### Reason

Thal University is a recognized Pakistani higher-education institution offering long-term IT-related undergraduate programs. The proposed `tu.edu.pk` domain is the institution's official domain and is used for institutional email communication.

No existing institution entry is being modified.
