### PR TITLE
Add Universitas Indonesia (ui.ac.id)

### DIFF
--- a/lib/domains/id/ac/ui.txt
+++ b/lib/domains/id/ac/ui.txt
@@ -1,0 +1,1 @@
+Universitas Indonesia


### PR DESCRIPTION
Adds `ui.ac.id` (Universitas Indonesia, https://ui.ac.id/) as `lib/domains/id/ac/ui.txt` per the contributing guide.

This makes `@ui.ac.id` student/staff email addresses eligible for academic domain verification.