### PR TITLE
Add Federal University of Technology, Akure (futa.edu.ng)

### DIFF
--- a/lib/domains/ng/edu/futa.txt
+++ b/lib/domains/ng/edu/futa.txt
@@ -1,0 +1,1 @@
+Federal University of Technology, Akure


### PR DESCRIPTION
This PR adds the official university email domain `futa.edu.ng` for the Federal University of Technology, Akure (FUTA), Nigeria.

### Verification information

* Official university website: https://futa.edu.ng/
* Official Information Technology programme: https://ift.futa.edu.ng/home/2373
* FUTA offers a B.Tech in Information Technology, with a programme duration of 10 academic semesters for UTME entry and 8 academic semesters for Direct Entry.
* Official FUTA School of Computing: https://soc.futa.edu.ng/

The added domain file is:

`lib/domains/ng/edu/futa.txt`

The file contains:

`Federal University of Technology, Akure`

This follows the domain format used by the swot repository.
