### PR TITLE
Add Bangladesh University of Professionals (bup.edu.bd)

### DIFF
--- a/lib/domains/abused.txt
+++ b/lib/domains/abused.txt
@@ -1,4 +1,4 @@
-mdx.ac
+﻿mdx.ac
 esoft.academy
 itstep.academy
 mbz.ens.sch.ae
@@ -29,7 +29,6 @@ sabah.edu.az
 student.edu.az
 osasmailovic.edu.ba
 oshs.edu.ba
-bup.edu.bd
 me.buet.ac.bd
 buet.ac.bd
 vu.edu.bd

--- a/lib/domains/bd/edu/bup.txt
+++ b/lib/domains/bd/edu/bup.txt
@@ -1,0 +1,1 @@
+﻿Bangladesh University of Professionals


### PR DESCRIPTION
## Add Bangladesh University of Professionals (bup.edu.bd)

### What this PR does
1. **Removes** `bup.edu.bd` from the abused domains list
2. **Adds** `bup.edu.bd` as a verified academic domain (`lib/domains/bd/edu/bup.txt`)

### About the University

**Bangladesh University of Professionals (BUP)** is a public university established by the Government of Bangladesh under the Bangladesh University of Professionals Act, 2009. It is recognized by the University Grants Commission (UGC) of Bangladesh.

- **Official Website:** [https://www.bup.edu.bd](https://www.bup.edu.bd)
- **UGC Listing:** [https://ugc-universities.gov.bd](https://ugc-universities.gov.bd) (listed as a public university)
- **Wikipedia:** [https://en.wikipedia.org/wiki/Bangladesh_University_of_Professionals](https://en.wikipedia.org/wiki/Bangladesh_University_of_Professionals)

### IT-Related Programs (Long-term, > 1 year)

BUP offers multiple long-term (4-year undergraduate and 1-2 year graduate) IT-related programs through its **Faculty of Science and Technology (FST)**:

**Department of Computer Science and Engineering (CSE):**
- B.Sc. in Computer Science and Engineering (4 years)
- M.Sc. in Computer Science and Engineering
- Masters in Cyber Security

**Department of Information and Communication Technology (ICT):**
- B.Sc. in Information and Communication Engineering (4 years)
- Masters in Information and Communication Engineering (MICE)
- Masters in Information and Communication Technology (MICT)
- Masters in Information Systems Security (MISS)

**Evidence links:**
- CSE Department: https://bup.edu.bd/academics/departments/department-of-computer-science-and-engineering
- ICT Department: https://bup.edu.bd/academics/departments/department-of-information-and-communication-technology
- Faculty of Science and Technology: https://bup.edu.bd/academics/faculties_centers/faculty-of-science-and-technology

### Student Email Domain

BUP provides official student email addresses in the format: `[student-id]@student.bup.edu.bd`

This is the official email domain issued to currently enrolled students by the university's ICT Centre. The student portal is accessible at https://webportal.bup.edu.bd

Adding `bup.edu.bd` to SWoT will automatically cover the `student.bup.edu.bd` subdomain.

### Regarding the Abuse List

I respectfully request that `bup.edu.bd` be removed from the abused domains list. BUP is a legitimate, government-established public university with over 10,000 students, accredited by the UGC of Bangladesh. The domain is exclusively used for academic purposes. If there were prior issues, they may have been caused by individual misuse rather than any institutional policy. I am a currently enrolled student and can verify my identity if needed.

### Summary

| Requirement | Status |
|---|---|
| Higher education institution | Public university, est. 2009 |
| Long-term IT course (>1 year) | 4-year B.Sc. CSE, B.Sc. ICE, + multiple Masters programs |
| Official academic domain | bup.edu.bd / student.bup.edu.bd |
| Accreditation | UGC Bangladesh |

Thank you for reviewing this request.