### PR TITLE
Add United States Army War College

### DIFF
--- a/lib/domains/edu/armywarcollege.txt
+++ b/lib/domains/edu/armywarcollege.txt
@@ -1,0 +1,1 @@
+United States Army War College


### PR DESCRIPTION
Requested domain: `armywarcollege.edu`

**School:** United States Army War College (USAWC), the U.S. Army's senior service college at Carlisle Barracks, Pennsylvania.

**Evidence:**
- Official website: https://www.army.edu/USAWC/ — `armywarcollege.edu` is the college's official domain and currently 301-redirects to that page.
- Listed as the official website on Wikipedia: https://en.wikipedia.org/wiki/United_States_Army_War_College
- `.edu` domains are restricted to accredited U.S. postsecondary institutions, so `@armywarcollege.edu` addresses are institutional.

Adds `lib/domains/edu/armywarcollege.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)