### PR TITLE
Add Jiangsu University of Technology domain

### DIFF
--- a/lib/domains/cn/edu/jsut.txt
+++ b/lib/domains/cn/edu/jsut.txt
@@ -1,0 +1,2 @@
+江苏理工学院
+Jiangsu University of Technology


### PR DESCRIPTION
## Summary

This is a follow-up to PR #40987:

https://github.com/JetBrains/swot/pull/40987

As confirmed by the maintainer, `jsut.edu.cn` has been removed from the upstream stoplist. This PR adds Jiangsu University of Technology under the standard `lib/domains` hierarchy.

## Institution

Jiangsu University of Technology (江苏理工学院) is a public university located in Changzhou, Jiangsu, China.

Official websites:

- https://www.jsut.edu.cn/ (Chinese)
- https://english.jsut.edu.cn/ (English)

## Domain Evidence

The official JSUT Network Center identifies `@smail.jsut.edu.cn` as the suffix used for students’ personal email accounts:

https://net.jsut.edu.cn/2023/0812/c6711a167849/page.htm

The domain file is added at:

`lib/domains/cn/edu/jsut.txt`

Because the repository automatically includes subdomains, adding `jsut.edu.cn` also covers official student addresses such as `smail.jsut.edu.cn`.

## IT-Related Programs

The official School of Computer Engineering website is:

https://jsjxy.jsut.edu.cn/main.htm

The official program introduction lists programs including Computer Science and Technology, Software Engineering, Artificial Intelligence, Network Engineering, and Data Science and Big Data Technology:

https://zs.jsut.edu.cn/jsjgcxy/list.htm

## Scope

This PR only adds `lib/domains/cn/edu/jsut.txt`.

It does not modify `stoplist.txt`, application logic, compiler configuration, or test files.

## Verification

- `gradlew clean test`
- All tests passed