### PR TITLE
Add Barani Institute of Information Technology

### DIFF
--- a/lib/domains/pk/edu/biit.txt
+++ b/lib/domains/pk/edu/biit.txt
@@ -1,0 +1,2 @@
+Barani Institute of Information Technology
+BIIT


### PR DESCRIPTION
Please add the biit.edu.pk domain for Barani Institute of Information Technology (BIIT).

Official website:
https://biit.edu.pk/

IT-related long-term program:
https://biit.edu.pk/degree

BIIT offers BSCS (Artificial Intelligence), BSCS (General Computing), and BSCS (Software Engineering).

The institution uses the biit.edu.pk domain for official student email addresses.