### PR TITLE
Add Bartın University

### DIFF
--- a/lib/domains/tr/edu/bartin.txt
+++ b/lib/domains/tr/edu/bartin.txt
@@ -1,0 +1,2 @@
+Bartın Üniversitesi
+Bartın University


### PR DESCRIPTION
Please add Bartın University, Turkey, with the domain bartin.edu.tr.

Students use email addresses under ogrenci.bartin.edu.tr.

Official university website:
https://www.bartin.edu.tr

Four-year Computer Engineering program:
https://ceng.bartin.edu.tr/about-department.html

Official confirmation of the student email domain:
https://btbs.bartin.edu.tr/duyurular/office-365-hesaplari-hakkinda.html