### PR TITLE
add gomail.txt with new college name

### DIFF
--- a/lib/domains/pl/edu/gomail.txt
+++ b/lib/domains/pl/edu/gomail.txt
@@ -1,0 +1,1 @@
+gomail college of engineering  


### PR DESCRIPTION
This pull request adds the "gomail.edu.pl" domain for Gomail College of Engineering.

The domain is used for official student email addresses, including:

"jean@gomail.edu.pl"

This will allow eligible students of Gomail College of Engineering to be recognized by services using the JetBrains SWoT database
for student verification.