### PR TITLE
Add GCTU domain and fix university name typo

### DIFF
--- a/lib/domains/gh/edu/gctu/live.txt
+++ b/lib/domains/gh/edu/gctu/live.txt
@@ -1,0 +1,1 @@
+Ghana Communication Technology Universit

--- a/lib/domains/gh/edu/gctu/live.txt
+++ b/lib/domains/gh/edu/gctu/live.txt
@@ -1,1 +1,1 @@
-Ghana Communication Technology Universit
+Ghana Communication Technology University


### PR DESCRIPTION
Adding the domain for Ghana Communication Technology University (GCTU) to resolve verification blocks for student programs. 

- Email Domain: live.gctu.edu.gh
- Official Institution Name: Ghana Communication Technology University
